### PR TITLE
Set GO1.16.9 as default GO version for goreleaser

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16.9"
+
       - name: Build artifacts
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16.9"
+
       - name: Build artifacts
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
related to #697

Github virtual environment Ubuntu20.04 has [cached several Go tools](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#go).

GoReleaser doesn't accept `builds.gobinary` [parameter](https://goreleaser.com/customization/build/) and still uses default GO1.15.

In order to fixing dependabot alerts, I would like to bump the versions of some modules that are already [required to be compiled in GO 1.16](https://github.com/k8gb-io/k8gb/runs/4009137543?check_suite_focus=true#step:3:64).

I'm introducing [setup-go](https://github.com/actions/setup-go#setup-go) action which is switching GO to desired version.

Signed-off-by: kuritka <kuritka@gmail.com>