### PR TITLE
Don't install extdns rbac by default

### DIFF
--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if or .Values.ns1.enabled .Values.route53.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -10,7 +11,9 @@ rules:
 - apiGroups: ["externaldns.k8s.io"]
   resources: ["dnsendpoints/status"]
   verbs: ["*"]
+{{- end }}
 ---
+{{- if or .Values.ns1.enabled .Values.route53.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -23,7 +26,9 @@ subjects:
 - kind: ServiceAccount
   name: k8gb-external-dns
   namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
+{{- if or .Values.ns1.enabled .Values.route53.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -32,4 +37,5 @@ metadata:
 {{- if and .Values.route53.enabled .Values.route53.irsaRole }}
   annotations:
     eks.amazonaws.com/role-arn: {{ .Values.route53.irsaRole }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
external-dns rbac is not protected by ns1, r53 option enablement.
This leads to external-dns rbac installed eitherway. This commit fixes
it.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>