### PR TITLE
Allow the EXT_GSLB_CLUSTERS_GEO_TAGS to contain CLUSTER_GEO_TAG

### DIFF
--- a/controllers/depresolver/depresolver_validator.go
+++ b/controllers/depresolver/depresolver_validator.go
@@ -158,16 +158,6 @@ func (v *validator) isHigherThan(num int) *validator {
 	return v
 }
 
-func (v *validator) isNotEqualTo(value string) *validator {
-	if v.err != nil {
-		return v
-	}
-	if v.strValue == value {
-		v.err = fmt.Errorf(`'%s' can't be equal to '%s'`, v.name, value)
-	}
-	return v
-}
-
 func (v *validator) hasItems() *validator {
 	if v.err != nil {
 		return v


### PR DESCRIPTION
It's addressing the first point in the [#720](https://github.com/k8gb-io/k8gb/issues/720) and basically we can ignore the value of `CLUSTER_GEO_TAG` if it's in the `EXT_GSLB_CLUSTERS_GEO_TAGS` list during the start of the application so that no other changes to code are needed (=> backward compatible change)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>