### PR TITLE
Increase the default timeout for Infoblox http requests to 60 sec

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -87,7 +87,7 @@ infoblox:
   # -- use SSL
   sslVerify: true
   # -- Request Timeout in secconds
-  httpRequestTimeout: 20
+  httpRequestTimeout: 60
   # -- Size of connections pool
   httpPoolConnections: 10
 


### PR DESCRIPTION
Because recently the 20 seconds was not enough

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>