### PR TITLE
refactor (2/3): Remove responsibility for target DNS from GSLB assistant

### DIFF
--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -62,6 +62,8 @@ spec:
               value: {{ .Values.k8gb.edgeDNSZone }}
             - name: EDGE_DNS_SERVER
               value: {{ .Values.k8gb.edgeDNSServer }}
+            - name: EDGE_DNS_SERVER_PORT
+              value: "53"
             - name: DNS_ZONE
               value: {{ .Values.k8gb.dnsZone }}
             - name: RECONCILE_REQUEUE_SECONDS

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -105,8 +105,6 @@ type Infoblox struct {
 
 // Override configuration
 type Override struct {
-	// FakeDNSEnabled; default=false
-	FakeDNSEnabled bool
 	// FakeInfobloxEnabled if true than Infoblox connection FQDN=`fakezone.example.com`; default = false
 	FakeInfobloxEnabled bool
 }
@@ -123,6 +121,8 @@ type Config struct {
 	EdgeDNSType EdgeDNSType
 	// EdgeDNSServer
 	EdgeDNSServer string
+	// EdgeDNSServerPort
+	EdgeDNSServerPort int
 	// EdgeDNSZone main zone which would contain gslb zone to delegate; e.g. example.com
 	EdgeDNSZone string
 	// DNSZone controlled by gslb; e.g. cloud.example.com

--- a/controllers/providers/assistant/assistant.go
+++ b/controllers/providers/assistant/assistant.go
@@ -30,12 +30,12 @@ type Assistant interface {
 	// GslbIngressExposedIPs retrieves list of IP's exposed by all GSLB ingresses
 	GslbIngressExposedIPs(gslb *k8gbv1beta1.Gslb) ([]string, error)
 	// GetExternalTargets retrieves slice of targets from external clusters
-	GetExternalTargets(host string, fakeDNSEnabled bool, extClusterNsNames map[string]string) (targets []string)
+	GetExternalTargets(host string, edgeDNSServerPort int, extClusterNsNames map[string]string) (targets []string)
 	// SaveDNSEndpoint update DNS endpoint or create new one if doesnt exist
 	SaveDNSEndpoint(namespace string, i *externaldns.DNSEndpoint) error
 	// RemoveEndpoint removes endpoint
 	RemoveEndpoint(endpointName string) error
 	// InspectTXTThreshold inspects fqdn TXT record from edgeDNSServer. If record doesn't exists or timestamp is greater than
 	// splitBrainThreshold the error is returned. In case fakeDNSEnabled is true, 127.0.0.1:7753 is used as edgeDNSServer
-	InspectTXTThreshold(fqdn string, fakeDNSEnabled bool, splitBrainThreshold time.Duration) error
+	InspectTXTThreshold(fqdn string, edgeDNSServerPort int, splitBrainThreshold time.Duration) error
 }

--- a/controllers/providers/assistant/assistant_mock.go
+++ b/controllers/providers/assistant/assistant_mock.go
@@ -69,17 +69,17 @@ func (mr *MockAssistantMockRecorder) CoreDNSExposedIPs() *gomock.Call {
 }
 
 // GetExternalTargets mocks base method.
-func (m *MockAssistant) GetExternalTargets(host string, fakeDNSEnabled bool, extClusterNsNames map[string]string) []string {
+func (m *MockAssistant) GetExternalTargets(host string, edgeDNSServerPort int, extClusterNsNames map[string]string) []string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExternalTargets", host, fakeDNSEnabled, extClusterNsNames)
+	ret := m.ctrl.Call(m, "GetExternalTargets", host, edgeDNSServerPort, extClusterNsNames)
 	ret0, _ := ret[0].([]string)
 	return ret0
 }
 
 // GetExternalTargets indicates an expected call of GetExternalTargets.
-func (mr *MockAssistantMockRecorder) GetExternalTargets(host, fakeDNSEnabled, extClusterNsNames interface{}) *gomock.Call {
+func (mr *MockAssistantMockRecorder) GetExternalTargets(host, edgeDNSServerPort, extClusterNsNames interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalTargets", reflect.TypeOf((*MockAssistant)(nil).GetExternalTargets), host, fakeDNSEnabled, extClusterNsNames)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalTargets", reflect.TypeOf((*MockAssistant)(nil).GetExternalTargets), host, edgeDNSServerPort, extClusterNsNames)
 }
 
 // GslbIngressExposedIPs mocks base method.
@@ -98,17 +98,17 @@ func (mr *MockAssistantMockRecorder) GslbIngressExposedIPs(gslb interface{}) *go
 }
 
 // InspectTXTThreshold mocks base method.
-func (m *MockAssistant) InspectTXTThreshold(fqdn string, fakeDNSEnabled bool, splitBrainThreshold time.Duration) error {
+func (m *MockAssistant) InspectTXTThreshold(fqdn string, edgeDNSServerPort int, splitBrainThreshold time.Duration) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InspectTXTThreshold", fqdn, fakeDNSEnabled, splitBrainThreshold)
+	ret := m.ctrl.Call(m, "InspectTXTThreshold", fqdn, edgeDNSServerPort, splitBrainThreshold)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InspectTXTThreshold indicates an expected call of InspectTXTThreshold.
-func (mr *MockAssistantMockRecorder) InspectTXTThreshold(fqdn, fakeDNSEnabled, splitBrainThreshold interface{}) *gomock.Call {
+func (mr *MockAssistantMockRecorder) InspectTXTThreshold(fqdn, edgeDNSServerPort, splitBrainThreshold interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectTXTThreshold", reflect.TypeOf((*MockAssistant)(nil).InspectTXTThreshold), fqdn, fakeDNSEnabled, splitBrainThreshold)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectTXTThreshold", reflect.TypeOf((*MockAssistant)(nil).InspectTXTThreshold), fqdn, edgeDNSServerPort, splitBrainThreshold)
 }
 
 // RemoveEndpoint mocks base method.

--- a/controllers/providers/dns/empty.go
+++ b/controllers/providers/dns/empty.go
@@ -46,7 +46,7 @@ func (p *EmptyDNSProvider) GslbIngressExposedIPs(gslb *k8gbv1beta1.Gslb) (r []st
 }
 
 func (p *EmptyDNSProvider) GetExternalTargets(host string) (targets []string) {
-	return p.assistant.GetExternalTargets(host, p.config.Override.FakeDNSEnabled, p.config.GetExternalClusterNSNames())
+	return p.assistant.GetExternalTargets(host, p.config.EdgeDNSServerPort, p.config.GetExternalClusterNSNames())
 }
 
 func (p *EmptyDNSProvider) SaveDNSEndpoint(gslb *k8gbv1beta1.Gslb, i *externaldns.DNSEndpoint) error {

--- a/controllers/providers/dns/external.go
+++ b/controllers/providers/dns/external.go
@@ -110,7 +110,7 @@ func (p *ExternalDNSProvider) Finalize(*k8gbv1beta1.Gslb) error {
 }
 
 func (p *ExternalDNSProvider) GetExternalTargets(host string) (targets []string) {
-	return p.assistant.GetExternalTargets(host, p.config.Override.FakeDNSEnabled, p.config.GetExternalClusterNSNames())
+	return p.assistant.GetExternalTargets(host, p.config.EdgeDNSServerPort, p.config.GetExternalClusterNSNames())
 }
 
 func (p *ExternalDNSProvider) GslbIngressExposedIPs(gslb *k8gbv1beta1.Gslb) ([]string, error) {

--- a/controllers/providers/dns/infoblox.go
+++ b/controllers/providers/dns/infoblox.go
@@ -96,7 +96,7 @@ func (p *InfobloxProvider) CreateZoneDelegationForExternalDNS(gslb *k8gbv1beta1.
 				for extClusterGeoTag, nsServerNameExt := range p.config.GetExternalClusterNSNames() {
 					err = p.assistant.InspectTXTThreshold(
 						extClusterHeartbeatFQDNs[extClusterGeoTag],
-						p.config.Override.FakeDNSEnabled,
+						p.config.EdgeDNSServerPort,
 						time.Second*time.Duration(gslb.Spec.Strategy.SplitBrainThresholdSeconds))
 					if err != nil {
 						log.Err(err).Msgf("Got the error from TXT based checkAlive. External cluster (%s) doesn't "+
@@ -171,7 +171,7 @@ func (p *InfobloxProvider) Finalize(gslb *k8gbv1beta1.Gslb) error {
 }
 
 func (p *InfobloxProvider) GetExternalTargets(host string) (targets []string) {
-	return p.assistant.GetExternalTargets(host, p.config.Override.FakeDNSEnabled, p.config.GetExternalClusterNSNames())
+	return p.assistant.GetExternalTargets(host, p.config.EdgeDNSServerPort, p.config.GetExternalClusterNSNames())
 }
 
 func (p *InfobloxProvider) GslbIngressExposedIPs(gslb *k8gbv1beta1.Gslb) ([]string, error) {


### PR DESCRIPTION
GSLB assistant decides whether mock DNS (localhost:7753) or calculated NSServerName (gslb-ns-uk-cloud.example.com:53) will be used for DNS exchange.
`OVERRIDE_WITH_FAKE_EXT_DNS` decides if NSServerNAme or localhost will be used.

This PR removes such functionality from gslb assistant. Depresolver getNSName returns NSName based on EdgeDNSServer.
If edgeDNSServer is localhost than nsname is localhost for any region, otherwise proper nsname is returned.
I also removed `OVERRIDE_WITH_FAKE_EXT_DNS` and introduced `EDGE_DNS_SERVER_PORT` with default value 53.
Now we can request DNS on any port.

Because OverrideWithFakeDNS was removed I had to change Assistant interface contract and regenerate mocks, covered by tests.

Signed-off-by: kuritka <kuritka@gmail.com>