### PR TITLE
Openshift support: flagged rbac for the Routes

### DIFF
--- a/chart/k8gb/templates/role.yaml
+++ b/chart/k8gb/templates/role.yaml
@@ -38,3 +38,12 @@ rules:
   - namespaces
   verbs:
   - 'list'
+{{ if .Values.openshift.enabled }}
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes/custom-host
+  verbs:
+  - create
+  - update
+{{ end }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -66,3 +66,6 @@ ns1:
   # optional custom NS1 API endpoint for on-prem setups
   # endpoint: https://api.nsone.net/v1/
   ignoreSSL: false
+
+openshift:
+  enabled: false


### PR DESCRIPTION
* Introduce openshift enablement flag in chart configuration
* Use it to extend k8gb Cluster Role with openshift specific access
  rules
* Fixes #422

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>