### PR TITLE
Metrics configuration #(1/4)

### DIFF
--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -125,3 +125,5 @@ spec:
               value: "true"
             - name: SPLIT_BRAIN_CHECK
               value: {{ quote .Values.k8gb.splitBrainCheck }}
+            - name: METRICS_ADDRESS
+              value: {{ .Values.k8gb.metricsAddress }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -26,6 +26,7 @@ k8gb:
     format: simple # log format (simple,json)
     level: info # log level (panic,fatal,error,warn,info,debug,trace)
   splitBrainCheck: false
+  metricsAddress: "0.0.0.0:8080"
 
 externaldns:
   image: k8s.gcr.io/external-dns/external-dns:v0.7.5

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -137,6 +137,8 @@ type Config struct {
 	CoreDNSExposed bool
 	// Log configuration
 	Log Log
+	// MetricsAddress in format address:port where address can be empty, IP address, or hostname, default: 0.0.0.0:8080
+	MetricsAddress string
 	// route53Enabled hidden. EdgeDNSType defines all enabled Enabled types
 	route53Enabled bool
 	// ns1Enabled flag

--- a/controllers/depresolver/depresolver_validator.go
+++ b/controllers/depresolver/depresolver_validator.go
@@ -139,6 +139,16 @@ func (v *validator) isLessOrEqualTo(num int) *validator {
 	return v
 }
 
+func (v *validator) isHigherThan(num int) *validator {
+	if v.err != nil {
+		return v
+	}
+	if v.intValue <= num {
+		v.err = fmt.Errorf(`'%s' is higher than '%v'`, v.name, num)
+	}
+	return v
+}
+
 func (v *validator) isNotEqualTo(value string) *validator {
 	if v.err != nil {
 		return v

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -173,7 +173,7 @@ func (r *GslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 // SetupWithManager configures controller manager
 func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Figure out Gslb resource name to Reconcile when non controlled Endpoint is updated
+	// Figure out Gslb resource name to Reconcile when non controlled Name is updated
 
 	endpointMapHandler := handler.EnqueueRequestsFromMapFunc(
 		func(a client.Object) []reconcile.Request {

--- a/main.go
+++ b/main.go
@@ -15,7 +15,6 @@ limitations under the License.
 package main
 
 import (
-	"flag"
 	"os"
 
 	str "github.com/AbsaOSS/gopkg/strings"
@@ -49,15 +48,7 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
 	var f *dns.ProviderFactory
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
-		"Enable leader election for controller manager. "+
-			"Enabling this will ensure there is only one active controller manager.")
-	flag.Parse()
-
 	resolver := depresolver.NewDependencyResolver()
 	config, err := resolver.ResolveOperatorConfig()
 	// Initialize desired log or default log in case of configuration failed.
@@ -75,9 +66,9 @@ func main() {
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:             runtimescheme,
-		MetricsBindAddress: metricsAddr,
+		MetricsBindAddress: config.MetricsAddress,
 		Port:               9443,
-		LeaderElection:     enableLeaderElection,
+		LeaderElection:     false,
 		LeaderElectionID:   "8020e9ff.absa.oss",
 	})
 	if err != nil {


### PR DESCRIPTION
Related to #124

I created a MetricsAddress field.  The default value is “0.0.0.0:8080" and defines where Prometheus metrics endpoint is listening. (see: https://docs.openshift.com/container-platform/4.1/applications/operator_sdk/osdk-monitoring-prometheus.html#osdk-monitoring-prometheus-metrics-helper_osdk-monitoring-prometheus)

I also removed flag.StringVar `"metrics-addr", ":8080”,` from `main.go` as moving inputs into depresolver and also, removed `enableLeaderElection` and overall flags completely.

Signed-off-by: kuritka <kuritka@gmail.com>