### PR TITLE
Don't deploy local path storage provisioner

### DIFF
--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -25,4 +25,4 @@ options:
     disableLoadbalancer: true
   k3s: # options passed on to K3s itself
     extraServerArgs: # additional arguments passed to the `k3s server` command; same as `--k3s-server-arg`
-      - --no-deploy=traefik,servicelb,metrics-server
+      - --no-deploy=traefik,servicelb,metrics-server,local-storage

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -22,4 +22,4 @@ options:
     disableLoadbalancer: true
   k3s: # options passed on to K3s itself
     extraServerArgs: # additional arguments passed to the `k3s server` command; same as `--k3s-server-arg`
-      - --no-deploy=traefik,servicelb,metrics-server
+      - --no-deploy=traefik,servicelb,metrics-server,local-storage


### PR DESCRIPTION
We don't use any persistant volume, to save up resources, skip
provisioning of local path storage provisioner.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>