### PR TITLE
Don't keep adding localtargets- prefix for each ext geo tag

### DIFF
--- a/controllers/providers/assistant/gslb.go
+++ b/controllers/providers/assistant/gslb.go
@@ -309,8 +309,8 @@ func (r *Gslb) GetExternalTargets(host string, extClusterNsNames map[string]stri
 			hostToUse = cluster
 		}
 		nameServersToUse := getNSCombinations(r.edgeDNSServers, hostToUse)
-		host = fmt.Sprintf("localtargets-%s", host)
-		a, err := dnsQuery(host, nameServersToUse)
+		lHost := fmt.Sprintf("localtargets-%s", host)
+		a, err := dnsQuery(lHost, nameServersToUse)
 		if err != nil {
 			return
 		}


### PR DESCRIPTION
We were testing always for two clusters so this flew under the radar,
but if there are 3 or more clusters the host will be `{localtargets-}^n + roundrobin.cloud.example.com`

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>