### PR TITLE
Time out and reconcile  aggressively.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -401,6 +401,8 @@ define deploy-k8gb-with-helm
 	helm -n k8gb upgrade -i k8gb $5 -f $(VALUES_YAML) \
 		--set k8gb.hostAlias.enabled=true \
 		--set k8gb.hostAlias.ip="`$(call get-host-alias-ip,k3d-$1,k3d-$2)`" \
+		--set k8gb.reconcileRequeueSeconds=10 \
+		--set k8gb.dnsZoneNegTTL=10 \
 		--set k8gb.imageTag=$3 $4 \
 		--set k8gb.log.format=$(LOG_FORMAT) \
 		--set k8gb.log.level=$(LOG_LEVEL) \

--- a/terratest/examples/failover-lifecycle.yaml
+++ b/terratest/examples/failover-lifecycle.yaml
@@ -16,4 +16,4 @@ spec:
     type: failover
     primaryGeoTag: "eu"
     splitBrainThresholdSeconds: 600
-    dnsTtlSeconds:  60
+    dnsTtlSeconds: 5

--- a/terratest/examples/failover-playground.yaml
+++ b/terratest/examples/failover-playground.yaml
@@ -14,4 +14,5 @@ spec:
             path: /
   strategy:
     type: failover
+    dnsTtlSeconds: 5
     primaryGeoTag: "eu"

--- a/terratest/examples/failover.yaml
+++ b/terratest/examples/failover.yaml
@@ -14,4 +14,5 @@ spec:
             path: /
   strategy:
     type: failover
+    dnsTtlSeconds: 5
     primaryGeoTag: "eu"

--- a/terratest/examples/failover1.yaml
+++ b/terratest/examples/failover1.yaml
@@ -14,4 +14,5 @@ spec:
             path: /
   strategy:
     type: failover
+    dnsTtlSeconds: 5
     primaryGeoTag: "eu"

--- a/terratest/examples/failover2.yaml
+++ b/terratest/examples/failover2.yaml
@@ -14,4 +14,5 @@ spec:
             path: /
   strategy:
     type: failover
+    dnsTtlSeconds: 5
     primaryGeoTag: "us"

--- a/terratest/examples/ingress-annotation-failover-simple.yaml
+++ b/terratest/examples/ingress-annotation-failover-simple.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     k8gb.io/strategy: failover
     k8gb.io/primary-geotag: "eu"
+    k8gb.io/dns-ttl-seconds: "5"
 spec:
   rules:
     - host: ingress-failover-simple.cloud.example.com

--- a/terratest/examples/ingress-annotation-failover.yaml
+++ b/terratest/examples/ingress-annotation-failover.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     k8gb.io/strategy: failover
     k8gb.io/primary-geotag: "eu"
-    k8gb.io/dns-ttl-seconds: "60"
+    k8gb.io/dns-ttl-seconds: "5"
     k8gb.io/splitbrain-threshold-seconds: "600"
   name: test-gslb-annotation-failover
 spec:

--- a/terratest/examples/ingress-annotation-rr.yaml
+++ b/terratest/examples/ingress-annotation-rr.yaml
@@ -3,6 +3,7 @@ kind: Ingress
 metadata:
   annotations:
     k8gb.io/strategy: roundRobin
+    k8gb.io/dns-ttl-seconds: "5"
   name: test-gslb-annotation
 spec:
   rules:

--- a/terratest/examples/roundrobin.yaml
+++ b/terratest/examples/roundrobin.yaml
@@ -28,3 +28,4 @@ spec:
             path: /
   strategy:
     type: roundRobin # Use a round robin load balancing strategy, when deciding which downstream clusters to route clients too
+    dnsTtlSeconds: 5

--- a/terratest/examples/roundrobin2.yaml
+++ b/terratest/examples/roundrobin2.yaml
@@ -14,3 +14,4 @@ spec:
             path: /
   strategy:
     type: roundRobin # Use a round robin load balancing strategy, when deciding which downstream clusters to route clients too
+    dnsTtlSeconds: 5

--- a/terratest/test/k8gb_ingress_annotation_failover_test.go
+++ b/terratest/test/k8gb_ingress_annotation_failover_test.go
@@ -62,7 +62,7 @@ func TestK8gbIngressAnnotationFailover(t *testing.T) {
 	utils.AssertGslbStatus(t, options, "test-gslb-annotation-failover", "ingress-failover-notfound."+settings.DNSZone+":NotFound ingress-failover-unhealthy."+settings.DNSZone+":NotFound ingress-failover."+settings.DNSZone+":NotFound")
 	utils.AssertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.type", "failover")
 	utils.AssertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.primaryGeoTag", settings.PrimaryGeoTag)
-	utils.AssertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.dnsTtlSeconds", "60")
+	utils.AssertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.dnsTtlSeconds", "5")
 	utils.AssertGslbSpec(t, options, "test-gslb-annotation-failover", ".spec.strategy.splitBrainThresholdSeconds", "600")
 
 	t.Run("Broken ingress is not proccessed", func(t *testing.T) {

--- a/terratest/test/k8gb_lifecycle_test.go
+++ b/terratest/test/k8gb_lifecycle_test.go
@@ -39,7 +39,7 @@ func TestK8gbRepeatedlyRecreatedFromIngress(t *testing.T) {
 
 	assertStrategy := func(t *testing.T, options *k8s.KubectlOptions) {
 		utils.AssertGslbSpec(t, options, name, "spec.strategy.splitBrainThresholdSeconds", "300")
-		utils.AssertGslbSpec(t, options, name, "spec.strategy.dnsTtlSeconds", "30")
+		utils.AssertGslbSpec(t, options, name, "spec.strategy.dnsTtlSeconds", "5")
 		utils.AssertGslbSpec(t, options, name, "spec.strategy.primaryGeoTag", settings.PrimaryGeoTag)
 		utils.AssertGslbSpec(t, options, name, "spec.strategy.type", "failover")
 	}
@@ -101,7 +101,7 @@ func TestK8gbSpecKeepsStableAfterIngressUpdates(t *testing.T) {
 
 	assertStrategy := func(t *testing.T, options *k8s.KubectlOptions) {
 		utils.AssertGslbSpec(t, options, name, "spec.strategy.splitBrainThresholdSeconds", "600")
-		utils.AssertGslbSpec(t, options, name, "spec.strategy.dnsTtlSeconds", "60")
+		utils.AssertGslbSpec(t, options, name, "spec.strategy.dnsTtlSeconds", "5")
 		utils.AssertGslbSpec(t, options, name, "spec.strategy.primaryGeoTag", settings.PrimaryGeoTag)
 		utils.AssertGslbSpec(t, options, name, "spec.strategy.type", "failover")
 	}


### PR DESCRIPTION
This makes dns caches to expire faster, providing faster feedback to
terratest loop.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>