### PR TITLE
Fix helm linting error for coredns.serviceType

### DIFF
--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -113,7 +113,7 @@ spec:
             - name: NS1_ENABLED
               value: "true"
             {{ end }}
-            {{ if eq "LoadBalancer" .Values.coredns.serviceType }}
+            {{ if eq "LoadBalancer" ( quote .Values.coredns.serviceType ) }}
             - name: COREDNS_EXPOSED
               value: "true"
             {{ end }}

--- a/chart/k8gb/templates/service-delete-hook/job.yaml
+++ b/chart/k8gb/templates/service-delete-hook/job.yaml
@@ -24,3 +24,14 @@ spec:
             - {{ .Release.Namespace }}
             - -l
             - 'app.kubernetes.io/name=coredns,k8gb-migrated-svc!=true'
+          securityContext:
+            readOnlyRootFilesystem: true
+            runAsUser: {{ .Values.k8gb.runAsUser }}
+            runAsNonRoot: true
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+            limits:
+              memory: "128Mi"
+              cpu: "250m"


### PR DESCRIPTION
This PR fixes helm linting error for `coredns.serviceType` value when k8gb chart dependency (coredns) is not yet updated:
```
[ERROR] templates/: template: k8gb/templates/operator.yaml:116:18: executing "k8gb/templates/operator.yaml" at <eq "LoadBalancer" .Values.coredns.serviceType>: error calling eq: incompatible types for comparison
```
It also fixes `kube-linter` security context errors in the service-delete-hook helm template
Signed-off-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>