### PR TITLE
upgrade to k3d-action v1.5.0

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -19,7 +19,7 @@ jobs:
           destination-repo: absaoss/k8gb
           destination-branch: gh-pages
       - name: Create single node k3s cluster
-        uses: AbsaOSS/k3d-action@v1.4.0
+        uses: AbsaOSS/k3d-action@v1.5.0
         with:
           cluster-name: "test-gslb1"
           use-default-registry: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -10,18 +10,18 @@ on:
 
 jobs:
   terratest:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
 
       - name: Create 1st k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.4.0
+        uses: AbsaOSS/k3d-action@v1.5.0
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.4.0
+        uses: AbsaOSS/k3d-action@v1.5.0
         with:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -10,18 +10,18 @@ on:
 
 jobs:
   upgrade-testing:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
 
       - name: Create 1st k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.4.0
+        uses: AbsaOSS/k3d-action@v1.5.0
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
-        uses: AbsaOSS/k3d-action@v1.4.0
+        uses: AbsaOSS/k3d-action@v1.5.0
         with:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -1,7 +1,7 @@
 apiVersion: k3d.io/v1alpha2
 kind: Simple
 name: test-gslb1
-image: docker.io/rancher/k3s:v1.20.5-k3s1
+image: docker.io/rancher/k3s:v1.21.2-k3s1
 agents: 1
 network: k3d-action-bridge-network
 ports:

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -1,7 +1,7 @@
 apiVersion: k3d.io/v1alpha2
 kind: Simple
 name: test-gslb2
-image: docker.io/rancher/k3s:v1.20.5-k3s1
+image: docker.io/rancher/k3s:v1.21.2-k3s1
 agents: 1
 network: k3d-action-bridge-network
 ports:


### PR DESCRIPTION
In addition to updating the action itself (problem with missing default gateway) I need to update the k3s version.
I'm reverting ubuntu back to v20.04

Signed-off-by: kuritka <kuritka@gmail.com>