### PR TITLE
Replace Infoblox.Override.FakeInfobloxEnabled by func IsFakeInfoblox() bool

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -103,10 +103,8 @@ type Infoblox struct {
 	HTTPPoolConnections int
 }
 
-// Override configuration
-type Override struct {
-	// FakeInfobloxEnabled if true than Infoblox connection FQDN=`fakezone.example.com`; default = false
-	FakeInfobloxEnabled bool
+func (i Infoblox) IsFakeInfobloxEnabled() bool {
+	return i.Host == "127.0.0.1" || i.Host == "localhost"
 }
 
 // Config is operator configuration returned by depResolver
@@ -131,8 +129,6 @@ type Config struct {
 	K8gbNamespace string
 	// Infoblox configuration
 	Infoblox Infoblox
-	// Override the behavior of GSLB in the test environments
-	Override Override
 	// CoreDNSExposed flag
 	CoreDNSExposed bool
 	// Log configuration

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -45,7 +45,6 @@ const (
 	InfobloxPasswordKey            = "EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD"
 	InfobloxHTTPRequestTimeoutKey  = "INFOBLOX_HTTP_REQUEST_TIMEOUT"
 	InfobloxHTTPPoolConnectionsKey = "INFOBLOX_HTTP_POOL_CONNECTIONS"
-	OverrideFakeInfobloxKey        = "FAKE_INFOBLOX"
 	K8gbNamespaceKey               = "POD_NAMESPACE"
 	CoreDNSExposedKey              = "COREDNS_EXPOSED"
 	LogLevelKey                    = "LOG_LEVEL"
@@ -79,7 +78,6 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 		dr.config.Infoblox.Password = env.GetEnvAsStringOrFallback(InfobloxPasswordKey, "")
 		dr.config.Infoblox.HTTPPoolConnections, _ = env.GetEnvAsIntOrFallback(InfobloxHTTPPoolConnectionsKey, 10)
 		dr.config.Infoblox.HTTPRequestTimeout, _ = env.GetEnvAsIntOrFallback(InfobloxHTTPRequestTimeoutKey, 20)
-		dr.config.Override.FakeInfobloxEnabled = env.GetEnvAsBoolOrFallback(OverrideFakeInfobloxKey, false)
 		dr.config.Log.Level, _ = zerolog.ParseLevel(strings.ToLower(env.GetEnvAsStringOrFallback(LogLevelKey, zerolog.InfoLevel.String())))
 		dr.config.Log.Format = parseLogOutputFormat(strings.ToLower(env.GetEnvAsStringOrFallback(LogFormatKey, SimpleFormat.String())))
 		dr.config.Log.NoColor = env.GetEnvAsBoolOrFallback(LogNoColorKey, false)

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -87,9 +87,6 @@ var predefinedConfig = depresolver.Config{
 		HTTPPoolConnections: 20,
 		HTTPRequestTimeout:  10,
 	},
-	Override: depresolver.Override{
-		FakeInfobloxEnabled: true,
-	},
 	Log: depresolver.Log{
 		Format: depresolver.SimpleFormat,
 	},

--- a/controllers/providers/dns/infoblox-ibclient.go
+++ b/controllers/providers/dns/infoblox-ibclient.go
@@ -38,7 +38,7 @@ func (p *InfobloxProvider) infobloxConnection() (*ibclient.ObjectManager, error)
 
 	var objMgr *ibclient.ObjectManager
 
-	if p.config.Override.FakeInfobloxEnabled {
+	if p.config.Infoblox.IsFakeInfobloxEnabled() {
 		fqdn := "fakezone.example.com"
 		fakeRefReturn := "zone_delegated/ZG5zLnpvbmUkLl9kZWZhdWx0LnphLmNvLmFic2EuY2Fhcy5vaG15Z2xiLmdzbGJpYmNsaWVudA:fakezone.example.com/default"
 		k8gbFakeConnector := &fakeInfobloxConnector{

--- a/controllers/providers/dns/infoblox_test.go
+++ b/controllers/providers/dns/infoblox_test.go
@@ -42,9 +42,6 @@ var predefinedConfig = depresolver.Config{
 		Port:     443,
 		Version:  "0.0.0",
 	},
-	Override: depresolver.Override{
-		FakeInfobloxEnabled: true,
-	},
 }
 
 func TestCanFilterOutDelegatedZoneEntryAccordingFQDNProvided(t *testing.T) {


### PR DESCRIPTION
I'd like to test the dns package more - currentlhy 20.4% coverage (of which infoblox is a part), and I'll use mock instead of FakeInfoblox class.

At the moment no test hits the fakeInfoblox section (https://github.com/k8gb-io/k8gb/blob/master/controllers/providers/dns/infoblox-ibclient.go#L41-L49).
To enter this section we use envar `FAKE_INFOBLOX` - in my opinion unnecessary. Entering the section (which is not technically used) is the only reason why we keep this variable.

I created a temporary function on Infoblox{}.IsFakeInfobloxEnabled() that says it is a fake infobox, instead of using a special variable in config.
 ATM I can't say on 100% but probably delete IsFakeInfobloxEnabled() completely in a following commit when I inject IBRConnection mock in controller tests instead.

Signed-off-by: kuritka <kuritka@gmail.com>