### PR TITLE
Use k8gb.io png icon asset as helm chart icon

### DIFF
--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: k8gb
 description: A Helm chart for Kubernetes Global Balancer
-icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/k8gb/icon/color/k8gb-icon-color.svg
+icon: https://www.k8gb.io/assets/images/icon-192x192.png
 type: application
 version: v0.8.3
 appVersion: v0.8.3


### PR DESCRIPTION
This PR changes the helm chart icon to be the k8gb.io icon png asset, as discussed in #671 and #675.

NOTE: Should be merged after #680!
 
Signed-off-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>