### PR TITLE
http failover, wait for app

### DIFF
--- a/terratest/test/k8gb_failover_playground_test.go
+++ b/terratest/test/k8gb_failover_playground_test.go
@@ -72,11 +72,13 @@ func TestFailoverPlayground(t *testing.T) {
 
 	t.Run("stop podinfo on eu cluster", func(t *testing.T) {
 		instanceEU.StopTestApp()
+		require.NoError(t, instanceEU.WaitForAppIsStopped())
 		actAndAssert(t.Name(), usGeoTag, usLocalTargets)
 	})
 
 	t.Run("start podinfo again on eu cluster", func(t *testing.T) {
 		instanceEU.StartTestApp()
+		require.NoError(t, instanceEU.WaitForAppIsRunning())
 		actAndAssert(t.Name(), euGeoTag, euLocalTargets)
 	})
 }


### PR DESCRIPTION
Small change, the test waits until the application starts or is stopped.

I also changed the implementation of the wait for app function. Now it can wait until the application starts as well as it can wait for it to stop.

Signed-off-by: kuritka <kuritka@gmail.com>