### PR TITLE
Multicluster setup (n > 2)

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -46,8 +46,21 @@ jobs:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
 
+      - name: Create 3rd k3s Cluster
+        uses: AbsaOSS/k3d-action@v1.5.0
+        with:
+          cluster-name: "test-gslb3"
+          args: -c k3d/test-gslb3.yaml
+
       - name: K8GB deployment
-        run: make deploy-candidate
+        run: |
+          make deploy-test-version list-running-pods CLUSTERS_NUMBER=3
+          echo "Cluster 1 (eu):"
+          kubectl get no -owide --context=k3d-test-gslb1
+          echo "Cluster 2 (us):"
+          kubectl get no -owide --context=k3d-test-gslb2
+          echo "Cluster 3 (cz):"
+          kubectl get no -owide --context=k3d-test-gslb3
 
       - name: Terratest
         run: make terratest

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -46,11 +46,17 @@ jobs:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
 
+      - name: Create 3rd k3s Cluster
+        uses: AbsaOSS/k3d-action@v1.5.0
+        with:
+          cluster-name: "test-gslb3"
+          args: -c k3d/test-gslb3.yaml
+
       - name: K8GB deploy stable version
-        run: make deploy-stable-version
+        run: make deploy-stable-version list-running-pods CLUSTERS_NUMBER=3
 
       - name: K8GB deploy test version
-        run: make deploy-test-version
+        run: make deploy-test-version list-running-pods CLUSTERS_NUMBER=3
 
       - name: Terratest
         run: make terratest

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ chart/k8gb/charts/*.tgz
 
 # gh-pages | Jekyll generated files
 _site
+
+# generated k3d configs
+k3d/test-gslb[!1-3].yaml

--- a/chart/k8gb/.helmignore
+++ b/chart/k8gb/.helmignore
@@ -20,3 +20,6 @@
 .idea/
 *.tmproj
 .vscode/
+
+LICENSE
+README.md

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -15,13 +15,9 @@ spec:
       labels:
         name: k8gb
     spec:
-      {{- if .Values.k8gb.hostAlias.enabled }}
+      {{- if .Values.k8gb.hostAliases }}
       hostAliases:
-        - ip: "{{ .Values.k8gb.hostAlias.ip }}"
-          hostnames:
-            {{- range.Values.k8gb.hostAlias.hostnames }}
-            - {{ . }}
-            {{- end }}
+        {{- toYaml .Values.k8gb.hostAliases | nindent 8 }}
       {{- end }}
       serviceAccountName: k8gb
       containers:

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -23,12 +23,14 @@ k8gb:
   clusterGeoTag: "eu"
   # -- comma-separated list of external gslb geo tags to pair with
   extGslbClustersGeoTags: "us"
-  hostAlias:
-    # -- use https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ inside operator pod. Useful for advanced testing scenarios and to break dependency on EdgeDNS for cross k8gb collaboration
-    enabled: false
-    ip: "172.17.0.1"
-    hostnames:
-     - "gslb-ns-us-cloud.example.com"
+  # -- use https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ inside operator pod. Useful for advanced testing scenarios and to break dependency on EdgeDNS for cross k8gb collaboration
+  hostAliases:
+  #   - ip: "172.17.0.1"
+  #     hostnames: 
+  #      - "gslb-ns-us-cloud.example.com"
+  #   - ip: "172.17.0.2"
+  #     hostnames: 
+  #      - "gslb-ns-eu-cloud.example.com"
   # -- Reconcile time in seconds
   reconcileRequeueSeconds: 30
   log:

--- a/k3d/generate-yaml.sh
+++ b/k3d/generate-yaml.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# use this simple script for generating additional config files for k3d
+# note: make sure the generated ports doesn't collide with your local environment
+# for instance on mac port 88 might be taken by kdc
+
+[[ $# != 1 ]] && echo "Usage: $0 <how_many>" && exit 1
+[[ -z "${1##*[!0-9]*}" ]] && echo "'$1' is not a positive integer" && exit 1
+UPTO=$1
+DIR="${DIR:-$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )}"
+
+echo Generating configs for $UPTO clusters..
+for c in $(seq $UPTO); do
+    export CLUSTER_INDEX=$(( 1 + $c ))
+    export PORT_HTTP=$(( 80 + $c ))
+    export PORT_HTTPS=$(( 443 + $c ))
+    export PORT_PROM=$(( 9080 + $c ))
+    export PORT_DNS=$(( 5053 + $c ))
+    cat ${DIR}/gslb.yaml.tmpl | envsubst > ${DIR}/test-gslb${CLUSTER_INDEX}.yaml
+done

--- a/k3d/gslb.yaml.tmpl
+++ b/k3d/gslb.yaml.tmpl
@@ -1,0 +1,25 @@
+apiVersion: k3d.io/v1alpha2
+kind: Simple
+name: test-gslb$CLUSTER_INDEX
+image: docker.io/rancher/k3s:v1.21.2-k3s1
+agents: 1
+network: k3d-action-bridge-network
+ports:
+- port: $PORT_HTTP:80
+  nodeFilters:
+  - agent[0]
+- port: $PORT_HTTPS:443
+  nodeFilters:
+  - agent[0]
+- port: $PORT_PROM:30090
+  nodeFilters:
+    - agent[0]
+- port: $PORT_DNS:53/udp
+  nodeFilters:
+  - agent[0]
+options:
+  k3d:
+    disableLoadbalancer: true
+  k3s: # options passed on to K3s itself
+    extraServerArgs: # additional arguments passed to the `k3s server` command; same as `--k3s-server-arg`
+      - --no-deploy=traefik,servicelb,metrics-server,local-storage

--- a/k3d/test-gslb3.yaml
+++ b/k3d/test-gslb3.yaml
@@ -1,0 +1,25 @@
+apiVersion: k3d.io/v1alpha2
+kind: Simple
+name: test-gslb3
+image: docker.io/rancher/k3s:v1.21.2-k3s1
+agents: 1
+network: k3d-action-bridge-network
+ports:
+- port: 82:80
+  nodeFilters:
+  - agent[0]
+- port: 445:443
+  nodeFilters:
+  - agent[0]
+- port: 9082:30090
+  nodeFilters:
+    - agent[0]
+- port: 5055:53/udp
+  nodeFilters:
+  - agent[0]
+options:
+  k3d:
+    disableLoadbalancer: true
+  k3s: # options passed on to K3s itself
+    extraServerArgs: # additional arguments passed to the `k3s server` command; same as `--k3s-server-arg`
+      - --no-deploy=traefik,servicelb,metrics-server,local-storage

--- a/terratest/test/init.go
+++ b/terratest/test/init.go
@@ -30,6 +30,7 @@ var (
 func init() {
 	p1, _ := env.GetEnvAsIntOrFallback("DNS_SERVER1_PORT", 5053)
 	p2, _ := env.GetEnvAsIntOrFallback("DNS_SERVER2_PORT", 5054)
+	p3, _ := env.GetEnvAsIntOrFallback("DNS_SERVER3_PORT", 5055)
 	settings = utils.TestSettings{
 		DNSZone:         env.GetEnvAsStringOrFallback("GSLB_DOMAIN", "cloud.example.com"),
 		PrimaryGeoTag:   env.GetEnvAsStringOrFallback("PRIMARY_GEO_TAG", "eu"),
@@ -38,8 +39,11 @@ func init() {
 		Port1:           p1,
 		DNSServer2:      env.GetEnvAsStringOrFallback("DNS_SERVER2", "localhost"),
 		Port2:           p2,
+		DNSServer3:      env.GetEnvAsStringOrFallback("DNS_SERVER3", "localhost"),
+		Port3:           p3,
 		Cluster1:        env.GetEnvAsStringOrFallback("K8GB_CLUSTER1", "k3d-test-gslb1"),
 		Cluster2:        env.GetEnvAsStringOrFallback("K8GB_CLUSTER2", "k3d-test-gslb2"),
+		Cluster3:        env.GetEnvAsStringOrFallback("K8GB_CLUSTER3", "k3d-test-gslb3"),
 		PodinfoImage:    env.GetEnvAsStringOrFallback("PODINFO_IMAGE_REPO", "ghcr.io/stefanprodan/podinfo"),
 	}
 }

--- a/terratest/utils/test_settings.go
+++ b/terratest/utils/test_settings.go
@@ -25,7 +25,10 @@ type TestSettings struct {
 	Port1           int
 	DNSServer2      string
 	Port2           int
+	DNSServer3      string
+	Port3           int
 	Cluster1        string
 	Cluster2        string
+	Cluster3        string
 	PodinfoImage    string
 }


### PR DESCRIPTION
- change the Makefile targets so that they run in a for loop
- add tests for terratest for round-robin @ 3 clusters (failover is still pending)
- change the helm chart to be able to set up more than one hostAlias entry for a pod
- add simple script that generates the yaml configs for k3d clusters so that we are DRY

to verify the change locally i suggest:
```bash
# deploy 5 clusters
make deploy-full-local-setup CLUSTERS_NUMBER=5

# do some testing
for i in {0..20} ; do make test-round-robin | grep mess ; done

# cleanup
make destroy-full-local-setup CLUSTERS_NUMBER=5
```

another consequence of this PR is that when trying to incorporate a change in local helm chart (that hasn't been published yet), one can do `make deploy-full-local-setup CHART=./chart/k8gb`

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>