### PR TITLE
Set onlyLastTag to true to prevent rate limiting issues w/ gh api

### DIFF
--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -16,14 +16,22 @@ jobs:
         with:
           token: ${{ secrets.CR_TOKEN }}
           project: k8gb
+          output: CHANGELOG-latest.md
           pullRequests: true
           author: true
           issues: true
           issuesWoLabels: true
           prWoLabels: true
+          onlyLastTag: true
           compareLink: true
           filterByMilestone: true
-          unreleased: true
+          unreleased: false
+      - name: Prepend the latest changes to CHANGELOG.md
+        run: |
+          mv CHANGELOG.md CHANGELOG-old.md
+          cat CHANGELOG-latest.md | sed -e'$d' > CHANGELOG.md
+          cat CHANGELOG-old.md | sed -e'1,4d' >> CHANGELOG.md
+          rm CHANGELOG-old.md CHANGELOG-latest.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
if the flag is true, it should translate to this logic: https://github.com/heinrichreimer/action-github-changelog-generator/blob/master/entrypoint.sh#L27

when evaluated that command locally it returned correctly the previous tag, so this should work 🤞 

What may go wrong is the previous gh checkout action not fetching all the tags, but `fetch-depth: 0` (as it is) [should](https://github.com/actions/checkout/blob/main/README.md?plain=1#L92) fetch everything, I am mentioning it in here so that we are aware that it may break if someone change that number to say `1`

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>