### PR TITLE
Fix failing `clean-test-apps` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ all: help
 .PHONY: clean-test-apps
 clean-test-apps:
 	kubectl delete -f deploy/test-apps
-	helm -n test-gslb uninstall backend
 	helm -n test-gslb uninstall frontend
 
 # see: https://dev4devs.com/2019/05/04/operator-framework-how-to-debug-golang-operator-projects/


### PR DESCRIPTION
Delete the removal of not used podinfo backend deployment from `clean-test-apps`:

```
❯ make clean-test-apps
...
service "unhealthy-app" deleted
deployment.apps "unhealthy-app" deleted
helm -n test-gslb uninstall backend
Error: uninstall: Release not loaded: backend: release: not found
make: *** [clean-test-apps] Error 1
```

Signed-off-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>