### PR TITLE
refactor: interface rename

### DIFF
--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -51,7 +51,7 @@ type GslbReconciler struct {
 	Config      *depresolver.Config
 	DepResolver *depresolver.DependencyResolver
 	Metrics     *metrics.PrometheusMetrics
-	DNSProvider dns.IDnsProvider
+	DNSProvider dns.Provider
 }
 
 const (

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -61,7 +61,7 @@ type testSettings struct {
 	client     client.Client
 	ingress    *v1beta1.Ingress
 	finalCall  bool
-	assistant  assistant.IAssistant
+	assistant  assistant.Assistant
 }
 
 var crSampleYaml = "../deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml"

--- a/controllers/providers/assistant/assistant.go
+++ b/controllers/providers/assistant/assistant.go
@@ -24,7 +24,7 @@ import (
 	externaldns "sigs.k8s.io/external-dns/endpoint"
 )
 
-type IAssistant interface {
+type Assistant interface {
 	// CoreDNSExposedIPs retrieves list of exposed IP by CoreDNS
 	CoreDNSExposedIPs() ([]string, error)
 	// GslbIngressExposedIPs retrieves list of IP's exposed by all GSLB ingresses

--- a/controllers/providers/dns/dns.go
+++ b/controllers/providers/dns/dns.go
@@ -22,7 +22,7 @@ import (
 	externaldns "sigs.k8s.io/external-dns/endpoint"
 )
 
-type IDnsProvider interface {
+type Provider interface {
 	// CreateZoneDelegationForExternalDNS handles delegated zone in Edge DNS
 	CreateZoneDelegationForExternalDNS(*k8gbv1beta1.Gslb) error
 	// GslbIngressExposedIPs retrieves list of IP's exposed by all GSLB ingresses

--- a/controllers/providers/dns/empty.go
+++ b/controllers/providers/dns/empty.go
@@ -26,11 +26,11 @@ import (
 
 // EmptyDNSProvider is executed when fakeDNSEnabled is true.
 type EmptyDNSProvider struct {
-	assistant assistant.IAssistant
+	assistant assistant.Assistant
 	config    depresolver.Config
 }
 
-func NewEmptyDNS(config depresolver.Config, assistant assistant.IAssistant) *EmptyDNSProvider {
+func NewEmptyDNS(config depresolver.Config, assistant assistant.Assistant) *EmptyDNSProvider {
 	return &EmptyDNSProvider{
 		config:    config,
 		assistant: assistant,

--- a/controllers/providers/dns/external.go
+++ b/controllers/providers/dns/external.go
@@ -40,7 +40,7 @@ const (
 )
 
 type ExternalDNSProvider struct {
-	assistant    assistant2.IAssistant
+	assistant    assistant2.Assistant
 	dnsType      ExternalDNSType
 	config       depresolver.Config
 	endpointName string
@@ -48,7 +48,7 @@ type ExternalDNSProvider struct {
 
 var log = logging.Logger()
 
-func NewExternalDNS(dnsType ExternalDNSType, config depresolver.Config, assistant assistant2.IAssistant) *ExternalDNSProvider {
+func NewExternalDNS(dnsType ExternalDNSType, config depresolver.Config, assistant assistant2.Assistant) *ExternalDNSProvider {
 	return &ExternalDNSProvider{
 		assistant:    assistant,
 		dnsType:      dnsType,

--- a/controllers/providers/dns/factory.go
+++ b/controllers/providers/dns/factory.go
@@ -42,7 +42,7 @@ func NewDNSProviderFactory(client client.Client, config depresolver.Config) (f *
 	return
 }
 
-func (f *ProviderFactory) Provider() IDnsProvider {
+func (f *ProviderFactory) Provider() Provider {
 	a := assistant.NewGslbAssistant(f.client, f.config.K8gbNamespace, f.config.EdgeDNSServer)
 	switch f.config.EdgeDNSType {
 	case depresolver.DNSTypeNS1:

--- a/controllers/providers/dns/infoblox.go
+++ b/controllers/providers/dns/infoblox.go
@@ -32,11 +32,11 @@ import (
 )
 
 type InfobloxProvider struct {
-	assistant assistant.IAssistant
+	assistant assistant.Assistant
 	config    depresolver.Config
 }
 
-func NewInfobloxDNS(config depresolver.Config, assistant assistant.IAssistant) *InfobloxProvider {
+func NewInfobloxDNS(config depresolver.Config, assistant assistant.Assistant) *InfobloxProvider {
 	return &InfobloxProvider{
 		assistant: assistant,
 		config:    config,


### PR DESCRIPTION
In order to https://golang.org/doc/effective_go#interface-names I'm renaming interfaces
IDnsProvider -> Provider
IAssistant -> Assistant

Signed-off-by: kuritka <kuritka@gmail.com>