### PR TITLE
Fix #631: helm - remove new lines from resulting yaml when using conditionals

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -1,4 +1,4 @@
-{{ if or .Values.ns1.enabled .Values.route53.enabled }}
+{{- if or .Values.ns1.enabled .Values.route53.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,4 +54,4 @@ spec:
             cpu: "500m"
         securityContext:
           readOnlyRootFilesystem: true
-{{ end }}
+{{- end }}

--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -29,7 +29,7 @@ kind: ServiceAccount
 metadata:
   name: k8gb-external-dns
   namespace: {{ .Release.Namespace }}
-{{ if and .Values.route53.enabled .Values.route53.irsaRole }}
+{{- if and .Values.route53.enabled .Values.route53.irsaRole }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.route53.irsaRole }}
-{{ end }}
+{{- end }}

--- a/chart/k8gb/templates/infoblox-cm.yaml
+++ b/chart/k8gb/templates/infoblox-cm.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.infoblox.enabled }}
+{{- if .Values.infoblox.enabled }}
 apiVersion: v1
 data:
   INFOBLOX_GRID_HOST: {{ quote .Values.infoblox.gridHost }}
@@ -9,4 +9,4 @@ data:
 kind: ConfigMap
 metadata:
   name: infoblox
-{{ end }}
+{{- end }}

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -15,14 +15,14 @@ spec:
       labels:
         name: k8gb
     spec:
-      {{ if .Values.k8gb.hostAlias.enabled }}
+      {{- if .Values.k8gb.hostAlias.enabled }}
       hostAliases:
         - ip: "{{ .Values.k8gb.hostAlias.ip }}"
           hostnames:
             {{- range.Values.k8gb.hostAlias.hostnames }}
             - {{ . }}
             {{- end }}
-      {{ end }}
+      {{- end }}
       serviceAccountName: k8gb
       containers:
         - name: k8gb
@@ -67,7 +67,7 @@ spec:
               value: {{ .Values.k8gb.dnsZone }}
             - name: RECONCILE_REQUEUE_SECONDS
               value: {{ quote .Values.k8gb.reconcileRequeueSeconds}}
-            {{ if .Values.infoblox.enabled }}
+            {{- if .Values.infoblox.enabled }}
             - name: INFOBLOX_GRID_HOST
               valueFrom:
                 configMapKeyRef:
@@ -103,19 +103,19 @@ spec:
                 secretKeyRef:
                   name: infoblox
                   key: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
-            {{ end }}
-            {{ if .Values.route53.enabled }}
+            {{- end }}
+            {{- if .Values.route53.enabled }}
             - name: ROUTE53_ENABLED
               value: "true"
-            {{ end }}
-            {{ if .Values.ns1.enabled }}
+            {{- end }}
+            {{- if .Values.ns1.enabled }}
             - name: NS1_ENABLED
               value: "true"
-            {{ end }}
-            {{ if eq "LoadBalancer" ( quote .Values.coredns.serviceType ) }}
+            {{- end }}
+            {{- if eq "LoadBalancer" ( quote .Values.coredns.serviceType ) }}
             - name: COREDNS_EXPOSED
               value: "true"
-            {{ end }}
+            {{- end }}
             - name: LOG_FORMAT
               value: {{ quote .Values.k8gb.log.format }}
             - name: LOG_LEVEL

--- a/chart/k8gb/templates/role.yaml
+++ b/chart/k8gb/templates/role.yaml
@@ -38,7 +38,7 @@ rules:
   - namespaces
   verbs:
   - 'list'
-{{ if .Values.openshift.enabled }}
+{{- if .Values.openshift.enabled }}
 - apiGroups:
   - route.openshift.io
   resources:
@@ -46,4 +46,4 @@ rules:
   verbs:
   - create
   - update
-{{ end }}
+{{- end }}


### PR DESCRIPTION
As described in [here](https://helm.sh/docs/chart_template_guide/control_structures/#controlling-whitespace), by adding the dash right after the double curly braces it will chomp whitespaces on the left (including new lines) so this should fix the unnecessary new lines in the rendered yamls (if the things are not enabled)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>