### PR TITLE
Fix url and add maintainers to Chart.yaml

### DIFF
--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -13,7 +13,7 @@ dependencies:
 
 home: https://www.k8gb.io/
 sources:
-  - https://github.com/AbsaOSS/k8gb
+  - https://github.com/k8gb-io/k8gb
 
 keywords:
   - gslb
@@ -21,6 +21,18 @@ keywords:
   - kuberneters-global-balancer
   - kubernetes-operator
   - balancer
+
+maintainers:
+  - email: dinar.valeev@absa.africa
+    name: Dinar Valeev
+  - email: jiri.kremser@gmail.com
+    name: Jiri Kremser
+  - email: kuritka@gmail.com
+    name: Michal Kuritka
+  - email: timofey.ilinykh@absa.africa
+    name: Timofey Ilinykh
+  - email: yury.tsarev@absa.africa
+    name: Yury Tsarev
 
 annotations:
   artifacthub.io/operator: "true"


### PR DESCRIPTION
This separated from the https://github.com/k8gb-io/k8gb/pull/668 The info is reused by the olm-bundle tool to fill the metadata in (CSV) ClusterServiceCersion CR for OLM (Operator Lifecycle Manager)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>