### PR TITLE
refactor (2/3): Remove responsibility for target DNS from GSLB assistant

### DIFF
--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -62,6 +62,8 @@ spec:
               value: {{ .Values.k8gb.edgeDNSZone }}
             - name: EDGE_DNS_SERVER
               value: {{ .Values.k8gb.edgeDNSServer }}
+            - name: EDGE_DNS_SERVER_PORT
+              value: "53"
             - name: DNS_ZONE
               value: {{ .Values.k8gb.dnsZone }}
             - name: RECONCILE_REQUEUE_SECONDS

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -105,8 +105,6 @@ type Infoblox struct {
 
 // Override configuration
 type Override struct {
-	// FakeDNSEnabled; default=false
-	FakeDNSEnabled bool
 	// FakeInfobloxEnabled if true than Infoblox connection FQDN=`fakezone.example.com`; default = false
 	FakeInfobloxEnabled bool
 }
@@ -123,6 +121,8 @@ type Config struct {
 	EdgeDNSType EdgeDNSType
 	// EdgeDNSServer
 	EdgeDNSServer string
+	// EdgeDNSServerPort
+	EdgeDNSServerPort int
 	// EdgeDNSZone main zone which would contain gslb zone to delegate; e.g. example.com
 	EdgeDNSZone string
 	// DNSZone controlled by gslb; e.g. cloud.example.com

--- a/controllers/depresolver/depresolver_test.go
+++ b/controllers/depresolver/depresolver_test.go
@@ -43,9 +43,10 @@ import (
 var predefinedConfig = Config{
 	ReconcileRequeueSeconds: 30,
 	ClusterGeoTag:           "us",
-	ExtClustersGeoTags:      []string{"uk", "eu"},
+	ExtClustersGeoTags:      []string{"za", "eu"},
 	EdgeDNSType:             DNSTypeInfoblox,
-	EdgeDNSServer:           "8.8.8.8",
+	EdgeDNSServer:           "dns.cloud.example.com",
+	EdgeDNSServerPort:       53,
 	EdgeDNSZone:             "example.com",
 	DNSZone:                 "cloud.example.com",
 	K8gbNamespace:           "k8gb",
@@ -60,7 +61,6 @@ var predefinedConfig = Config{
 		11,
 	},
 	Override: Override{
-		false,
 		false,
 	},
 	Log: Log{
@@ -170,6 +170,7 @@ func TestResolveConfigWithoutEnvVarsSet(t *testing.T) {
 	defaultConfig.ReconcileRequeueSeconds = 30
 	defaultConfig.Infoblox.HTTPRequestTimeout = 20
 	defaultConfig.Infoblox.HTTPPoolConnections = 10
+	defaultConfig.EdgeDNSServerPort = 53
 	defaultConfig.EdgeDNSType = DNSTypeNoEdgeDNS
 	defaultConfig.ExtClustersGeoTags = []string{}
 	defaultConfig.Log.Level = zerolog.InfoLevel
@@ -457,6 +458,50 @@ func TestResolveConfigWithInvalidIpAddressEdgeDnsServer(t *testing.T) {
 	defer cleanup()
 	expected := predefinedConfig
 	expected.EdgeDNSServer = "22.147.90.2."
+	// act,assert
+	arrangeVariablesAndAssert(t, expected, assert.Error)
+}
+
+func TestResolveConfigWithNoEdgeDnsServerPort(t *testing.T) {
+	// arrange
+	defer cleanup()
+	configureEnvVar(predefinedConfig)
+	_ = os.Setenv(EdgeDNSServerPortKey, "")
+	resolver := NewDependencyResolver()
+	// act
+	config, err := resolver.ResolveOperatorConfig()
+	// assert
+	assert.NoError(t, err)
+	assert.Equal(t, 53, config.EdgeDNSServerPort)
+}
+
+func TestResolveConfigWithEdgeDnsServerPort(t *testing.T) {
+	// arrange
+	defer cleanup()
+	expected := predefinedConfig
+	expected.EdgeDNSServerPort = 7753
+	// act,assert
+	arrangeVariablesAndAssert(t, expected, assert.NoError)
+}
+
+func TestResolveConfigWithInvalidEdgeDnsServerPort(t *testing.T) {
+	// arrange
+	defer cleanup()
+	configureEnvVar(predefinedConfig)
+	_ = os.Setenv(EdgeDNSServerPortKey, "invalid")
+	resolver := NewDependencyResolver()
+	// act
+	config, err := resolver.ResolveOperatorConfig()
+	// assert
+	assert.NoError(t, err)
+	assert.Equal(t, 53, config.EdgeDNSServerPort)
+}
+
+func TestResolveConfigWithZeroOrNegativeEdgeDnsServerPort(t *testing.T) {
+	// arrange
+	defer cleanup()
+	expected := predefinedConfig
+	expected.EdgeDNSServerPort = 0
 	// act,assert
 	arrangeVariablesAndAssert(t, expected, assert.Error)
 }
@@ -1079,26 +1124,6 @@ func TestResolveConfigEnableFakeDNSAsFalse(t *testing.T) {
 	arrangeVariablesAndAssert(t, expected, assert.NoError)
 }
 
-func TestResolveConfigEnableFakeDNSAsInvalidValue(t *testing.T) {
-	// arrange
-	defer cleanup()
-	configureEnvVar(predefinedConfig)
-	_ = os.Setenv(OverrideWithFakeDNSKey, "i.am.wrong??.")
-	resolver := NewDependencyResolver()
-	// act
-	config, err := resolver.ResolveOperatorConfig()
-	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, false, config.Override.FakeDNSEnabled)
-}
-
-func TestResolveConfigEnableFakeDNSAsUnsetEnvironmentVariable(t *testing.T) {
-	// arrange
-	defer cleanup()
-	// act,assert
-	arrangeVariablesAndAssert(t, predefinedConfig, assert.NoError, OverrideWithFakeDNSKey)
-}
-
 func TestResolveConfigEnableFakeInfobloxAsTrue(t *testing.T) {
 	// arrange
 	defer cleanup()
@@ -1390,6 +1415,23 @@ func TestNsServerNamesWithMultipleExtClusterGeoTag(t *testing.T) {
 	}
 }
 
+func TestNsServerNamesForLocalEdgeDNS(t *testing.T) {
+	// arrange
+	defer cleanup()
+	for _, edgeDNSServer := range []string{"127.0.0.1", "localhost"} {
+		customConfig := predefinedConfig
+		customConfig.EdgeDNSServer = edgeDNSServer
+		configureEnvVar(customConfig)
+		resolver := NewDependencyResolver()
+		// act
+		config, err := resolver.ResolveOperatorConfig()
+		// assert
+		assert.NoError(t, err)
+		assert.Equal(t, config.GetClusterNSName(), edgeDNSServer)
+		assert.True(t, reflect.DeepEqual(config.GetExternalClusterNSNames(), map[string]string{"za": edgeDNSServer, "eu": edgeDNSServer}))
+	}
+}
+
 func TestNsServerNamesWithOneExtClusterGeoTag(t *testing.T) {
 	// arrange
 	defer cleanup()
@@ -1428,13 +1470,13 @@ func TestNsServerNamesLargeDNSZone(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "gslb-ns-us-k8gb-test-preprod-lorem-ipsum-donor-blah-blah-blah-gslb.cloud.example.com", config.GetClusterNSName())
 	extNsNames := config.GetExternalClusterNSNames()
-	expectedExtNsNames := map[string]string{"uk": "gslb-ns-uk-k8gb-test-preprod-lorem-ipsum-donor-blah-blah-blah-gslb.cloud.example.com",
+	expectedExtNsNames := map[string]string{"za": "gslb-ns-za-k8gb-test-preprod-lorem-ipsum-donor-blah-blah-blah-gslb.cloud.example.com",
 		"eu": "gslb-ns-eu-k8gb-test-preprod-lorem-ipsum-donor-blah-blah-blah-gslb.cloud.example.com"}
 	assert.True(t, reflect.DeepEqual(extNsNames, expectedExtNsNames), "maps must be equal: \n %v\n %v", extNsNames, expectedExtNsNames)
 }
 
 func TestNsServerNamesWithLargeExtClusterGeoTag(t *testing.T) {
-	const largeGeoTag = "uk-lorem-ipsum-donor-b-blah-lorem"
+	const largeGeoTag = "za-lorem-ipsum-donor-b-blah-lorem"
 	defer cleanup()
 	// arrange
 	customConfig := predefinedConfig
@@ -1454,7 +1496,7 @@ func TestNsServerNamesWithLargeExtClusterGeoTag(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "gslb-ns-us-k8gb-test-preprod-gslb.cloud.example.com", config.GetClusterNSName())
 	extNsNames := config.GetExternalClusterNSNames()
-	expectedExtNsNames := map[string]string{largeGeoTag: "gslb-ns-uk-lorem-ipsum-donor-b-blah-lorem-k8gb-test-preprod-gslb.cloud.example.com",
+	expectedExtNsNames := map[string]string{largeGeoTag: "gslb-ns-za-lorem-ipsum-donor-b-blah-lorem-k8gb-test-preprod-gslb.cloud.example.com",
 		"eu": "gslb-ns-eu-k8gb-test-preprod-gslb.cloud.example.com"}
 	assert.True(t, reflect.DeepEqual(extNsNames, expectedExtNsNames), "maps must be equal: \n %v\n %v", extNsNames, expectedExtNsNames)
 
@@ -1477,7 +1519,7 @@ func TestNsServerNamesWithLargeClusterGeoTag(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, "gslb-ns-us-lorem-ipsum-donor-blah-blah-blah-blah-k8gb-test-preprod-gslb.cloud.example.com", config.GetClusterNSName())
 	extNsNames := config.GetExternalClusterNSNames()
-	expectedExtNsNames := map[string]string{"uk": "gslb-ns-uk-k8gb-test-preprod-gslb.cloud.example.com",
+	expectedExtNsNames := map[string]string{"za": "gslb-ns-za-k8gb-test-preprod-gslb.cloud.example.com",
 		"eu": "gslb-ns-eu-k8gb-test-preprod-gslb.cloud.example.com"}
 	assert.True(t, reflect.DeepEqual(extNsNames, expectedExtNsNames), "maps must be equal: \n %v\n %v", extNsNames, expectedExtNsNames)
 
@@ -1536,8 +1578,8 @@ func arrangeVariablesAndAssert(t *testing.T, expected Config,
 
 func cleanup() {
 	for _, s := range []string{ReconcileRequeueSecondsKey, ClusterGeoTagKey, ExtClustersGeoTagsKey, EdgeDNSZoneKey, DNSZoneKey, EdgeDNSServerKey,
-		Route53EnabledKey, NS1EnabledKey, InfobloxGridHostKey, InfobloxVersionKey, InfobloxPortKey, InfobloxUsernameKey, InfobloxPasswordKey,
-		OverrideWithFakeDNSKey, OverrideFakeInfobloxKey, K8gbNamespaceKey, CoreDNSExposedKey, InfobloxHTTPRequestTimeoutKey,
+		EdgeDNSServerPortKey, Route53EnabledKey, NS1EnabledKey, InfobloxGridHostKey, InfobloxVersionKey, InfobloxPortKey, InfobloxUsernameKey,
+		InfobloxPasswordKey, OverrideFakeInfobloxKey, K8gbNamespaceKey, CoreDNSExposedKey, InfobloxHTTPRequestTimeoutKey,
 		InfobloxHTTPPoolConnectionsKey, LogLevelKey, LogFormatKey, LogNoColorKey, SplitBrainCheckKey} {
 		if os.Unsetenv(s) != nil {
 			panic(fmt.Errorf("cleanup %s", s))
@@ -1550,6 +1592,7 @@ func configureEnvVar(config Config) {
 	_ = os.Setenv(ClusterGeoTagKey, config.ClusterGeoTag)
 	_ = os.Setenv(ExtClustersGeoTagsKey, strings.Join(config.ExtClustersGeoTags, ","))
 	_ = os.Setenv(EdgeDNSServerKey, config.EdgeDNSServer)
+	_ = os.Setenv(EdgeDNSServerPortKey, strconv.Itoa(config.EdgeDNSServerPort))
 	_ = os.Setenv(EdgeDNSZoneKey, config.EdgeDNSZone)
 	_ = os.Setenv(DNSZoneKey, config.DNSZone)
 	_ = os.Setenv(K8gbNamespaceKey, config.K8gbNamespace)
@@ -1563,7 +1606,6 @@ func configureEnvVar(config Config) {
 	_ = os.Setenv(InfobloxPasswordKey, config.Infoblox.Password)
 	_ = os.Setenv(InfobloxHTTPRequestTimeoutKey, strconv.Itoa(config.Infoblox.HTTPRequestTimeout))
 	_ = os.Setenv(InfobloxHTTPPoolConnectionsKey, strconv.Itoa(config.Infoblox.HTTPPoolConnections))
-	_ = os.Setenv(OverrideWithFakeDNSKey, strconv.FormatBool(config.Override.FakeDNSEnabled))
 	_ = os.Setenv(OverrideFakeInfobloxKey, strconv.FormatBool(config.Override.FakeInfobloxEnabled))
 	_ = os.Setenv(LogLevelKey, config.Log.Level.String())
 	_ = os.Setenv(LogFormatKey, config.Log.Format.String())

--- a/controllers/providers/assistant/assistant.go
+++ b/controllers/providers/assistant/assistant.go
@@ -30,12 +30,12 @@ type Assistant interface {
 	// GslbIngressExposedIPs retrieves list of IP's exposed by all GSLB ingresses
 	GslbIngressExposedIPs(gslb *k8gbv1beta1.Gslb) ([]string, error)
 	// GetExternalTargets retrieves slice of targets from external clusters
-	GetExternalTargets(host string, fakeDNSEnabled bool, extClusterNsNames map[string]string) (targets []string)
+	GetExternalTargets(host string, edgeDNSServerPort int, extClusterNsNames map[string]string) (targets []string)
 	// SaveDNSEndpoint update DNS endpoint or create new one if doesnt exist
 	SaveDNSEndpoint(namespace string, i *externaldns.DNSEndpoint) error
 	// RemoveEndpoint removes endpoint
 	RemoveEndpoint(endpointName string) error
 	// InspectTXTThreshold inspects fqdn TXT record from edgeDNSServer. If record doesn't exists or timestamp is greater than
 	// splitBrainThreshold the error is returned. In case fakeDNSEnabled is true, 127.0.0.1:7753 is used as edgeDNSServer
-	InspectTXTThreshold(fqdn string, fakeDNSEnabled bool, splitBrainThreshold time.Duration) error
+	InspectTXTThreshold(fqdn string, edgeDNSServerPort int, splitBrainThreshold time.Duration) error
 }

--- a/controllers/providers/assistant/assistant_mock.go
+++ b/controllers/providers/assistant/assistant_mock.go
@@ -69,17 +69,17 @@ func (mr *MockAssistantMockRecorder) CoreDNSExposedIPs() *gomock.Call {
 }
 
 // GetExternalTargets mocks base method.
-func (m *MockAssistant) GetExternalTargets(host string, fakeDNSEnabled bool, extClusterNsNames map[string]string) []string {
+func (m *MockAssistant) GetExternalTargets(host string, edgeDNSServerPort int, extClusterNsNames map[string]string) []string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExternalTargets", host, fakeDNSEnabled, extClusterNsNames)
+	ret := m.ctrl.Call(m, "GetExternalTargets", host, edgeDNSServerPort, extClusterNsNames)
 	ret0, _ := ret[0].([]string)
 	return ret0
 }
 
 // GetExternalTargets indicates an expected call of GetExternalTargets.
-func (mr *MockAssistantMockRecorder) GetExternalTargets(host, fakeDNSEnabled, extClusterNsNames interface{}) *gomock.Call {
+func (mr *MockAssistantMockRecorder) GetExternalTargets(host, edgeDNSServerPort, extClusterNsNames interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalTargets", reflect.TypeOf((*MockAssistant)(nil).GetExternalTargets), host, fakeDNSEnabled, extClusterNsNames)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalTargets", reflect.TypeOf((*MockAssistant)(nil).GetExternalTargets), host, edgeDNSServerPort, extClusterNsNames)
 }
 
 // GslbIngressExposedIPs mocks base method.
@@ -98,17 +98,17 @@ func (mr *MockAssistantMockRecorder) GslbIngressExposedIPs(gslb interface{}) *go
 }
 
 // InspectTXTThreshold mocks base method.
-func (m *MockAssistant) InspectTXTThreshold(fqdn string, fakeDNSEnabled bool, splitBrainThreshold time.Duration) error {
+func (m *MockAssistant) InspectTXTThreshold(fqdn string, edgeDNSServerPort int, splitBrainThreshold time.Duration) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InspectTXTThreshold", fqdn, fakeDNSEnabled, splitBrainThreshold)
+	ret := m.ctrl.Call(m, "InspectTXTThreshold", fqdn, edgeDNSServerPort, splitBrainThreshold)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InspectTXTThreshold indicates an expected call of InspectTXTThreshold.
-func (mr *MockAssistantMockRecorder) InspectTXTThreshold(fqdn, fakeDNSEnabled, splitBrainThreshold interface{}) *gomock.Call {
+func (mr *MockAssistantMockRecorder) InspectTXTThreshold(fqdn, edgeDNSServerPort, splitBrainThreshold interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectTXTThreshold", reflect.TypeOf((*MockAssistant)(nil).InspectTXTThreshold), fqdn, fakeDNSEnabled, splitBrainThreshold)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InspectTXTThreshold", reflect.TypeOf((*MockAssistant)(nil).InspectTXTThreshold), fqdn, edgeDNSServerPort, splitBrainThreshold)
 }
 
 // RemoveEndpoint mocks base method.

--- a/controllers/providers/dns/empty.go
+++ b/controllers/providers/dns/empty.go
@@ -46,7 +46,7 @@ func (p *EmptyDNSProvider) GslbIngressExposedIPs(gslb *k8gbv1beta1.Gslb) (r []st
 }
 
 func (p *EmptyDNSProvider) GetExternalTargets(host string) (targets []string) {
-	return p.assistant.GetExternalTargets(host, p.config.Override.FakeDNSEnabled, p.config.GetExternalClusterNSNames())
+	return p.assistant.GetExternalTargets(host, p.config.EdgeDNSServerPort, p.config.GetExternalClusterNSNames())
 }
 
 func (p *EmptyDNSProvider) SaveDNSEndpoint(gslb *k8gbv1beta1.Gslb, i *externaldns.DNSEndpoint) error {

--- a/controllers/providers/dns/external.go
+++ b/controllers/providers/dns/external.go
@@ -110,7 +110,7 @@ func (p *ExternalDNSProvider) Finalize(*k8gbv1beta1.Gslb) error {
 }
 
 func (p *ExternalDNSProvider) GetExternalTargets(host string) (targets []string) {
-	return p.assistant.GetExternalTargets(host, p.config.Override.FakeDNSEnabled, p.config.GetExternalClusterNSNames())
+	return p.assistant.GetExternalTargets(host, p.config.EdgeDNSServerPort, p.config.GetExternalClusterNSNames())
 }
 
 func (p *ExternalDNSProvider) GslbIngressExposedIPs(gslb *k8gbv1beta1.Gslb) ([]string, error) {

--- a/controllers/providers/dns/external_test.go
+++ b/controllers/providers/dns/external_test.go
@@ -50,8 +50,8 @@ var a = struct {
 	Config: depresolver.Config{
 		ReconcileRequeueSeconds: 30,
 		ClusterGeoTag:           "us",
-		ExtClustersGeoTags:      []string{"uk", "eu"},
-		EdgeDNSServer:           "8.8.8.8",
+		ExtClustersGeoTags:      []string{"za", "eu"},
+		EdgeDNSServer:           "dns.cloud.example.com",
 		EdgeDNSZone:             "example.com",
 		DNSZone:                 "cloud.example.com",
 		K8gbNamespace:           "k8gb",
@@ -69,8 +69,8 @@ var a = struct {
 	},
 	TargetNSNamesSorted: []string{
 		"gslb-ns-eu-cloud.example.com",
-		"gslb-ns-uk-cloud.example.com",
 		"gslb-ns-us-cloud.example.com",
+		"gslb-ns-za-cloud.example.com",
 	},
 }
 

--- a/controllers/providers/dns/infoblox.go
+++ b/controllers/providers/dns/infoblox.go
@@ -96,7 +96,7 @@ func (p *InfobloxProvider) CreateZoneDelegationForExternalDNS(gslb *k8gbv1beta1.
 				for extClusterGeoTag, nsServerNameExt := range p.config.GetExternalClusterNSNames() {
 					err = p.assistant.InspectTXTThreshold(
 						extClusterHeartbeatFQDNs[extClusterGeoTag],
-						p.config.Override.FakeDNSEnabled,
+						p.config.EdgeDNSServerPort,
 						time.Second*time.Duration(gslb.Spec.Strategy.SplitBrainThresholdSeconds))
 					if err != nil {
 						log.Err(err).Msgf("Got the error from TXT based checkAlive. External cluster (%s) doesn't "+
@@ -171,7 +171,7 @@ func (p *InfobloxProvider) Finalize(gslb *k8gbv1beta1.Gslb) error {
 }
 
 func (p *InfobloxProvider) GetExternalTargets(host string) (targets []string) {
-	return p.assistant.GetExternalTargets(host, p.config.Override.FakeDNSEnabled, p.config.GetExternalClusterNSNames())
+	return p.assistant.GetExternalTargets(host, p.config.EdgeDNSServerPort, p.config.GetExternalClusterNSNames())
 }
 
 func (p *InfobloxProvider) GslbIngressExposedIPs(gslb *k8gbv1beta1.Gslb) ([]string, error) {


### PR DESCRIPTION
GSLB assistant with help of `OVERRIDE_WITH_FAKE_EXT_DNS` decides whether to use mock DNS (localhost:7753) or calculated NSServerName (gslb-ns-uk-cloud.example.com:53).

This PR removes such functionality from gslb assistant. Depresolver `getNSName` returns NSName based on EdgeDNSServer.
If edgeDNSServer is localhost than nsname is localhost for any region, otherwise proper nsname is returned.
I also removed `OVERRIDE_WITH_FAKE_EXT_DNS` and introduced `EDGE_DNS_SERVER_PORT`.
Now we can request edge DNS server on any port. All current settings are backward compatible as default 53 port is used.

Because OverrideWithFakeDNS was removed I had to change Assistant interface contract and regenerate mocks, covered by tests.
 

Signed-off-by: kuritka <kuritka@gmail.com>