### PR TITLE
Fix version of podinfo test sample chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,8 @@ define deploy-test-apps
 	helm upgrade --install frontend --namespace test-gslb -f deploy/test-apps/podinfo/podinfo-values.yaml \
 		--set ui.message="`$(call get-cluster-geo-tag)`" \
 		--set image.repository="$(PODINFO_IMAGE_REPO)" \
-		podinfo/podinfo
+		podinfo/podinfo \
+		--version 5.1.1
 endef
 
 define get-cluster-geo-tag


### PR DESCRIPTION
Otherwise most recent `6.0.0` fails with message like

```
Error: UPGRADE FAILED: chart requires kubeVersion: >=1.19.0-0 which is incompatible with Kubernetes v1.17.17
```

on older clusters

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>