### PR TITLE
Make securityContext of the deployment fully configurable

### DIFF
--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -28,11 +28,10 @@ spec:
         - name: k8gb
           image: {{ .Values.k8gb.imageRepo }}:{{ .Values.k8gb.imageTag | default .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
+          {{- if .Values.k8gb.securityContext }}
           securityContext:
-            runAsUser: {{ .Values.k8gb.runAsUser }}
-            runAsNonRoot: true
-            readOnlyRootFilesystem: true
-            allowPrivilegeEscalation: false
+            {{- toYaml .Values.k8gb.securityContext | nindent 12 }}
+          {{- end }}
           resources:
             requests:
               memory: "32Mi"

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -29,12 +29,16 @@ k8gb:
     level: info # log level (panic,fatal,error,warn,info,debug,trace)
   splitBrainCheck: false
   metricsAddress: "0.0.0.0:8080"
-  runAsUser: 1000
+  securityContext: # For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#securitycontext-v1-core
+    runAsNonRoot: true
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    runAsUser: 1000
 
 externaldns:
   image: k8s.gcr.io/external-dns/external-dns:v0.9.0
   interval: "20s"
-  securityContext:
+  securityContext: # For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#securitycontext-v1-core
     fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files
     runAsUser: 1000
     runAsNonRoot: true


### PR DESCRIPTION
context: aligning the logic w/ the coredns helm chart (upstream [version](https://github.com/coredns/helm/blob/70519f776a9175db2b429b7b39625262c273180d/charts/coredns/templates/deployment.yaml#L130:L132)), this will allow for more flexibility on platforms like OpenShift (changing fsGroup, selinux, seccomp profile and what not)

btw. if one wants to remove the `runAsUser: 1000` (which is set by default) from the resulting yamls, they can set the value explicitly to `null`

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>