### PR TITLE
Fix external-dns managed records option usage

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -25,7 +25,9 @@ spec:
         - --domain-filter={{ .Values.k8gb.edgeDNSZone }} # will make ExternalDNS see only the hosted zones matching provided domain, omit to process all available hosted zones
         - --policy=sync # enable full synchronization including record removal
         - --log-level=debug # debug only
-        - --managed-record-types=A,CNAME,NS
+        - --managed-record-types=A
+        - --managed-record-types=CNAME
+        - --managed-record-types=NS
         - --annotation-filter=k8gb.absa.oss/dnstype={{ include "k8gb.extdnsAnnotation" . }} # filter out only relevant DNSEntrypoints
         - --txt-owner-id={{ include "k8gb.extdnsOwnerID" . }}
         - --provider={{ include "k8gb.extdnsProvider" . }}


### PR DESCRIPTION
There is a bug in external-dns parameter documentation. Flag must be
used multiple types to enable multiple records.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>