### PR TITLE
Add automatic deployment preview of PRs when changing the site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -376,6 +376,18 @@ test-failover:
 terratest: # Run terratest suite
 	cd terratest/test/ && go mod download && go test -v -timeout 15m -parallel=12
 
+.PHONY: website
+website:
+	@if [ "$(CI)" = "true" ]; then\
+		git config remote.origin.url || git remote add -f -t gh-pages origin https://github.com/k8gb-io/k8gb ;\
+		git fetch origin gh-pages:gh-pages ;\
+		git checkout gh-pages ;\
+		git checkout - {README,CONTRIBUTING,CHANGELOG}.md docs/ ;\
+		mv CNAME EMANC ;\
+		bundle install ;\
+		bundle exec jekyll build ;\
+	fi
+
 .PHONY: version
 version:
 	@echo $(VERSION)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  command = "make website"
+  publish = "_site/"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- {README,CONTRIBUTING,CHANGELOG}.md docs/"
+
+[context.deploy-preview]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF -- {README,CONTRIBUTING,CHANGELOG}.md docs/"


### PR DESCRIPTION
This is basically https://github.com/k8gb-io/k8gb/pull/657 + https://github.com/k8gb-io/k8gb/pull/658 combined to just one (no need to have a makefile target on the gh-pages branch if it's done in the bash script)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>