### PR TITLE
Extend cut_release GHA workflow with release revert mechanism

### DIFF
--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Get New Tag
-        id: get_new_tag
+      - name: Get Desired Tag
+        id: get_desired_tag
         run: |
           tag=$(awk '/appVersion:/ {print $2}' chart/k8gb/Chart.yaml)
           echo "Version to release: ${tag}"
@@ -27,7 +27,7 @@ jobs:
           github_token: ${{ secrets.CR_TOKEN }}
           create_annotated_tag: true
           tag_prefix: ""
-          custom_tag: ${{ steps.get_new_tag.outputs.tag }}
+          custom_tag: ${{ steps.get_desired_tag.outputs.tag }}
       - name: Get Current Tag
         if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:')
         id: get_current_tag
@@ -40,10 +40,10 @@ jobs:
         id: get_previous_tag
         run: |
           tag=$(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)
-          echo "Previos tag: ${tag}"
+          echo "Previous tag: ${tag}"
           echo "::set-output name=tag::${tag}"
       - name: Delete Tag and Release
-        if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:') && steps.get_new_tag.outputs.tag == steps.get_previous_tag.outputs.tag
+        if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:') && steps.get_desired_tag.outputs.tag == steps.get_previous_tag.outputs.tag
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true # default: false

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Get New Tag
         id: get_new_tag
         run: |

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Get New Tag
-        if: startsWith(github.event.head_commit.message, 'RELEASE:')
         id: get_new_tag
         run: |
           tag=$(awk '/appVersion:/ {print $2}' chart/k8gb/Chart.yaml)
@@ -34,8 +33,15 @@ jobs:
           tag=$(git describe --tags --abbrev=0)
           echo "Version to revert: ${tag}"
           echo "::set-output name=tag::${tag}"
-      - name: Delete Tag and Release
+      - name: Get Previous Tag
         if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:')
+        id: get_previous_tag
+        run: |
+          tag=$(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)
+          echo "Previos tag: ${tag}"
+          echo "::set-output name=tag::${tag}"
+      - name: Delete Tag and Release
+        if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:') && steps.get_new_tag.outputs.tag == steps.get_previous_tag.outputs.tag
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true # default: false

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -1,4 +1,4 @@
-name: Create Tag for Release
+name: Release tagging
 
 on:
   push:

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -12,17 +12,33 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Get Tag
-        id: get_tag
+      - name: Get New Tag
+        if: startsWith(github.event.head_commit.message, 'RELEASE:')
+        id: get_new_tag
         run: |
-          new_tag=$(awk '/appVersion:/ {print $2}' chart/k8gb/Chart.yaml)
-          echo "Version to release: ${new_tag}"
-          echo "::set-output name=new_tag::${new_tag}"
+          tag=$(awk '/appVersion:/ {print $2}' chart/k8gb/Chart.yaml)
+          echo "Version to release: ${tag}"
+          echo "::set-output name=tag::${tag}"
       - name: Push Tag
+        if: startsWith(github.event.head_commit.message, 'RELEASE:')
         uses: mathieudutour/github-tag-action@v5.6
-        if: "startsWith(github.event.head_commit.message, 'RELEASE:')"
         with:
           github_token: ${{ secrets.CR_TOKEN }}
           create_annotated_tag: true
           tag_prefix: ""
-          custom_tag: ${{ steps.get_tag.outputs.new_tag }}
+          custom_tag: ${{ steps.get_new_tag.outputs.tag }}
+      - name: Get Current Tag
+        if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:')
+        id: get_current_tag
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          echo "Version to revert: ${tag}"
+          echo "::set-output name=tag::${tag}"
+      - name: Delete Tag and Release
+        if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:')
+        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        with:
+          delete_release: true # default: false
+          tag_name: ${{ steps.get_current_tag.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}


### PR DESCRIPTION
* Delete tag and release on associated revert commit
* Conditional expression fix/simplification according to
  https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idif

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>