### PR TITLE
helm: translate the edgeDNSServer -> edgeDNSServers using a tempate

### DIFF
--- a/chart/k8gb/templates/_helpers.tpl
+++ b/chart/k8gb/templates/_helpers.tpl
@@ -88,3 +88,11 @@ k8gb-{{ .Values.k8gb.dnsZone }}-{{ .Values.k8gb.clusterGeoTag }}
 k8gb-{{ .Values.route53.hostedZoneID }}-{{ .Values.k8gb.clusterGeoTag }}
 {{- end -}}
 {{- end -}}
+
+{{- define "k8gb.edgeDNSServers" -}}
+{{- if .Values.k8gb.edgeDNSServer -}}
+{{ .Values.k8gb.edgeDNSServer }}
+{{- else -}}
+{{ join "," .Values.k8gb.edgeDNSServers }}
+{{- end -}}
+{{- end -}}

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -61,7 +61,7 @@ spec:
             - name: EDGE_DNS_ZONE
               value: {{ .Values.k8gb.edgeDNSZone }}
             - name: EDGE_DNS_SERVERS
-              value: {{ join "," .Values.k8gb.edgeDNSServers }}
+              value: {{ include "k8gb.edgeDNSServers" . }}
             - name: DNS_ZONE
               value: {{ .Values.k8gb.dnsZone }}
             - name: RECONCILE_REQUEUE_SECONDS


### PR DESCRIPTION
When deploying `0.8.3` with using old `value.yaml` file, the `.Values.k8gb.edgeDNSServer` would not be passed correctly to the deployment as env var. (it's basically not read anywhere in the current helm chart and thrown away)

Hiding the ugliness into `_helpers.tpl` as impl detail

the logic is following:
when `edgeDNSServers` is set in `values.yaml` or using `--set ..`, then these values are being used, otherwise `edgeDNSServer` is tried

edit: if `edgeDNSServers` contains only one entry with "1.1.1.1" (default value coming from our `values.yaml`) and the `edgeDNSServer` is not empty, then `edgeDNSServer` wins

some examples:

```
# simulating using outdated custom value file (translation done properly, even if the 1.1.1.1 was coming from the defaults)
helm template .  --set k8gb.edgeDNSServer=1.1.1.2 | grep EDGE_DNS_SERVERS -A1
            - name: EDGE_DNS_SERVERS
              value: 1.1.1.2

# if not specified, using the 1.1.1.1 from defaults values.yaml bundled w/ the chart
helm template . | grep EDGE_DNS_SERVERS -A1
            - name: EDGE_DNS_SERVERS
              value: 1.1.1.1

# suggested usage - using the new option and forgot the old one
helm template .  --set k8gb.edgeDNSServers={1.1.1.2} | grep EDGE_DNS_SERVERS -A1
            - name: EDGE_DNS_SERVERS
              value: 1.1.1.2

# hybrids
helm template .  --set k8gb.edgeDNSServer=1.1.1.3 --set k8gb.edgeDNSServers={1.1.1.2} | grep EDGE_DNS_SERVERS -A1
            - name: EDGE_DNS_SERVERS
              value: 1.1.1.2

helm template .  --set k8gb.edgeDNSServer=1.1.1.3 --set k8gb.edgeDNSServers={1.1.1.1} | grep EDGE_DNS_SERVERS -A1
            - name: EDGE_DNS_SERVERS
              value: 1.1.1.3

helm template .  --set k8gb.edgeDNSServer=1.1.1.3 --set k8gb.edgeDNSServers="{1.1.1.1,1.2.3.4}" | grep EDGE_DNS_SERVERS -A1
            - name: EDGE_DNS_SERVERS
              value: 1.1.1.1,1.2.3.4
```

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>