### PR TITLE
Display anchor header only on hover for readability

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -45,7 +45,7 @@
     </header>
 
     <main id="content" class="main-content" role="main">
-      {% include anchor_headings.html html=content anchorBody="§" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
+      {% include anchor_headings.html html=content anchorBody="§" anchorClass="heading-anchor" anchorAttrs="aria-labelledby=\"%html_id%\"" headerAttrs="class=heading" %}
 
       <footer class="site-footer">
         <a href="https://www.cncf.io" target="_blank">

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -64,16 +64,11 @@ a.header-url:hover {
     display: none;
 }
 
-.anchor-heading {
+.heading-anchor {
     visibility: hidden;
 }
 
-.anchor-heading:hover,
-h1:hover > .anchor-heading,
-h2:hover > .anchor-heading,
-h3:hover > .anchor-heading,
-h4:hover > .anchor-heading,
-h5:hover > .anchor-heading,
-h6:hover > .anchor-heading {
+.heading-anchor:hover,
+.heading:hover > .heading-anchor {
     visibility: visible;
 }


### PR DESCRIPTION
This PR makes k8gb.io anchor headers visible only on hover to improve the documentation visibility.
Default display:
![image](https://user-images.githubusercontent.com/502695/138777917-ca8d6f28-a568-4d15-b84e-b9d5683f4ba7.png)

On hover (whole header):
![image](https://user-images.githubusercontent.com/502695/138777860-6f4b9038-034f-4229-a159-7c2f94252de7.png)


Signed-off-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>