### PR TITLE
create-pull-request creates commit

### DIFF
--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -24,12 +24,6 @@ jobs:
           compareLink: true
           filterByMilestone: true
           unreleased: true
-      - name: Commit changelog
-        run: |
-          git config user.name 'Github Action'
-          git config user.email 'action@users.noreply.github.com'
-          git add CHANGELOG.md
-          git commit -m "Update Offline Changelog"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
It is not required to have changes committed in advance,
create-pull-request does this automatically.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>