### PR TITLE
Remove K8GB_VERSION env var

### DIFF
--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -54,8 +54,6 @@ spec:
                   fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "k8gb"
-            - name: K8GB_VERSION
-              value: {{ quote .Chart.AppVersion }}
             - name: CLUSTER_GEO_TAG
               value: {{ quote .Values.k8gb.clusterGeoTag }}
             - name: EXT_GSLB_CLUSTERS_GEO_TAGS


### PR DESCRIPTION
We keep `K8GB_VERSION` within `operator.yaml` and is not used anywhere, besides I see here the problem of a single source of truth. The k8gb version including commit hash is compiled into executable and logged at startup, also provided through the metrics.
see: https://github.com/k8gb-io/k8gb/blob/master/.goreleaser.yml#L18

Signed-off-by: kuritka <kuritka@gmail.com>