### PR TITLE
Use edgeDNSServer for NS name resolution

### DIFF
--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -71,7 +71,7 @@ var predefinedConfig = depresolver.Config{
 	ReconcileRequeueSeconds: 30,
 	ClusterGeoTag:           "us-west-1",
 	ExtClustersGeoTags:      []string{"us-east-1"},
-	EdgeDNSServer:           "8.8.8.8",
+	EdgeDNSServer:           "127.0.0.1",
 	EdgeDNSServerPort:       7753,
 	EdgeDNSZone:             "example.com",
 	DNSZone:                 "cloud.example.com",
@@ -708,6 +708,7 @@ func TestCreatesNSDNSRecordsForRoute53(t *testing.T) {
 	dnsEndpointRoute53 := &externaldns.DNSEndpoint{}
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSServer = "1.1.1.1"
+	customConfig.EdgeDNSServerPort = 53
 	customConfig.CoreDNSExposed = true
 	coreDNSService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -778,6 +779,7 @@ func TestCreatesNSDNSRecordsForNS1(t *testing.T) {
 	dnsEndpointNS1 := &externaldns.DNSEndpoint{}
 	customConfig := predefinedConfig
 	customConfig.EdgeDNSServer = "1.1.1.1"
+	customConfig.EdgeDNSServerPort = 53
 	customConfig.CoreDNSExposed = true
 	coreDNSService := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -822,6 +824,9 @@ func TestCreatesNSDNSRecordsForNS1(t *testing.T) {
 
 func TestResolvesLoadBalancerHostnameFromIngressStatus(t *testing.T) {
 	// arrange
+	customConfig := predefinedConfig
+	customConfig.EdgeDNSServer = "1.1.1.1"
+	customConfig.EdgeDNSServerPort = 53
 	serviceName := "frontend-podinfo"
 	want := []*externaldns.Endpoint{
 		{
@@ -835,7 +840,7 @@ func TestResolvesLoadBalancerHostnameFromIngressStatus(t *testing.T) {
 			RecordType: "A",
 			Targets:    externaldns.Targets{"1.0.0.1", "1.1.1.1"}},
 	}
-	settings := provideSettings(t, predefinedConfig)
+	settings := provideSettings(t, customConfig)
 	dnsEndpoint := &externaldns.DNSEndpoint{ObjectMeta: metav1.ObjectMeta{Namespace: settings.gslb.Namespace, Name: settings.gslb.Name}}
 	createHealthyService(t, &settings, serviceName)
 	defer deleteHealthyService(t, &settings, serviceName)

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -30,6 +30,7 @@ import (
 	k8gbv1beta1 "github.com/AbsaOSS/k8gb/api/v1beta1"
 	"github.com/AbsaOSS/k8gb/controllers/depresolver"
 	"github.com/AbsaOSS/k8gb/controllers/internal/utils"
+	"github.com/AbsaOSS/k8gb/controllers/logging"
 	"github.com/AbsaOSS/k8gb/controllers/providers/assistant"
 	"github.com/AbsaOSS/k8gb/controllers/providers/dns"
 	"github.com/AbsaOSS/k8gb/controllers/providers/metrics"
@@ -1207,6 +1208,7 @@ func provideSettings(t *testing.T, expected depresolver.Config) (settings testSe
 		assistant:  a,
 	}
 	reconcileAndUpdateGslb(t, settings)
+	logging.Init(&expected)
 	return settings
 }
 

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -435,15 +435,13 @@ func TestCanGetExternalTargetsFromK8gbInAnotherLocation(t *testing.T) {
 		{IP: "10.0.0.3"},
 	}
 	dnsEndpoint := &externaldns.DNSEndpoint{}
-	customConfig := predefinedConfig
-	customConfig.EdgeDNSServer = "localhost"
 	utils.NewFakeDNS(fakeDNSSettings).
 		AddARecord("localtargets-roundrobin.cloud.example.com.", net.IPv4(10, 1, 0, 3)).
 		AddARecord("localtargets-roundrobin.cloud.example.com.", net.IPv4(10, 1, 0, 2)).
 		AddARecord("localtargets-roundrobin.cloud.example.com.", net.IPv4(10, 1, 0, 1)).
 		Start().
 		RunTestFunc(func() {
-			settings := provideSettings(t, customConfig)
+			settings := provideSettings(t, predefinedConfig)
 
 			err := settings.client.Get(context.TODO(), settings.request.NamespacedName, settings.ingress)
 			require.NoError(t, err, "Failed to get expected ingress")
@@ -471,16 +469,14 @@ func TestCanGetExternalTargetsFromK8gbInAnotherLocation(t *testing.T) {
 
 func TestCanCheckExternalGslbTXTRecordForValidityAndFailIfItIsExpired(t *testing.T) {
 	// arrange
-	customConfig := predefinedConfig
-	customConfig.EdgeDNSServer = "localhost"
 	utils.NewFakeDNS(fakeDNSSettings).
 		AddTXTRecord("test-gslb-heartbeat-eu.example.com.", oldEdgeTimestamp("10m")).
 		Start().
 		RunTestFunc(func() {
-			settings := provideSettings(t, customConfig)
+			settings := provideSettings(t, predefinedConfig)
 			// act
 			got := settings.assistant.InspectTXTThreshold("test-gslb-heartbeat-eu.example.com",
-				customConfig.EdgeDNSServerPort, time.Minute*5)
+				predefinedConfig.EdgeDNSServerPort, time.Minute*5)
 			want := errors.NewResourceExpired("Split brain TXT record expired the time threshold: (5m0s)")
 			// assert
 			assert.Equal(t, want, got, "got:\n %s from TXT split brain check,\n\n want error:\n %v", got, want)
@@ -489,16 +485,14 @@ func TestCanCheckExternalGslbTXTRecordForValidityAndFailIfItIsExpired(t *testing
 
 func TestCanCheckExternalGslbTXTRecordForValidityAndPAssIfItISNotExpired(t *testing.T) {
 	// arrange
-	customConfig := predefinedConfig
-	customConfig.EdgeDNSServer = "localhost"
 	utils.NewFakeDNS(fakeDNSSettings).
 		AddTXTRecord("test-gslb-heartbeat-za.example.com.", oldEdgeTimestamp("3m")).
 		Start().
 		RunTestFunc(func() {
-			settings := provideSettings(t, customConfig)
+			settings := provideSettings(t, predefinedConfig)
 			// act
 			err2 := settings.assistant.InspectTXTThreshold("test-gslb-heartbeat-za.example.com",
-				customConfig.EdgeDNSServerPort, time.Minute*5)
+				predefinedConfig.EdgeDNSServerPort, time.Minute*5)
 			// assert
 			assert.NoError(t, err2, "got:\n %s from TXT split brain check,\n\n want error:\n %v", err2, nil)
 		}).RequireNoError(t)

--- a/controllers/providers/assistant/gslb.go
+++ b/controllers/providers/assistant/gslb.go
@@ -230,10 +230,10 @@ func getARecords(msg *dns.Msg) []string {
 	return ARecords
 }
 
-func dnsQuery(fqdn string, nameserver string, nameserverport int) (*dns.Msg, error) {
+func dnsQuery(host string, nameserver string, nameserverport int) (*dns.Msg, error) {
 	dnsMsg := new(dns.Msg)
 	edgeDNSServer := fmt.Sprintf("%s:%v", nameserver, nameserverport)
-	fqdn = fmt.Sprintf("%s.", fqdn) // Convert to true FQDN with dot at the end
+	fqdn := fmt.Sprintf("%s.", host) // Convert to true FQDN with dot at the end
 	dnsMsg.SetQuestion(fqdn, dns.TypeA)
 	dnsMsgA, err := dns.Exchange(dnsMsg, edgeDNSServer)
 	if err != nil {


### PR DESCRIPTION
* Use edgeDNSServer for NS name resolution with the fallback to the local nameserver
* Supporting dns related functions
* Logs to stdout during the tests
* Use localhost as default edgeDNSServer to avoid network timeout