### PR TITLE
simplifying Failover and RoundRobin tests

### DIFF
--- a/terratest/test/k8gb_full_roundrobin_test.go
+++ b/terratest/test/k8gb_full_roundrobin_test.go
@@ -47,48 +47,42 @@ func TestFullRoundRobin(t *testing.T) {
 	expectedIPs := append(instance1LocalTargets, instance2LocalTargets...)
 
 	t.Run("round-robin on two concurrent clusters with podinfo running", func(t *testing.T) {
-		_, err = instance1.WaitForExpected(expectedIPs)
+		err = instance1.WaitForExpected(expectedIPs)
 		require.NoError(t, err)
-		_, err = instance2.WaitForExpected(expectedIPs)
+		err = instance2.WaitForExpected(expectedIPs)
 		require.NoError(t, err)
 	})
 
 	t.Run("kill podinfo on the second cluster", func(t *testing.T) {
 		instance2.StopTestApp()
-		ip1, err := instance1.WaitForGSLB(instance2)
+		err = instance1.WaitForExpected(instance1LocalTargets)
 		require.NoError(t, err)
-		ip2, err := instance2.WaitForGSLB(instance1)
+		err = instance2.WaitForExpected(instance1LocalTargets)
 		require.NoError(t, err)
-		require.True(t, utils.EqualStringSlices(instance1LocalTargets, ip1))
-		require.True(t, utils.EqualStringSlices(instance1LocalTargets, ip2))
 	})
 
 	t.Run("kill podinfo on the first cluster", func(t *testing.T) {
 		instance1.StopTestApp()
-		ip2, err := instance2.WaitForGSLB(instance1)
+		err = instance2.WaitForExpected([]string{})
 		require.NoError(t, err)
-		ip1, err := instance1.WaitForGSLB(instance2)
+		err = instance1.WaitForExpected([]string{})
 		require.NoError(t, err)
-		require.Nil(t, ip1)
-		require.Nil(t, ip2)
 	})
 
 	t.Run("start podinfo on the second cluster", func(t *testing.T) {
 		instance2.StartTestApp()
-		ip1, err := instance1.WaitForGSLB(instance2)
+		err = instance1.WaitForExpected(instance2LocalTargets)
 		require.NoError(t, err)
-		ip2, err := instance2.WaitForGSLB(instance1)
+		err = instance2.WaitForExpected(instance2LocalTargets)
 		require.NoError(t, err)
-		require.True(t, utils.EqualStringSlices(instance2LocalTargets, ip1))
-		require.True(t, utils.EqualStringSlices(instance2LocalTargets, ip2))
 	})
 
 	t.Run("start podinfo on the first cluster", func(t *testing.T) {
 		// start app in the both clusters
 		instance1.StartTestApp()
-		_, err = instance1.WaitForExpected(expectedIPs)
+		err = instance1.WaitForExpected(expectedIPs)
 		require.NoError(t, err)
-		_, err = instance2.WaitForExpected(expectedIPs)
+		err = instance2.WaitForExpected(expectedIPs)
 		require.NoError(t, err)
 	})
 }

--- a/terratest/utils/extensions.go
+++ b/terratest/utils/extensions.go
@@ -248,8 +248,9 @@ func (i *Instance) WaitForGSLB(instances ...*Instance) ([]string, error) {
 }
 
 // WaitForExpected waits until GSLB dig doesnt return list of expected IP's
-func (i *Instance) WaitForExpected(expectedIPs []string) ([]string, error) {
-	return waitForLocalGSLBNew(i.w.t, i.w.state.gslb.host, i.w.state.gslb.port, expectedIPs)
+func (i *Instance) WaitForExpected(expectedIPs []string) (err error) {
+	_, err = waitForLocalGSLBNew(i.w.t, i.w.state.gslb.host, i.w.state.gslb.port, expectedIPs)
+	return
 }
 
 func (i *Instance) String() string {


### PR DESCRIPTION
- By dropping WaitForGSLB from the failover and roundrobin tests I achieved a simplification.
- raise condition fix : https://github.com/k8gb-io/k8gb/runs/2875202024?check_suite_focus=true

Signed-off-by: kuritka <kuritka@gmail.com>