### PR TITLE
Bump coredns with plugin to v0.0.7

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -50,7 +50,7 @@ coredns:
     skipConfig: true
   image:
     repository: absaoss/k8s_crd
-    tag: "v0.0.6"
+    tag: "v0.0.7"
   serviceAccount:
     create: true
     name: coredns


### PR DESCRIPTION
This PR bumps the version of coredns-crd-plugin dependency to v0.0.7 in order to address security vulnerabilities:
https://artifacthub.io/packages/helm/k8gb/k8gb?modal=security-report
https://github.com/k8gb-io/coredns-crd-plugin/pull/19
Signed-off-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>