### PR TITLE
.gitignore k8gb chart dependency .tgz files at `gh-pages` branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _site
 .jekyll-metadata
 vendor
 .env
+chart/k8gb/charts/*.tgz


### PR DESCRIPTION
Ignore k8gb chart dependency .tgz archives during `gh-pages` authoring.

See similar rule from `master` brach:
https://github.com/k8gb-io/k8gb/blob/master/.gitignore#L108 rule

Signed-off-by: Timofey Ilinykh <ilinytim@gmail.com>