### PR TITLE
Fix ldflags argument for goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - -s -w -X main.version={{ .Tag }} main.commit={{ .Commit }}
+      - -s -w -X main.version={{ .Tag }} -X main.commit={{ .Commit }}
 dockers:
 - image_templates:
   - "absaoss/k8gb:{{ .Tag }}-amd64"


### PR DESCRIPTION
each env var needs to be prepended by -X as described [here](https://github.com/goreleaser/goreleaser/blob/master/www/docs/customization/build.md?plain=1#L56)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>