### PR TITLE
web-preview: list the files to checkout w/o using the {foo,bar}.md syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,7 @@ website:
 		git config remote.origin.url || git remote add -f -t gh-pages origin https://github.com/k8gb-io/k8gb ;\
 		git fetch origin gh-pages:gh-pages ;\
 		git checkout gh-pages ;\
-		git checkout - {README,CONTRIBUTING,CHANGELOG}.md docs/ ;\
+		git checkout - README.md CONTRIBUTING.md CHANGELOG.md docs/ ;\
 		mv CNAME EMANC ;\
 		bundle install ;\
 		bundle exec jekyll build ;\


### PR DESCRIPTION
The previous syntax (even though working on my Mac) was failing when running from Makefile @Ubuntu 16.04: https://app.netlify.com/sites/k8gb-preview/deploys/616e9b377bb07d00073b2224#L70

This should fix it, I've tried it on my fork: https://github.com/jkremser/k8gb/pull/12