### PR TITLE
curldemo: Build the container image only for pushes to master

### DIFF
--- a/.github/workflows/curldemo.yaml
+++ b/.github/workflows/curldemo.yaml
@@ -2,6 +2,8 @@ name: curldemo
 
 on:
   push:
+    branches:
+      - master
     paths:
       - 'deploy/test-apps/curldemo/**'
 


### PR DESCRIPTION
hopefully fixing the unexpected trigger during the release

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>