### PR TITLE
Fix api version for RBAC to not produce a warning

### DIFF
--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -11,7 +11,7 @@ rules:
   resources: ["dnsendpoints/status"]
   verbs: ["*"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: k8gb-external-dns-viewer


### PR DESCRIPTION
```bash
...
Release "k8gb" does not exist. Installing it now.
W0906 10:59:34.461505   10203 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
W0906 10:59:34.529496   10203 warnings.go:70] rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding
NAME: k8gb
...
```

Also the `make deploy-full-local-setup` uses the helm chart from the repository not "local" one (`./chart/k8gb`) but I assume it's on purpose because there are other targets (`{deploy, upgrade}-candidate`) that use the "local" one