### PR TITLE
Create new tag when version in Chart.yaml is bumped

### DIFF
--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -1,0 +1,28 @@
+name: Create Tag for Release
+
+on:
+  push:
+    branches:
+    - 'master'
+    paths:
+     - 'chart/k8gb/Chart.yaml'
+
+jobs:
+  cut_release:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get Tag
+        id: get_tag
+        run: |
+          new_tag=$(awk '/appVersion:/ {print $2}' chart/k8gb/Chart.yaml)
+          echo "Version to release: ${new_tag}"
+          echo "::set-output name=new_tag::${new_tag}"
+      - name: Push Tag
+        uses: mathieudutour/github-tag-action@v5.6
+        if: "contains(github.event.head_commit.message, 'RELEASE:')"
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          create_annotated_tag: true
+          tag_prefix: ""
+          custom_tag: ${{ steps.get_tag.outputs.new_tag }}


### PR DESCRIPTION
- The commit message has to contain `RELEASE:` to trigger this action.
- The version is taken from the appVersion field from Chart.yaml

tested on my fork: this [action](https://github.com/jkremser/k8gb/actions/runs/1461913379) was triggered after [this pr](https://github.com/jkremser/k8gb/pull/14) was merged. And as the result the tag [v6.6.6](https://github.com/jkremser/k8gb/tree/v6.6.6) was created.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>