### PR TITLE
curldemo: Use full path to Dockerfile

### DIFF
--- a/.github/workflows/curldemo.yaml
+++ b/.github/workflows/curldemo.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: ./deploy/test-apps/curldemo/
-          file: ./Dockerfile
+          file: ./deploy/test-apps/curldemo/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_USER }}/k8gb-demo-curl:latest
 


### PR DESCRIPTION
Unfortunately, it doesn't compose the docker context w/ the path to Dockerfile correctly, so ./Dockerfile is actually pointing to our "main" (k8gb) dockerfile and the build fails on [this](https://github.com/k8gb-io/k8gb/runs/4214218135?check_suite_focus=true).


Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>