### PR TITLE
Add backup dns server for dig during tests

### DIFF
--- a/controllers/internal/utils/dns.go
+++ b/controllers/internal/utils/dns.go
@@ -26,6 +26,10 @@ import (
 
 // Dig retrieves list of tuple <IP address, A record > from edge DNS server for specific FQDN
 func Dig(edgeDNSServer, fqdn string) ([]string, error) {
+	return DigWithBackup(edgeDNSServer, "", fqdn)
+}
+
+func DigWithBackup(edgeDNSServer, backupDNSServer, fqdn string) ([]string, error) {
 	var dig dnsutil.Dig
 	if edgeDNSServer == "" {
 		return nil, fmt.Errorf("empty edgeDNSServer")
@@ -34,6 +38,13 @@ func Dig(edgeDNSServer, fqdn string) ([]string, error) {
 	if err != nil {
 		err = fmt.Errorf("dig error: can't set query dns (%s) with error(%s)", edgeDNSServer, err)
 		return nil, err
+	}
+	if backupDNSServer != "" {
+		err := dig.SetBackupDNS(backupDNSServer)
+		if err != nil {
+			err = fmt.Errorf("dig error: can't set dns backup server (%s) with error(%s)", backupDNSServer, err)
+			return nil, err
+		}
 	}
 	a, err := dig.A(fqdn)
 	if err != nil {

--- a/controllers/internal/utils/dns_test.go
+++ b/controllers/internal/utils/dns_test.go
@@ -30,9 +30,10 @@ func TestValidDig(t *testing.T) {
 		t.Skipf("no connectivity, skipping")
 	}
 	edgeDNSServer := "8.8.8.8"
+	backupDNSServer := "dns.google"
 	fqdn := "google.com"
 	// act
-	result, err := Dig(edgeDNSServer, fqdn)
+	result, err := DigWithBackup(edgeDNSServer, backupDNSServer, fqdn)
 	// assert
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result)
@@ -45,9 +46,10 @@ func TestEmptyFQDNButValidEdgeDNS(t *testing.T) {
 		t.Skipf("no connectivity, skipping")
 	}
 	edgeDNSServer := "8.8.8.8"
+	backupDNSServer := "dns.google"
 	fqdn := ""
 	// act
-	result, err := Dig(edgeDNSServer, fqdn)
+	result, err := DigWithBackup(edgeDNSServer, backupDNSServer, fqdn)
 	// assert
 	assert.NoError(t, err)
 	assert.Nil(t, result)


### PR DESCRIPTION
when running `make docker-build` I was hitting this error:

```bash
--- FAIL: TestValidDig (3.60s)
    dns_test.go:37:
        	Error Trace:	dns_test.go:37
        	Error:      	Received unexpected error:
        	            	dig error: can't dig fqdn(google.com) with error(read udp 24.148.101.228:53427->8.8.8.8:53: i/o timeout)
        	Test:       	TestValidDig
    dns_test.go:38:
        	Error Trace:	dns_test.go:38
        	Error:      	Should NOT be empty, but was []
        	Test:       	TestValidDig
```

it wasn't caused by the dns settings in docker, because running `dig @8.8.8.8 google.com` (on host) was also causing the timeout for me. Let's just add another fallback dns server for the tests to make them more robust.