### PR TITLE
Use `k8gb` prefix for external dns rbac

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -14,7 +14,7 @@ spec:
       labels:
         app: external-dns
     spec:
-      serviceAccountName: external-dns
+      serviceAccountName: k8gb-external-dns
       securityContext:
         fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
         runAsUser: 1000

--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: external-dns
+  name: k8gb-external-dns
 rules:
 - apiGroups: ["externaldns.k8s.io"]
   resources: ["dnsendpoints"]
@@ -14,20 +14,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: external-dns-viewer
+  name: k8gb-external-dns-viewer
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: external-dns
+  name: k8gb-external-dns
 subjects:
 - kind: ServiceAccount
-  name: external-dns
+  name: k8gb-external-dns
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: external-dns
+  name: k8gb-external-dns
   namespace: {{ .Release.Namespace }}
 {{ if .Values.route53.enabled }}
   annotations:


### PR DESCRIPTION
* Use k8gb prefix for rbac resources to avoid the conflict
  with the standard upstream external-dns names
* Fixes #542

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>