### PR TITLE
make: Suppress symlink warnings on getting k8gb $VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ NO_VALUE ?= no_value
 #		VARIABLES
 ###############################
 PWD ?=  $(shell pwd)
-VERSION ?= $(shell helm show chart chart/k8gb/|awk '/appVersion:/ {print $$2}')
+VERSION ?= $(shell helm show chart chart/k8gb/ 2> /dev/null | awk '/appVersion:/ {print $$2}')
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
 SEMVER ?= $(VERSION)-$(COMMIT_HASH)
 # image URL to use all building/pushing image targets


### PR DESCRIPTION
This PR suppresses `walk.go:74: found symbolic link...` [message noise](https://github.com/helm/helm/issues/7019) during k8gb helm chart $VERSION extraction in Makefile by muting the stderr stream for that command.

> NOTE: This change affects only `helm show chart chart/k8gb/` command.
Other helm commands used in Makefile are deliberately left intact to not miss possible important helm errors.

Before:
```sh
❯ make                        
walk.go:74: found symbolic link in path: /Users/abti021/src/absaoss/k8gb/chart/k8gb/LICENSE resolves to /Users/abti021/src/absaoss/k8gb/LICENSE
walk.go:74: found symbolic link in path: /Users/abti021/src/absaoss/k8gb/chart/k8gb/README.md resolves to /Users/abti021/src/absaoss/k8gb/README.md
walk.go:74: found symbolic link in path: /Users/abti021/src/absaoss/k8gb/chart/k8gb/LICENSE resolves to /Users/abti021/src/absaoss/k8gb/LICENSE
walk.go:74: found symbolic link in path: /Users/abti021/src/absaoss/k8gb/chart/k8gb/README.md resolves to /Users/abti021/src/absaoss/k8gb/README.md
walk.go:74: found symbolic link in path: /Users/abti021/src/absaoss/k8gb/chart/k8gb/LICENSE resolves to /Users/abti021/src/absaoss/k8gb/LICENSE
walk.go:74: found symbolic link in path: /Users/abti021/src/absaoss/k8gb/chart/k8gb/README.md resolves to /Users/abti021/src/absaoss/k8gb/README.md
walk.go:74: found symbolic link in path: /Users/abti021/src/absaoss/k8gb/chart/k8gb/LICENSE resolves to /Users/abti021/src/absaoss/k8gb/LICENSE
walk.go:74: found symbolic link in path: /Users/abti021/src/absaoss/k8gb/chart/k8gb/README.md resolves to /Users/abti021/src/absaoss/k8gb/README.md
demo-failover        Execute failover demo
demo-roundrobin      Execute round-robin demo
...
```
After:
```sh
❯ make                        
demo-failover        Execute failover demo
demo-roundrobin      Execute round-robin demo
...
```

Signed-off-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>