### PR TITLE
Switch version to the latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ NO_VALUE ?= no_value
 #		VARIABLES
 ###############################
 PWD ?=  $(shell pwd)
-VERSION ?= $(shell helm show chart chart/k8gb/|awk '/appVersion:/ {print $$2}')
+VERSION ?= $(shell git describe --tags --abbrev=0)
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
 SEMVER ?= $(VERSION)-$(COMMIT_HASH)
 # image URL to use all building/pushing image targets


### PR DESCRIPTION
There are cases when Chart version is bumped but tag is is not yet set,
this breaks semantics of preparing a release and relying on the data is
not true yet. E.g. appVersion have no docker image pushed yet.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>