### PR TITLE
Using non-default token for opening the PR

### DIFF
--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.upstreamRepo }}
           path: sandbox
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_OLM_TOKEN }}
           fetch-depth: 0
 
       - name: Copy the generated manifests
@@ -59,7 +59,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_OLM_TOKEN }}
           push-to-fork: k8gb-io/community-operators
           path: sandbox
           commit-message: OLM bundle for k8gb@${{ github.event.inputs.bundleVersion }}


### PR DESCRIPTION
The default one [doesn't have](https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/) the right  to open a PR from public fork and fails on [this](https://github.com/k8gb-io/k8gb/runs/4009370787?check_suite_focus=true#step:7:81).

The blog post says:
The rights for the default `GITHUB_TOKEN` can be fine tuned, but it also says:

> Pull requests from public forks are still considered a special case and will receive a read token regardless of these settings.


Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>