### PR TITLE
Upgrade the controller-gen dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ K8GB_COREDNS_IP ?= kubectl get svc k8gb-coredns -n k8gb -o custom-columns='IP:sp
 CLUSTER_GSLB2_HELM_ARGS ?= --set k8gb.clusterGeoTag='us' --set k8gb.extGslbClustersGeoTags='eu' --set k8gb.hostAlias.hostnames='{gslb-ns-eu-cloud.example.com}'
 LOG_FORMAT ?= simple
 LOG_LEVEL ?= debug
-CONTROLLER_GEN_VERSION  ?= v0.4.1
+CONTROLLER_GEN_VERSION  ?= v0.7.0
 GOLIC_VERSION  ?= v0.5.0
 GOKART_VERSION ?= v0.2.0
 POD_NAMESPACE ?= k8gb

--- a/chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml
+++ b/chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.7.0
   creationTimestamp: null
   name: gslbs.k8gb.absa.oss
 spec:


### PR DESCRIPTION
related to #697

In order to [upgrade operator framework to v1.14.0](https://github.com/operator-framework/operator-sdk/releases/tag/v1.14.0) I'm upgrading controller-gen version.

controller-gen is called several times during the workflow (e.g. `make check`) and only forces a version change in the file: `chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml`. Otherwise everything remains backwards compatible. 


Signed-off-by: kuritka <kuritka@gmail.com>