### PR TITLE
Align exact version in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.16.9
       - name: Login to Dockerhub
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
related to #697, #698

forgot to align exact GO version with `release.yaml`, `terrascan.yaml`

Signed-off-by: kuritka <kuritka@gmail.com>