### PR TITLE
K8gbEndpointStatus

### DIFF
--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -170,7 +170,7 @@ func (r *GslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	}
 
 	// == Status =
-	err = r.updateGslbStatus(gslb)
+	err = r.updateGslbStatus(gslb, dnsEndpoint)
 	if err != nil {
 		m.IncrementError(gslb)
 		return result.RequeueError(err)

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -29,7 +29,7 @@ import (
 	externaldns "sigs.k8s.io/external-dns/endpoint"
 )
 
-func (r *GslbReconciler) updateGslbStatus(gslb *k8gbv1beta1.Gslb) error {
+func (r *GslbReconciler) updateGslbStatus(gslb *k8gbv1beta1.Gslb, ep *externaldns.DNSEndpoint) error {
 	var err error
 
 	gslb.Status.ServiceHealth, err = r.getServiceHealthStatus(gslb)
@@ -47,6 +47,8 @@ func (r *GslbReconciler) updateGslbStatus(gslb *k8gbv1beta1.Gslb) error {
 	gslb.Status.GeoTag = r.Config.ClusterGeoTag
 
 	m.UpdateHealthyRecordsMetric(gslb, gslb.Status.HealthyRecords)
+
+	m.UpdateEndpointStatus(ep)
 
 	err = r.Status().Update(context.TODO(), gslb)
 	return err


### PR DESCRIPTION
related to #587
`k8gb_endpoint_status`, the metric provides information about the number of targets in DNSEndpoint.

```shell
k8gb_endpoint_status{dns_name="failover.cloud.example.com", exported_name="test-gslb-failover", instance="10.42.0.6:8080", job="kubernetes-pods", kubernetes_namespace="k8gb", kubernetes_pod_name="k8gb-7f5564d48b-xtt4w", name="k8gb", namespace="test-gslb", pod_template_hash="7f5564d48b"} | 2
k8gb_endpoint_status{dns_name="localtargets-failover.cloud.example.com", exported_name="test-gslb-failover", instance="10.42.0.6:8080", job="kubernetes-pods", kubernetes_namespace="k8gb", kubernetes_pod_name="k8gb-7f5564d48b-xtt4w", name="k8gb", namespace="test-gslb", pod_template_hash="7f5564d48b"} | 2
k8gb_endpoint_status{dns_name="localtargets-roundrobin.cloud.example.com", exported_name="test-gslb", instance="10.42.0.6:8080", job="kubernetes-pods", kubernetes_namespace="k8gb", kubernetes_pod_name="k8gb-7f5564d48b-xtt4w", name="k8gb", namespace="test-gslb", pod_template_hash="7f5564d48b"} | 2
k8gb_endpoint_status{dns_name="roundrobin.cloud.example.com", exported_name="test-gslb", instance="10.42.0.6:8080", job="kubernetes-pods", kubernetes_namespace="k8gb", kubernetes_pod_name="k8gb-7f5564d48b-xtt4w", name="k8gb", namespace="test-gslb", pod_template_hash="7f5564d48b"} | 4
```

In addition:
 - I moved the linter test from `gslb_controller_test` to `prometheus_test`.
 - according to #587 the request was to rename one of the metrics to `k8gb_gslb_service_status_count,`. Unfortunately, this metric is GaugeVec and the linter does not allow to use the `_count` or `_total` suffix (they are reserved for counters). Therefore I renamed the metric to `k8gb_gslb_service_status,`

Signed-off-by: kuritka <kuritka@gmail.com>