### PR TITLE
Ability to disable IRSA role association in route53 scenario

### DIFF
--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -29,7 +29,7 @@ kind: ServiceAccount
 metadata:
   name: k8gb-external-dns
   namespace: {{ .Release.Namespace }}
-{{ if .Values.route53.enabled }}
+{{ if and .Values.route53.enabled .Values.route53.irsaRole }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.route53.irsaRole }}
 {{ end }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -65,6 +65,7 @@ infoblox:
 route53:
   enabled: false
   hostedZoneID: ZXXXSSS
+  # specify IRSA Role in AWS ARN format or disable it by setting to `false`
   irsaRole: arn:aws:iam::111111:role/external-dns
 
 ns1:


### PR DESCRIPTION
* Fixes #593
* To disable just set `irsaRole` to `false`

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>