### PR TITLE
.disable-logo selector

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -39,3 +39,8 @@ a.header-url:hover {
       height: $k8gb-logo-height / 2;
   }
 }
+
+.disable-logo {
+  display: none;
+}
+


### PR DESCRIPTION
This is one of two PRs should allow the large logo to be displayed on https://github.com/k8gb-io/k8gb while k8gb.io will display a different instance of the logo in its header.
The user will always see a single logo

This PR will disable logo in k8gb.io but is not applied in https://github.com/k8gb-io/k8gb where the logo will be shown

Signed-off-by: kuritka <kuritka@gmail.com>