### PR TITLE
Remove FAKE_INFOBLOX (2/3)

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -104,12 +104,6 @@ type Infoblox struct {
 	HTTPPoolConnections int
 }
 
-// Override configuration
-type Override struct {
-	// FakeInfobloxEnabled if true than Infoblox connection FQDN=`fakezone.example.com`; default = false
-	FakeInfobloxEnabled bool
-}
-
 // Config is operator configuration returned by depResolver
 type Config struct {
 	// Reschedule of Reconcile loop to pickup external Gslb targets
@@ -130,8 +124,6 @@ type Config struct {
 	K8gbNamespace string
 	// Infoblox configuration
 	Infoblox Infoblox
-	// Override the behavior of GSLB in the test environments
-	Override Override
 	// CoreDNSExposed flag
 	CoreDNSExposed bool
 	// Log configuration

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -47,7 +47,6 @@ const (
 	InfobloxPasswordKey            = "EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD"
 	InfobloxHTTPRequestTimeoutKey  = "INFOBLOX_HTTP_REQUEST_TIMEOUT"
 	InfobloxHTTPPoolConnectionsKey = "INFOBLOX_HTTP_POOL_CONNECTIONS"
-	OverrideFakeInfobloxKey        = "FAKE_INFOBLOX"
 	K8gbNamespaceKey               = "POD_NAMESPACE"
 	CoreDNSExposedKey              = "COREDNS_EXPOSED"
 	LogLevelKey                    = "LOG_LEVEL"
@@ -91,7 +90,6 @@ func (dr *DependencyResolver) ResolveOperatorConfig() (*Config, error) {
 		dr.config.Infoblox.Password = env.GetEnvAsStringOrFallback(InfobloxPasswordKey, "")
 		dr.config.Infoblox.HTTPPoolConnections, _ = env.GetEnvAsIntOrFallback(InfobloxHTTPPoolConnectionsKey, 10)
 		dr.config.Infoblox.HTTPRequestTimeout, _ = env.GetEnvAsIntOrFallback(InfobloxHTTPRequestTimeoutKey, 20)
-		dr.config.Override.FakeInfobloxEnabled = env.GetEnvAsBoolOrFallback(OverrideFakeInfobloxKey, false)
 		dr.config.Log.Level, _ = zerolog.ParseLevel(strings.ToLower(env.GetEnvAsStringOrFallback(LogLevelKey, zerolog.InfoLevel.String())))
 		dr.config.Log.Format = parseLogOutputFormat(strings.ToLower(env.GetEnvAsStringOrFallback(LogFormatKey, SimpleFormat.String())))
 		dr.config.Log.NoColor = env.GetEnvAsBoolOrFallback(LogNoColorKey, false)

--- a/controllers/depresolver/depresolver_test.go
+++ b/controllers/depresolver/depresolver_test.go
@@ -78,9 +78,6 @@ var predefinedConfig = Config{
 		21,
 		11,
 	},
-	Override: Override{
-		false,
-	},
 	Log: Log{
 		Format: SimpleFormat,
 	},
@@ -1323,63 +1320,6 @@ func TestNegativeInfobloxHTTPRequestTimeout(t *testing.T) {
 
 }
 
-func TestResolveConfigEnableFakeDNSAsTrue(t *testing.T) {
-	// arrange
-	defer cleanup()
-	expected := predefinedConfig
-	expected.Override.FakeInfobloxEnabled = true
-	// act,assert
-	arrangeVariablesAndAssert(t, expected, assert.NoError)
-}
-
-func TestResolveConfigEnableFakeDNSAsFalse(t *testing.T) {
-	// arrange
-	defer cleanup()
-	expected := predefinedConfig
-	expected.Override.FakeInfobloxEnabled = false
-	// act,assert
-	arrangeVariablesAndAssert(t, expected, assert.NoError)
-}
-
-func TestResolveConfigEnableFakeInfobloxAsTrue(t *testing.T) {
-	// arrange
-	defer cleanup()
-	expected := predefinedConfig
-	expected.Override.FakeInfobloxEnabled = true
-	// act,assert
-	arrangeVariablesAndAssert(t, expected, assert.NoError)
-}
-
-func TestResolveConfigEnableFakeInfobloxAsFalse(t *testing.T) {
-	// arrange
-	defer cleanup()
-	expected := predefinedConfig
-	expected.Override.FakeInfobloxEnabled = false
-	// act,assert
-	arrangeVariablesAndAssert(t, expected, assert.NoError)
-
-}
-
-func TestResolveConfigEnableFakeInfobloxAsInvalidValue(t *testing.T) {
-	// arrange
-	defer cleanup()
-	configureEnvVar(predefinedConfig)
-	_ = os.Setenv(OverrideFakeInfobloxKey, "i.am.wrong??.")
-	resolver := NewDependencyResolver()
-	// act
-	config, err := resolver.ResolveOperatorConfig()
-	// assert
-	assert.NoError(t, err)
-	assert.Equal(t, false, config.Override.FakeInfobloxEnabled)
-}
-
-func TestResolveConfigEnableFakeInfobloxAsUnsetEnvironmentVariable(t *testing.T) {
-	// arrange
-	defer cleanup()
-	// act,assert
-	arrangeVariablesAndAssert(t, predefinedConfig, assert.NoError, OverrideFakeInfobloxKey)
-}
-
 func TestResolveLoggerUseDefaultValue(t *testing.T) {
 	// arrange
 	// Build zerolog from empty string which is equal to zerolog.NoLevel.
@@ -1894,7 +1834,7 @@ func arrangeVariablesAndAssert(t *testing.T, expected Config,
 func cleanup() {
 	for _, s := range []string{ReconcileRequeueSecondsKey, ClusterGeoTagKey, ExtClustersGeoTagsKey, EdgeDNSZoneKey, DNSZoneKey, EdgeDNSServersKey,
 		Route53EnabledKey, NS1EnabledKey, InfobloxGridHostKey, InfobloxVersionKey, InfobloxPortKey, InfobloxUsernameKey,
-		InfobloxPasswordKey, OverrideFakeInfobloxKey, K8gbNamespaceKey, CoreDNSExposedKey, InfobloxHTTPRequestTimeoutKey,
+		InfobloxPasswordKey, K8gbNamespaceKey, CoreDNSExposedKey, InfobloxHTTPRequestTimeoutKey,
 		InfobloxHTTPPoolConnectionsKey, LogLevelKey, LogFormatKey, LogNoColorKey, MetricsAddressKey, SplitBrainCheckKey} {
 		if os.Unsetenv(s) != nil {
 			panic(fmt.Errorf("cleanup %s", s))
@@ -1920,7 +1860,6 @@ func configureEnvVar(config Config) {
 	_ = os.Setenv(InfobloxPasswordKey, config.Infoblox.Password)
 	_ = os.Setenv(InfobloxHTTPRequestTimeoutKey, strconv.Itoa(config.Infoblox.HTTPRequestTimeout))
 	_ = os.Setenv(InfobloxHTTPPoolConnectionsKey, strconv.Itoa(config.Infoblox.HTTPPoolConnections))
-	_ = os.Setenv(OverrideFakeInfobloxKey, strconv.FormatBool(config.Override.FakeInfobloxEnabled))
 	_ = os.Setenv(LogLevelKey, config.Log.Level.String())
 	_ = os.Setenv(LogFormatKey, config.Log.Format.String())
 	_ = os.Setenv(LogNoColorKey, strconv.FormatBool(config.Log.NoColor))

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -91,9 +91,6 @@ var predefinedConfig = depresolver.Config{
 		HTTPPoolConnections: 20,
 		HTTPRequestTimeout:  10,
 	},
-	Override: depresolver.Override{
-		FakeInfobloxEnabled: true,
-	},
 	Log: depresolver.Log{
 		Format: depresolver.SimpleFormat,
 	},

--- a/controllers/providers/dns/infoblox_test.go
+++ b/controllers/providers/dns/infoblox_test.go
@@ -52,9 +52,6 @@ var predefinedConfig = depresolver.Config{
 		Port:     443,
 		Version:  "0.0.0",
 	},
-	Override: depresolver.Override{
-		FakeInfobloxEnabled: true,
-	},
 }
 
 func TestCanFilterOutDelegatedZoneEntryAccordingFQDNProvided(t *testing.T) {


### PR DESCRIPTION
This is a follow-up PR to #630 (1/3), do not review until #630 is merged.

Everything is now being mocked up, there is no need to distinguish between local and production infoblox.
Bool switch no longer makes sense, removing

Signed-off-by: kuritka <kuritka@gmail.com>
