### PR TITLE
Revert "RELEASE: v0.8.4 "

### DIFF
--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -3,8 +3,8 @@ name: k8gb
 description: A Helm chart for Kubernetes Global Balancer
 icon: https://www.k8gb.io/assets/images/icon-192x192.png
 type: application
-version: v0.8.4
-appVersion: v0.8.4
+version: v0.8.3
+appVersion: v0.8.3
 
 dependencies:
   - name: coredns


### PR DESCRIPTION
Reverts k8gb-io/k8gb#724 to incorporate and test https://github.com/k8gb-io/k8gb/pull/732 by further redoing of release