### PR TITLE
Update docs about automatic tag during release process + different token

### DIFF
--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -20,7 +20,7 @@ jobs:
           echo "::set-output name=new_tag::${new_tag}"
       - name: Push Tag
         uses: mathieudutour/github-tag-action@v5.6
-        if: "contains(github.event.head_commit.message, 'RELEASE:')"
+        if: "startsWith(github.event.head_commit.message, 'RELEASE:')"
         with:
           github_token: ${{ secrets.CR_TOKEN }}
           create_annotated_tag: true

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: mathieudutour/github-tag-action@v5.6
         if: "contains(github.event.head_commit.message, 'RELEASE:')"
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.CR_TOKEN }}
           create_annotated_tag: true
           tag_prefix: ""
           custom_tag: ${{ steps.get_tag.outputs.new_tag }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -328,16 +328,11 @@ make demo DEMO_URL=https://failover.test.exampledns.tk DEMO_DEBUG=1
 
 ## Release process
 
-* Bump the version in `Chart.yaml`, see [example PR](https://github.com/k8gb-io/k8gb/pull/521).
+* Bump the version in `Chart.yaml`, see [example PR](https://github.com/k8gb-io/k8gb/pull/724). Make sure the
+commit message starts with `RELEASE:`.
 * Merge the Pull Request after the review approval
-* Create release tag (make sure you do the following steps on the up to date `master` branch)
-```sh
-export RELEASE_TAG=<tag, e.g.: v0.8.2>
-git tag $RELEASE_TAG -s -m "Release $RELEASE_TAG"
-git push origin refs/tags/$RELEASE_TAG
-```
-* At this point a DRAFT release will be created on GitHub. After the [release pipeline](https://github.com/k8gb-io/k8gb/actions/workflows/release.yaml)
-has been successfully completed, you check the [release DRAFT](https://github.com/k8gb-io/k8gb/releases) and if it is OK, you click on the **"Publish release"** button.
+* At this point a DRAFT release will be created on GitHub. After the [automatic tag](https://github.com/k8gb-io/k8gb/actions/workflows/cut_release.yaml) & [release pipeline](https://github.com/k8gb-io/k8gb/actions/workflows/release.yaml)
+have been successfully completed, you check the [release DRAFT](https://github.com/k8gb-io/k8gb/releases) and if it is OK, you click on the **"Publish release"** button.
 
 * Check the [helm publish pipeline](https://github.com/k8gb-io/k8gb/actions/workflows/helm_publish.yaml) status
 * Check the [offline changelog](https://github.com/k8gb-io/k8gb/actions/workflows/changelog_pr.yaml) status. This pipeline creates


### PR DESCRIPTION
Updating docs.

[Previously](https://github.com/k8gb-io/k8gb/actions/runs/1462539270) the tag has been pushed, but didn't trigger the release probably because of [this](https://github.community/t/github-actions-workflow-not-triggering-with-tag-push/17053/2 ). So let's use a different token

edit: added one more thing - `contains` function was changed to `startsWith` because when reverting a commit, it takes the original msg and prepends "Revert" which would trigger the event (good catch @ytsarev)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>