### PR TITLE
Release build optimisations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,10 @@ builds:
     goarch:
       - amd64
       - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.Version={{ .Tag }}
 dockers:
 - image_templates:
   - "absaoss/k8gb:{{ .Tag }}-amd64"

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ import (
 
 var (
 	runtimescheme = runtime.NewScheme()
+	version       = "development"
 )
 
 func init() {
@@ -58,6 +59,7 @@ func main() {
 	// Initialize desired log or default log in case of configuration failed.
 	logging.Init(config)
 	log := logging.Logger()
+	log.Info().Str("version", version).Msg("k8gb:")
 	if err != nil {
 		log.Err(err).Msg("can't resolve environment variables")
 		return


### PR DESCRIPTION
this PR affects three things
 - (`-X`) setting the k8gb version during the compile time, version is logged. The default version on local environment is `development` while prod version has release tag e.g: `v0.8.2`.
 - (`-s -w`) deletion of linter stamps that are not needed in the production binary (reduction from 47MB to 38MB).
 - (`-trimpath`) remove all file system paths from the resulting executable. Instead of file system paths,   a plain import path is printed. (Instead of  workspace/controllers/providers/assistant/gslb.go:68 -> github.com/AbsaOSS/k8gb/controllers/providers/assistant/gslb.go:68)

The PR doesn't affect local environment

Signed-off-by: kuritka <kuritka@gmail.com>