### PR TITLE
cleaning .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,125 +1,23 @@
-
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
-bin
-
-# Test binary, build with `go test -c`
-*.test
-
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
-
-# Kubernetes Generated files - skip generated files, except for vendored files
-
-!vendor/**/zz_generated.*
-
-# editor and IDE paraphernalia
-.idea
-*.swp
-*.swo
-*~
-
-# Temporary Build Files
-build/_output
-build/_test
-# Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
-### Emacs ###
-# -*- mode: gitignore; -*-
-*~
-\#*\#
-/.emacs.desktop
-/.emacs.desktop.lock
-*.elc
-auto-save-list
-tramp
-.\#*
-# Org-mode
-.org-id-locations
-*_archive
-# flymake-mode
-*_flymake.*
-# eshell files
-/eshell/history
-/eshell/lastdir
-# elpa packages
-/elpa/
-# reftex files
-*.rel
-# AUCTeX auto folder
-/auto/
-# cask packages
-.cask/
 dist/
-# Flycheck
-flycheck_*.el
-# server auth directory
-/server/
-# projectiles files
-.projectile
-projectile-bookmarks.eld
-# directory configuration
-.dir-locals.el
-# saveplace
-places
-# url cache
-url/cache/
-# cedet
-ede-projects.el
-# smex
-smex-items
-# company-statistics
-company-statistics-cache.el
-# anaconda-mode
-anaconda-mode/
-### Go ###
-# Binaries for programs and plugins
-*.exe
-*.exe~
-*.dll
-*.so
-*.dylib
-# Test binary, build with 'go test -c'
-*.test
-# Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-### Vim ###
-# swap
-.sw[a-p]
-.*.sw[a-p]
-# session
-Session.vim
-# temporary
-.netrwhist
-# auto-generated tag files
-tags
-### VisualStudioCode ###
-.vscode/*
-.history
-# End of https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
-
-### JetBrains IDE ###
-.idea
-# End of idea tools
-# Exclude chart tar.gz files
-chart/k8gb/charts/*.tgz
-
-# Ignore testing kubeconfigs
-kubeconfig*
-
-# Ignore changes from github_changelog_generator action
-changes
-
-# dotenv file
+*.sw[ap]
+k8gb
+k8gb.exe
 .env
 
-# gh-pages | Jekyll generated files
-_site
-.jekyll-metadata
+# IDE specific files (debug config etc...)
+.vscode/
+.idea/
+Session.vim
+.netrwhist
+tags
+
+# Helm charts
+chart/k8gb/charts/*.tgz
 
 # OLM
 /olm/bundle
 /olm/olm-bundle
+
+# gh-pages | Jekyll generated files
+_site


### PR DESCRIPTION
please try the local branch to see if everything works as expected.
Because things in .gitignore were repetitive and didn't make much sense, I refactored .gitignore.

- We stayed in denyList mode.
- ~~It has two sections~~
  - ~~the first section is generated by [toptal.com](https://www.toptal.com/developers/gitignore) for vim,go,goland,visualstudiocode,emacs,jekyll~~
  - ~~the second section follows the first one and is for custom rules of our project.~~

Signed-off-by: kuritka <kuritka@gmail.com>