### PR TITLE
Add icon URL to k8gb helm chart

### DIFF
--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: k8gb
 description: A Helm chart for Kubernetes Global Balancer
+icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/k8gb/icon/color/k8gb-icon-color.svg
 type: application
 version: v0.8.3
 appVersion: v0.8.3


### PR DESCRIPTION
This PR adds an official icon URL to the k8gb helm chart for improved visibility in artifact hubs and app catalogs.

Signed-off-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>