### PR TITLE
Add target to gh-pages' makefile for building the site in netlify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,9 @@ else
 	@echo "Local generation requires a GitHub PAT token with the 'public_repo' scope (https://github.com/settings/tokens/new)."
 	@echo "The token should be assigned to the JEKYLL_GITHUB_TOKEN environment variable."
 endif
+
+# Used from Netflify context
+.PHONY: netlify-build
+netlify-build:
+	git checkout - {README,CONTRIBUTING,CHANGELOG}.md docs/ && \
+	mv CNAME EMANC && bundle install && bundle exec jekyll build


### PR DESCRIPTION
New target that will be triggered by netlify to build the website
note: `CNAME` file needs to be deleted/renamed because the preview is not exposed under k8gb.io domain

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>