### PR TITLE
Parametrize security settings for k8gb and externaldns pods

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -15,10 +15,7 @@ spec:
         app: external-dns
     spec:
       serviceAccountName: k8gb-external-dns
-      securityContext:
-        fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
-        runAsUser: 1000
-        runAsNonRoot: true
+      securityContext: {{ .Values.externaldns.securityContext }}
       containers:
       - name: external-dns
         image: {{ .Values.externaldns.image }}

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -29,7 +29,7 @@ spec:
           image: {{ .Values.k8gb.imageRepo }}:{{ .Values.k8gb.imageTag | default .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
           securityContext:
-            runAsUser: 1000
+            runAsUser: {{ .Values.k8gb.runAsUser }}
             runAsNonRoot: true
             readOnlyRootFilesystem: true
           resources:

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -27,6 +27,7 @@ k8gb:
     level: info # log level (panic,fatal,error,warn,info,debug,trace)
   splitBrainCheck: false
   metricsAddress: "0.0.0.0:8080"
+  runAsUser: 1000
 
 externaldns:
   image: k8s.gcr.io/external-dns/external-dns:v0.9.0


### PR DESCRIPTION
* Parametrize `runAsUser` for k8gb pod
* Propagate `securityContext` for externaldns pod
* Fixes #421

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>