### PR TITLE
Add automatic deployment preview of PRs when changing the site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "git config remote.origin.url || git remote add -f -t gh-pages origin https://github.com/k8gb-io/k8gb && git fetch origin gh-pages:gh-pages && git checkout gh-pages && make netlify-build"
+  publish = "_site/"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- {README,CONTRIBUTING,CHANGELOG}.md docs/"
+
+[context.deploy-preview]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- {README,CONTRIBUTING,CHANGELOG}.md docs/"


### PR DESCRIPTION
This PR should go in only after #657 

Add config for netlify that will trigger the build and deploys the preview of pull-request.

Such PR needs to be opened against master and some of the following files need to be changed: `{README,CONTRIBUTING,CHANGELOG}.md docs/`

**Example:**
- this is example PR on my fork w/ a change that doesn't contain the web page related change: https://github.com/jkremser/k8gb/pull/8

- and this is an example PR w/ web related change: https://github.com/jkremser/k8gb/pull/9

**Some limitations:**
- It's a one shot thing so even if new commits go to the PR or if the pr is closed and opened it wont re-trigger the build.

- We have 300mins of free build time each month and I've used 20 during the development (1 build is like a 1 or 2 minutes) it should be more than enough

Also the website required GH token to be able to fill some metadata about the repo - `JEKYLL_GITHUB_TOKEN`. Fortunately, it uses the thing only in read only mode probably to prevent the rate limiter blocks. I've set this token in the Netlify web and used one that doesn't have write access to this repo w/ the minimal privileges. It's a token from my wife actually who has access to 1 private repo w/ her web site :D So even if it leaks, no biggie.

If it works well, some future improvement could be running this thing also if the PR is opened against `gh-pages` (change to layouts, CSS, etc.)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>