### PR TITLE
typo: GH_TOKEN -> GITHUB_TOKEN

### DIFF
--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.upstreamRepo }}
           path: sandbox
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
       - name: Copy the generated manifests
@@ -59,7 +59,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           push-to-fork: k8gb-io/community-operators
           path: sandbox
           commit-message: OLM bundle for k8gb@${{ github.event.inputs.bundleVersion }}


### PR DESCRIPTION
I was testing the action on my fork, where the secret was called differently so I've missed this. 