### PR TITLE
Expose grafana as NodePort service and open it on k3d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,14 +202,17 @@ deploy-grafana:
 	@echo "\n$(YELLOW)Local cluster $(CYAN)$(CLUSTER_GSLB1)$(NC)"
 	@echo "\n$(YELLOW)install grafana $(NC)"
 	@$(eval PREVIOUS_CONTEXT := $(shell kubectl config current-context))
-	kubectl config use-context k3d-$(CLUSTER_GSLB1)
-	kubectl apply -f deploy/grafana/dashboard-cm.yaml
-	@kubectl config use-context $(PREVIOUS_CONTEXT)
 	helm repo add grafana https://grafana.github.io/helm-charts
 	helm repo update
 	helm -n k8gb upgrade -i grafana grafana/grafana -f deploy/grafana/values.yaml \
 		--wait --timeout=2m0s \
 		--kube-context=k3d-$(CLUSTER_GSLB1)
+	kubectl config use-context k3d-$(CLUSTER_GSLB1)
+	kubectl apply -f deploy/grafana/dashboard-cm.yaml -n k8gb
+	@kubectl config use-context $(PREVIOUS_CONTEXT)
+	@echo "\nGrafana is listening on http://localhost:3000\n"
+	@echo "🖖 credentials are admin:admin\n"
+
 
 .PHONY: uninstall-grafana
 uninstall-grafana:

--- a/deploy/grafana/values.yaml
+++ b/deploy/grafana/values.yaml
@@ -1,3 +1,10 @@
+adminUser: admin
+adminPassword: admin # don't use in production (1st login to web ui will ask for the password change)
+service:
+  nodePort: 30030 # allowed port range between 30000 and 32768
+  targetPort: 3000
+  port: 3000
+  type: NodePort
 sidecar:
   dashboards:
     enabled: true

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -11,6 +11,9 @@ ports:
 - port: 443:443
   nodeFilters:
   - agent[0]
+- port: 3000:30030
+  nodeFilters:
+    - agent[0]
 - port: 8080:30090
   nodeFilters:
     - agent[0]


### PR DESCRIPTION
In order to improve the ux for Grafana, this PR exposes the grafana service as NodePort (`30030` -> pod's `3000`) and then on the k3d side we open port `3000 -> 30030` (similarly as for Prometheus, b/c there is a restriction that  `30k < nodeport < ~32k`).
Also changing the order in makefile: 1st deploy the grafana w/ the side-car that watches the configmaps and only then create the configmap (now w/ explicitly set namespace), because sometimes I hit a case when it wasn't picked up correctly

result: no need to run the `kubectl port-forward` and also setting the credentials to `admin:admin`, the web ui will ask to change it (before the change one had to run `kubectl get secret --namespace k8gb grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo`)

cc @kuritka this is the follow-up we were talking about, I didn't want to complicate the previous PR w/ it

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>