### PR TITLE
yet another olm CI fixes

### DIFF
--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       bundleVersion:
-        description: Version of the bundle that should be generated. If not provided, the latest release tag is taken
+        description: Version of the bundle that should be generated. If not provided, the latest release tag is taken. Use 'master' for incorporating the latest changes in repo
         required: false
         default: ""
       upstreamRepo:
@@ -43,6 +43,7 @@ jobs:
       - name: Generate OLM bundle
         env:
           TOOL_VERSION: ${{ github.event.inputs.olmBundleToolVersion }}
+          PREVIOUS_VERSION: "v0.0.1" # remove me after the pr on community-operators repo is merged
           DEBUG: 1
         run: |
           ./olm/generate.sh ${{ steps.get_version.outputs.version }}
@@ -69,7 +70,7 @@ jobs:
           push-to-fork: k8gb-io/community-operators
           path: sandbox
           commit-message: OLM bundle for k8gb@${{ steps.get_version.outputs.bundleDir }}
-          title: OLM bundle for k8gb@${{ steps.get_version.outputs.bundleDir }}
+          title: operators k8gb ({{ steps.get_version.outputs.bundleDir }})
           body: |
             :package: Update k8gb operator bundle :package:
 
@@ -90,7 +91,7 @@ jobs:
 
             This automated PR was created by [this action][1].
 
-            [1]: https://github.com/k8gb-io/k8gb/runs/${GITHUB_RUN_ID}
+            [1]: https://github.com/k8gb-io/k8gb/runs/${{ github.run_id }}
           branch: k8gb-${{ steps.get_version.outputs.bundleDir }}
           delete-branch: true
           signoff: true

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -43,6 +43,10 @@ annotations:
       name: gslbs.k8gb.absa.oss
       displayName: Gslb
       description: Gslb resource for global load balancing strategy configuration
+    - kind: DNSEndpoint
+      name: dnsendpoints.externaldns.k8s.io
+      version: v1alpha1
+      description: Using ExternalDNS it synchronizes exposed Kubernetes Services and Ingresses with DNS providers
   artifacthub.io/crdsExamples: |
     - apiVersion: k8gb.absa.oss/v1beta1
       kind: Gslb

--- a/olm/annotations.yaml.tmpl
+++ b/olm/annotations.yaml.tmpl
@@ -3,7 +3,6 @@ annotations:
     certified: "false"
     createdAt: "2021-09-24 12:00:00"
     description: A cloud native Kubernetes Global Balancer
-    namespace: placeholder
     operatorframework.io/suggested-namespace: k8gb
     operators.operatorframework.io.bundle.mediatype.v1: registry+v1
     operators.operatorframework.io.bundle.manifests.v1: manifests/

--- a/olm/clusterserviceversion.yaml.tmpl
+++ b/olm/clusterserviceversion.yaml.tmpl
@@ -1,5 +1,7 @@
 apiVersion: v1alpha1
 kind: ClusterServiceVersion
+metadata:
+  namespace: placeholder
 spec:
   maturity: alpha
   minKubeVersion: 1.17.0

--- a/olm/generate.sh
+++ b/olm/generate.sh
@@ -29,6 +29,8 @@ main() {
     else
         git checkout v${_VERSION}
     fi
+    PREVIOUS_VERSION=${PREVIOUS_VERSION:-$(git describe --abbrev=0 --tags v${_VERSION}^)}
+
     generate
 }
 
@@ -39,7 +41,8 @@ generate() {
         --name-template=k8gb \
         --set k8gb.securityContext.runAsUser=null | ${OLM_BINARY} \
             --chart-file-path=${DIR}/../chart/k8gb/Chart.yaml \
-            --version=${_VERSION} \
+            --version=v${_VERSION} \
+            --replaces-version=${PREVIOUS_VERSION} \
             --helm-chart-overrides \
             --output-dir ${DIR}
     git checkout ${DIR}/annotations.yaml.tmpl


### PR DESCRIPTION
Couple of unrelated changes, but didn't want to open 3 very small PRs, because the changes are pretty small. If you want I can split them.

- fix 'replaces' relation to the previously submited olm bundle (which release this release replaces), see https://docs.openshift.com/container-platform/4.2/operators/understanding_olm/olm-understanding-olm.html#olm-upgrades-example-upgrade-path_olm-understanding-olm ([failed check](https://github.com/k8s-operatorhub/community-operators/runs/4045005693?check_suite_focus=true#step:3:1456)) This utilises the [change](https://github.com/AbsaOSS/olm-bundle/pull/8) to `olm-bundle` tool.

- add `DNSEndpoint` as `owned` crd, moving it under `required` didn't work ([failed check](https://github.com/k8s-operatorhub/community-operators/runs/4045005648?check_suite_focus=true#step:6:847))

- improved wording for pull-requst description: 
   1) fix the link to the gh action that produces this pr; 
   1) PR title aligned w/ their gh-action bot that keeps renaming it if we set it to something else
   1) add better description for `bundleVersion` (if value is set to master)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>