### PR TITLE
Fix onlyLastTag in change log generator

### DIFF
--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: heinrichreimer/github-changelog-generator-action@v2.2
+      - uses: heinrichreimer/github-changelog-generator-action@v2.3
         with:
           token: ${{ secrets.CR_TOKEN }}
           project: k8gb


### PR DESCRIPTION
Update action version to 2.3 to include
https://github.com/heinrichreimer/action-github-changelog-generator/commit/e928fd01f0cbe834ce042f704db89b63d6be7198

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>