### PR TITLE
Fix DNS query logging message

### DIFF
--- a/controllers/providers/assistant/gslb.go
+++ b/controllers/providers/assistant/gslb.go
@@ -239,7 +239,7 @@ func dnsQuery(host string, nameserver string, nameserverport int) (*dns.Msg, err
 	dnsMsg.SetQuestion(fqdn, dns.TypeA)
 	dnsMsgA, err := dns.Exchange(dnsMsg, edgeDNSServer)
 	if err != nil {
-		log.Warn().Msgf("Can't resolve FQDN(%s) using edgeDNSServer(%s) : (%v)", fqdn, nameserver, err)
+		log.Warn().Msgf("Can't resolve FQDN(%s) using nameserver(%s) : (%v)", fqdn, nameserver, err)
 	}
 	return dnsMsgA, err
 }


### PR DESCRIPTION
EdgeDNSServer here is misleading as the algorithm
falls back to local nameservers and eventually `gslb-ns-*`
servers to resolve different FQDNs on different lifecycle
stages.

So use generic `nameserver` here and the semantics can be
deducted by the nameserver name itself while observing the
log messages.

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>