### PR TITLE
Install prometheus on local clusters (2/4)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@
 - [Testing](#testing)
   - [Testing against real k8s clusters](#testing-against-real-k8s-clusters)
 - [Debugging](#debugging)
+- [Metrics](#metrics)
 - [Code style](#code-style)
 - [Commit and Pull Request message](#commit-and-pull-request-message)
   - [Signature](#signature)
@@ -129,6 +130,17 @@ There is a dedicated make target available for Goland:
     [This article](https://dev4devs.com/2019/05/04/operator-framework-how-to-debug-golang-operator-projects/) describes possible option examples for Goland and VS Code.
 
 3. Attach debugger of your IDE to port `2345`.
+
+## Metrics
+More info about k8gb metrics can be found in the [metrics.md](/docs/metrics.md) document. 
+If you need to check and query the k8gb metrics locally, you can install a Prometheus in the local clusters using the `make deploy-prometheus` command.
+
+The deployed Prometheus scrapes metrics from the dedicated k8gb operator endpoint and makes them accessible via Prometheus web UI:
+
+- http://127.0.0.1:8080
+- http://127.0.0.1:8081
+
+To uninstall Prometheus, run `make uninstall-prometheus`
 
 ## Code style
 

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,16 @@ destroy-full-local-setup: ## Destroy full local multicluster setup
 	k3d cluster delete $(CLUSTER_GSLB2)
 	docker network rm $(CLUSTER_GSLB_NETWORK)
 
+.PHONY: deploy-prometheus
+deploy-prometheus:
+	$(call deploy-prometheus,$(CLUSTER_GSLB1))
+	$(call deploy-prometheus,$(CLUSTER_GSLB2))
+
+.PHONY: uninstall-prometheus
+uninstall-prometheus:
+	$(call uninstall-prometheus,$(CLUSTER_GSLB1))
+	$(call uninstall-prometheus,$(CLUSTER_GSLB2))
+
 .PHONY: dns-tools
 dns-tools: ## Run temporary dnstools pod for debugging DNS issues
 	@kubectl -n k8gb get svc k8gb-coredns
@@ -486,4 +496,29 @@ endef
 define list-running-pods
 	@echo "\n$(YELLOW)Local cluster $(CYAN)$1 $(NC)"
 	kubectl get pods -A --context=k3d-$1
+endef
+
+define deploy-prometheus
+	@echo "\n$(YELLOW)Local cluster $(CYAN)$1$(NC)"
+
+	@echo "\n$(YELLOW)Set annotations on pods that will be scraped by prometheus$(NC)"
+	kubectl annotate pods -l name=k8gb -n k8gb --overwrite prometheus.io/scrape="true" --context=k3d-$1
+	kubectl annotate pods -l name=k8gb -n k8gb --overwrite prometheus.io/port="8080" --context=k3d-$1
+
+	@echo "\n$(YELLOW)install prometheus $(NC)"
+	helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+	helm repo update
+	helm -n k8gb upgrade -i prometheus prometheus-community/prometheus -f deploy/prometheus/values.yaml \
+		--version 14.2.0 \
+		--wait --timeout=2m0s \
+		--kube-context=k3d-$1
+endef
+
+define uninstall-prometheus
+	@echo "\n$(YELLOW)Local cluster $(CYAN)$1$(NC)"
+
+	@echo "\n$(YELLOW)uninstall prometheus $(NC)"
+	helm uninstall prometheus -n k8gb --kube-context=k3d-$1
+	kubectl annotate pods -l name=k8gb -n k8gb prometheus.io/scrape- --context=k3d-$1
+	kubectl annotate pods -l name=k8gb -n k8gb prometheus.io/port- --context=k3d-$1
 endef

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This setup is adapted for local scenarios and works without external DNS provide
 
 Consult with [local playground](/docs/local.md) documentation to learn all the details of experimenting with local setup.
 
+Optionally, you can run `make-deploy-prometheus` and check the metrics on the test clusters (http://localhost:8080, http://localhost:8081).
 ## Motivation and Architecture
 
 k8gb was born out of the need for an open source, cloud native GSLB solution at Absa Group in South Africa.

--- a/deploy/prometheus/values.yaml
+++ b/deploy/prometheus/values.yaml
@@ -1,0 +1,20 @@
+server:
+  enabled: true
+  service:
+    nodePort: 30090 # allowed port range between 30000 and 32768
+    servicePort: 9090
+    type: NodePort
+
+alertmanager:
+  enabled: false
+#  service:
+#    nodePort: 30091 # allowed port range between 30000 and 32768
+#    servicePort: 9091
+#    type: NodePort
+
+pushgateway:
+  enabled: false
+#  service:
+#    nodePort: 30092 # allowed port range between 30000 and 32768
+#    servicePort: 9092
+#    type: NodePort

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -10,7 +10,10 @@ ports:
   - agent[0] 
 - port: 443:443
   nodeFilters:
-  - agent[0] 
+  - agent[0]
+- port: 8080:30090
+  nodeFilters:
+    - agent[0]
 - port: 5053:53/udp
   nodeFilters:
   - agent[0] 

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -10,7 +10,10 @@ ports:
   - agent[0] 
 - port: 444:443
   nodeFilters:
-  - agent[0] 
+  - agent[0]
+- port: 8081:30090
+  nodeFilters:
+    - agent[0]
 - port: 5054:53/udp
   nodeFilters:
   - agent[0] 


### PR DESCRIPTION
related to #124

I want to check metrics that will be implemented. That's why I'm adding the option to install prometheus on both clusters with `make deploy-prometheus`.

Such deployed prometheus scrapes metrics of k8gb operator and is accessible directly from the browser:

 - http://127.0.0.1:8080 - test-gslb1
 - http://127.0.0.1:8081 - test-gslb2


Co-authored-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>

Signed-off-by: kuritka <kuritka@gmail.com>