### PR TITLE
Drop socrecard OLM annotation

### DIFF
--- a/olm/annotations.yaml.tmpl
+++ b/olm/annotations.yaml.tmpl
@@ -12,7 +12,5 @@ annotations:
     operators.operatorframework.io.bundle.channels.v1: alpha
     operators.operatorframework.io/builder: operator-sdk-v1.12.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    operators.operatorframework.io.test.mediatype.v1: scorecard+v1
-    operators.operatorframework.io.test.config.v1: tests/scorecard/
     repository: https://github.com/k8gb-io/k8gb
     support: cncf-k8gb-maintainers@lists.cncf.io


### PR DESCRIPTION
We don't have scorecard tests.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>