### PR TITLE
Temporarly downgrade GitHub runner to Ubuntu 18.04

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   terratest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   upgrade-testing:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
The GitHub runner has been upgraded to the latest [version 20210628.1](https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F20210628.1) which has changed the kernel.
The K3d action stopped working, so we don't get terratests, releases, etc..

I found that the tests would pass if I upgraded the k3d version, but unfortunately k3d has changed too much and just upgrading the version inside the k3d action is not enough and I will need more time to investigate.

That's why I'm temporarily downgrading the github runner until I fix the k3d-action.

Signed-off-by: kuritka <kuritka@gmail.com>