### PR TITLE
olm: Add missing annotations + typo in repository

### DIFF
--- a/olm/annotations.yaml.tmpl
+++ b/olm/annotations.yaml.tmpl
@@ -5,7 +5,14 @@ annotations:
     description: A cloud native Kubernetes Global Balancer
     namespace: placeholder
     operatorframework.io/suggested-namespace: k8gb
+    operators.operatorframework.io.bundle.mediatype.v1: registry+v1
+    operators.operatorframework.io.bundle.manifests.v1: manifests/
+    operators.operatorframework.io.bundle.metadata.v1: metadata/
+    operators.operatorframework.io.bundle.package.v1: k8gb
+    operators.operatorframework.io.bundle.channels.v1: alpha
     operators.operatorframework.io/builder: operator-sdk-v1.12.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    repository: https://github.com/k8gb/k8gb
+    operators.operatorframework.io.test.mediatype.v1: scorecard+v1
+    operators.operatorframework.io.test.config.v1: tests/scorecard/
+    repository: https://github.com/k8gb-io/k8gb
     support: cncf-k8gb-maintainers@lists.cncf.io


### PR DESCRIPTION
Fix https://github.com/k8s-operatorhub/community-operators/runs/4011228290?check_suite_focus=true#step:5:427 that's failing on this [PR](https://github.com/k8s-operatorhub/community-operators/pull/356)

Also the `k8gb/k8gb -> k8gb-io/k8gb` typo


Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>