### PR TITLE
Refactor test target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,12 @@ performs upgrade of k8gb helm chart and controller to the testing version built 
   These tests are updated only if the change is substantial enough to affect the main end-to-end flow.
 - See the [local playground guide](https://github.com/k8gb-io/k8gb/blob/master/docs/local.md) for local testing environment setup and integration test execution.
 
+### Unit testing
+- Include unit tests when you contribute new features, as they help to a) prove that your code works correctly, and b) guard against future breaking changes to lower the maintenance cost.
+- Bug fixes also generally require unit tests, because the presence of bugs usually indicates insufficient test coverage.
+
+Use `make test` to check your implementation changes.
+
 ### Testing against real k8s clusters
 There is a possibility to execute the integration terratest suite over the real clusters.
 For this, you need to override the set of test settings as in the example below.
@@ -112,7 +118,7 @@ There is a dedicated make target available for Goland:
 k8gb project is using the coding style suggested by the Golang community. See the [golang-style-doc](https://github.com/golang/go/wiki/CodeReviewComments) for details.
 
 Please follow this style to make k8gb easy to review, maintain and develop.
-Run `make lint` to automatically check if your code is compliant.
+Run `make check` to automatically check if your code is compliant.
 
 ## Commit and Pull Request message
 

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ endif
 
 all: help
 
+# check integrity
+.PHONY: check
+check: license lint test ## Check project integrity
+
 .PHONY: clean-test-apps
 clean-test-apps:
 	kubectl delete -f deploy/test-apps
@@ -296,7 +300,7 @@ start-test-app:
 
 # run tests
 .PHONY: test
-test: license lint
+test:
 	$(call generate)
 	$(call manifest)
 	go test ./... -coverprofile cover.out


### PR DESCRIPTION
`test` target runs unit tests only while `check` target runs golic + lint + test

Signed-off-by: kuritka <kuritka@gmail.com>