### PR TITLE
Remove only the first two lines from old changelog when appending

### DIFF
--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           mv CHANGELOG.md CHANGELOG-old.md
           cat CHANGELOG-latest.md | sed -e'$d' > CHANGELOG.md
-          cat CHANGELOG-old.md | sed -e'1,4d' >> CHANGELOG.md
+          cat CHANGELOG-old.md | sed -e'1,2d' >> CHANGELOG.md
           rm CHANGELOG-old.md CHANGELOG-latest.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
```
cat CHANGELOG.md | sed -e'1,2d' | head -5
## [v0.8.3](https://github.com/k8gb-io/k8gb/tree/v0.8.3) (2021-10-19)

[Full Changelog](https://github.com/k8gb-io/k8gb/compare/v0.8.2...v0.8.3)

**Implemented enhancements:**
```

vs

```
cat CHANGELOG.md | sed -e'1,4d' | head -5
[Full Changelog](https://github.com/k8gb-io/k8gb/compare/v0.8.2...v0.8.3)

**Implemented enhancements:**

- Helm chart produces empty lines in yamls [\#631](https://github.com/k8gb-io/k8gb/issues/631)
```






Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>