### PR TITLE
Add parameter denoting how long to wait for k8gbcurl.sh demo script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ EDGE_DNS_ZONE ?= example.com
 DNS_ZONE ?= cloud.example.com
 DEMO_URL ?= http://failover.cloud.example.com
 DEMO_DEBUG ?=0
+DEMO_DELAY ?=5
 
 ifndef NO_COLOR
 YELLOW=\033[0;33m
@@ -454,7 +455,7 @@ define testapp-set-replicas
 endef
 
 define demo-host
-	kubectl run -it --rm k8gb-demo --restart=Never --image=absaoss/k8gb-demo-curl --env="DEBUG=$(DEMO_DEBUG)" \
+	kubectl run -it --rm k8gb-demo --restart=Never --image=absaoss/k8gb-demo-curl --env="DELAY=$(DEMO_DELAY)" --env="DEBUG=$(DEMO_DEBUG)" \
 	"`$(K8GB_COREDNS_IP)`" $1
 endef
 

--- a/deploy/test-apps/curldemo/k8gbcurl.sh
+++ b/deploy/test-apps/curldemo/k8gbcurl.sh
@@ -4,6 +4,11 @@
 # $1 - nameserver to use usually k8gb-coredns service ip
 # $2 - test fqdn to resolve in demo loops
 
+# checks
+[[ $# != 2 ]] && echo "Usage: $0 <nameserver> <url>" && exit 1
+
+DELAY="${DELAY:-5}"
+
 if [ "$DEBUG" == 1 ]
 then
    set -x
@@ -18,7 +23,7 @@ url="$2"
 
 while true
 do
-  curl -k -s -w "%{stderr}\n%{http_code}\n" --location --request GET "${url}" |grep message
-  sleep 5
+  curl -k -s -w "%{stderr}\n%{http_code}\n" --location --request GET "${url}" | grep message
+  sleep ${DELAY}
   echo "[`date`] ..."
 done


### PR DESCRIPTION
Setting optionally the frequency, how ofter the curl is called. By default it's a no-op and it's called each 5 sec, but one can do

```bash
DEMO_DELAY=.5 make demo
```
to set that to, say, 500ms

note: the image `absaoss/k8gb-demo-curl` on dockerhub would need to be also updated to pick this change

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>