### PR TITLE
refs #683: remove EXTERNAL_DNS_ from infoblox wapi username and password

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,8 +283,8 @@ init-round-robin:
 .PHONY: infoblox-secret
 infoblox-secret:
 	kubectl -n k8gb create secret generic infoblox \
-		--from-literal=EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME=$${WAPI_USERNAME} \
-		--from-literal=EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD=$${WAPI_PASSWORD}
+		--from-literal=INFOBLOX_WAPI_USERNAME=$${WAPI_USERNAME} \
+		--from-literal=INFOBLOX_WAPI_PASSWORD=$${WAPI_PASSWORD}
 
 # GoKart - Go Security Static Analysis
 # see: https://github.com/praetorian-inc/gokart

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -92,16 +92,16 @@ spec:
                 configMapKeyRef:
                   name: infoblox
                   key: INFOBLOX_HTTP_POOL_CONNECTIONS
-            - name: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
+            - name: INFOBLOX_WAPI_USERNAME
               valueFrom:
                 secretKeyRef:
                   name: infoblox
-                  key: EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME
-            - name: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
+                  key: INFOBLOX_WAPI_USERNAME
+            - name: INFOBLOX_WAPI_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: infoblox
-                  key: EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD
+                  key: INFOBLOX_WAPI_PASSWORD
             {{- end }}
             {{- if .Values.route53.enabled }}
             - name: ROUTE53_ENABLED

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -99,9 +99,9 @@ type Infoblox struct {
 	// Port
 	Port int `env:"INFOBLOX_WAPI_PORT, default=0"`
 	// Username
-	Username string `env:"EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME"`
+	Username string `env:"INFOBLOX_WAPI_USERNAME"`
 	// Password
-	Password string `env:"EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD"`
+	Password string `env:"INFOBLOX_WAPI_PASSWORD"`
 	// HTTPRequestTimeout seconds
 	HTTPRequestTimeout int `env:"INFOBLOX_HTTP_REQUEST_TIMEOUT, default=20"`
 	// HTTPPoolConnections seconds

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -43,9 +43,9 @@ const (
 	InfobloxGridHostKey        = "INFOBLOX_GRID_HOST"
 	InfobloxVersionKey         = "INFOBLOX_WAPI_VERSION"
 	InfobloxPortKey            = "INFOBLOX_WAPI_PORT"
-	InfobloxUsernameKey        = "EXTERNAL_DNS_INFOBLOX_WAPI_USERNAME"
+	InfobloxUsernameKey        = "INFOBLOX_WAPI_USERNAME"
 	// #nosec G101; ignore false positive gosec; see: https://securego.io/docs/rules/g101.html
-	InfobloxPasswordKey            = "EXTERNAL_DNS_INFOBLOX_WAPI_PASSWORD"
+	InfobloxPasswordKey            = "INFOBLOX_WAPI_PASSWORD"
 	InfobloxHTTPRequestTimeoutKey  = "INFOBLOX_HTTP_REQUEST_TIMEOUT"
 	InfobloxHTTPPoolConnectionsKey = "INFOBLOX_HTTP_POOL_CONNECTIONS"
 	K8gbNamespaceKey               = "POD_NAMESPACE"


### PR DESCRIPTION
Removed "EXTERNAL_DNS_" from infoblox wapi username and password in all occurences