### PR TITLE
k8gb_gslb_reconciliation_loops_total per GSLB

### DIFF
--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -180,7 +180,7 @@ func (r *GslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	// Everything went fine, requeue after some time to catch up
 	// with external Gslb status
 	// TODO: potentially enhance with smarter reaction to external Event
-	m.IncrementReconciliation()
+	m.IncrementReconciliation(gslb)
 	return result.Requeue()
 }
 

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -278,10 +278,10 @@ func TestHealthyRecordMetric(t *testing.T) {
 func TestGslbReconciliationTotalIncrement(t *testing.T) {
 	// arrange
 	settings := provideSettings(t, predefinedConfig)
-	cnt := testutil.ToFloat64(metrics.Metrics().Get(metrics.K8gbGslbReconciliationLoopsTotal).AsCounter())
+	cnt := testutil.ToFloat64(metrics.Metrics().Get(metrics.K8gbGslbReconciliationLoopsTotal).AsCounterVec())
 	// act
 	_, err := settings.reconciler.Reconcile(context.TODO(), settings.request)
-	cnt2 := testutil.ToFloat64(metrics.Metrics().Get(metrics.K8gbGslbReconciliationLoopsTotal).AsCounter())
+	cnt2 := testutil.ToFloat64(metrics.Metrics().Get(metrics.K8gbGslbReconciliationLoopsTotal).AsCounterVec())
 	// assert
 	assert.NoError(t, err)
 	assert.Equal(t, cnt+1, cnt2)

--- a/controllers/providers/metrics/prometheus.go
+++ b/controllers/providers/metrics/prometheus.go
@@ -63,7 +63,7 @@ type collectors struct {
 	K8gbGslbStatusCountForRoundrobin  *prometheus.GaugeVec
 	K8gbGslbStatusCountForGeoip       *prometheus.GaugeVec
 	K8gbGslbErrorsTotal               *prometheus.CounterVec
-	K8gbGslbReconciliationLoopsTotal  prometheus.Counter
+	K8gbGslbReconciliationLoopsTotal  *prometheus.CounterVec
 	K8gbInfobloxZoneUpdatesTotal      *prometheus.CounterVec
 	K8gbInfobloxZoneUpdateErrorsTotal *prometheus.CounterVec
 	K8gbInfobloxHeartbeatsTotal       *prometheus.CounterVec
@@ -143,8 +143,8 @@ func (m *PrometheusMetrics) IncrementError(gslb *k8gbv1beta1.Gslb) {
 	m.metrics.K8gbGslbErrorsTotal.With(prometheus.Labels{"namespace": gslb.Namespace, "name": gslb.Name}).Inc()
 }
 
-func (m *PrometheusMetrics) IncrementReconciliation() {
-	m.metrics.K8gbGslbReconciliationLoopsTotal.Inc()
+func (m *PrometheusMetrics) IncrementReconciliation(gslb *k8gbv1beta1.Gslb) {
+	m.metrics.K8gbGslbReconciliationLoopsTotal.With(prometheus.Labels{"namespace": gslb.Namespace, "name": gslb.Name}).Inc()
 }
 
 func (m *PrometheusMetrics) InfobloxIncrementZoneUpdate(gslb *k8gbv1beta1.Gslb) {
@@ -242,11 +242,13 @@ func (m *PrometheusMetrics) init() {
 		[]string{"namespace", "name"},
 	)
 
-	m.metrics.K8gbGslbReconciliationLoopsTotal = prometheus.NewCounter(
+	m.metrics.K8gbGslbReconciliationLoopsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: K8gbGslbReconciliationLoopsTotal,
 			Help: "Number of successful reconciliation loops.",
-		})
+		},
+		[]string{"namespace", "name"},
+	)
 
 	m.metrics.K8gbGslbStatusCountForFailover = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/controllers/providers/metrics/prometheus_result.go
+++ b/controllers/providers/metrics/prometheus_result.go
@@ -38,7 +38,3 @@ func (c *MetricResult) AsGaugeVec() *prometheus.GaugeVec {
 func (c *MetricResult) AsCounterVec() *prometheus.CounterVec {
 	return c.value.(*prometheus.CounterVec)
 }
-
-func (c *MetricResult) AsCounter() prometheus.Counter {
-	return c.value.(prometheus.Counter)
-}

--- a/controllers/providers/metrics/prometheus_test.go
+++ b/controllers/providers/metrics/prometheus_test.go
@@ -102,11 +102,11 @@ func TestMetricsRegister(t *testing.T) {
 func TestReconciliationTotal(t *testing.T) {
 	// arrange
 	m := newPrometheusMetrics(defaultConfig)
-	cnt1 := testutil.ToFloat64(m.Get(K8gbGslbReconciliationLoopsTotal).AsCounter())
+	cnt1 := testutil.ToFloat64(m.Get(K8gbGslbReconciliationLoopsTotal).AsCounterVec().With(prometheus.Labels{"namespace": namespace, "name": gslbName}))
 	// act
-	m.IncrementReconciliation()
+	m.IncrementReconciliation(defaultGslb)
 	// assert
-	cnt2 := testutil.ToFloat64(m.Get(K8gbGslbReconciliationLoopsTotal).AsCounter())
+	cnt2 := testutil.ToFloat64(m.Get(K8gbGslbReconciliationLoopsTotal).AsCounterVec().With(prometheus.Labels{"namespace": namespace, "name": gslbName}))
 	assert.Equal(t, cnt1+1.0, cnt2)
 }
 


### PR DESCRIPTION
related to #587

`k8gb_gslb_reconciliation_loops_total` was called per k8gb controller. I decided to change this and count the number of successful reconciliations per GSLB
 - k8gb_gslb_reconciliation_loops_total becomes to be CounterVec instead of Counter


Signed-off-by: kuritka <kuritka@gmail.com>