### PR TITLE
k8gb_runtime_info

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.Version={{ .Tag }}
+      - -s -w -X main.version={{ .Tag }} main.commit={{ .Commit }}
 dockers:
 - image_templates:
   - "absaoss/k8gb:{{ .Tag }}-amd64"

--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ import (
 var (
 	runtimescheme = runtime.NewScheme()
 	version       = "development"
+	commit        = "none"
 )
 
 func init() {
@@ -61,6 +62,7 @@ func main() {
 	log := logging.Logger()
 	log.Info().
 		Str("version", version).
+		Str("commit", commit).
 		Msg("K8gb status")
 	if err != nil {
 		log.Err(err).Msg("can't resolve environment variables")
@@ -124,6 +126,7 @@ func main() {
 		log.Err(err).Msg("Unable to create controller Gslb")
 		return
 	}
+	metrics.Metrics().SetRuntimeInfo(version, commit)
 	// +kubebuilder:scaffold:builder
 	log.Info().Msg("Starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
related to #587

Runtime info provides information about the k8gb controller. The version and
git SHA are obtained during compilation (see: `.gitreleaser.yml`)
otherwise they are set to <`development`, `none`>. The metric is always 1.
Since it doesn't need to be run periodically, it is only activated once when cntroller starts.
GitSHA (commit) is `none` in case the controller is not released. If released, commit is shortened to 7 digits.

see example:
```
k8gb_runtime_info{arch="amd64", git_sha="none", go_version="go1.16.8", instance="10.42.0.5:8080", job="kubernetes-pods", k8gb_version="development", kubernetes_namespace="k8gb", kubernetes_pod_name="k8gb-56c7fbfd7d-kdvch", name="k8gb", namespace="k8gb", os="linux", pod_template_hash="56c7fbfd7d"} 1
k8gb_runtime_info{arch="amd64", git_sha="3277cb9", go_version="go1.16.8", instance="10.42.0.5:8080", job="kubernetes-pods", k8gb_version="v0.8.2", kubernetes_namespace="k8gb", kubernetes_pod_name="k8gb-56c7fbfd7d-kdvch", name="k8gb", namespace="k8gb", os="linux", pod_template_hash="56c7fbfd7d"} 1
```

Signed-off-by: kuritka <kuritka@gmail.com>