### PR TITLE
Fix NS1 deployment

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-ns1.yaml
@@ -31,12 +31,11 @@ spec:
         - --ns1-endpoint={{ .Values.ns1.endpoint }}
 {{- end }}
 {{- if .Values.ns1.ignoreSSL }}
-        - --ns1-ignoressl={{ .Values.ns1.ignoreSSL }}
+        - --ns1-ignoressl
 {{- end }}
         - --txt-owner-id=k8gb-{{ .Values.k8gb.dnsZone }}-{{ .Values.k8gb.clusterGeoTag }}
         - --policy=sync # enable full synchronization including record removal
         - --log-level=debug # debug only
-        - --managed-record-types=A,CNAME,NS
         env:
         - name: NS1_APIKEY
           valueFrom:


### PR DESCRIPTION
In 95cd31b16e465f4827c65bd91e4b0118d50f93fa it was forgotted to remove
unsupported flag from NS1 provider during external-dns upgrade.

Also fix --ignoressl option, it doesn't take value, it is evaluated
true/false by the fact option is specified

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>