### PR TITLE
Add a way to use non-released changes in repo for producing an olm bundle

### DIFF
--- a/olm/generate.sh
+++ b/olm/generate.sh
@@ -21,7 +21,14 @@ main() {
         OLM_BINARY="olm-bundle"
     fi
 
-    git checkout v${_VERSION}
+    # if master is set as version don't do the checkout and use the latest annotated tag (~release) as the
+    # desired version for the olm bundle
+    if [[ ${_VERSION} == "master" ]]; then
+        _VERSION=$(git describe --abbrev=0 --tags)
+        _VERSION=${_VERSION#"v"}
+    else
+        git checkout v${_VERSION}
+    fi
     generate
 }
 


### PR DESCRIPTION
This will allow for hot-fixing in case some files are missing/out-of-sync
with those inputs for the olm-bundle generation process:
1) Chart.yaml
2) helm chart itself
3) templates for the olm-bundle tool (stuff under `/olm/*`)

That's actually currently happening, the release `0.8.3` was done w/o the files necessary for the olm-bundle automation to be in place. The GHA is currently done in a way that it takes the latest released tag (if not provided explicitly) and checks out the repo into that state... but the files are not there so it fails.

This PR adds more flexibility. If the version is set to `master` it will not check out the release tag and use the current tip of the repo for the action.

note: the action is failing only because it's running against the latest release that doesn't have the needed files, if the next release is done, it would work also without this change, but again there would be no way to hot-fix a typo or anything without making a new release and only then be able to do the olm bundle.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>