### PR TITLE
Switch to CR_TOKEN with the workflow scope

### DIFF
--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: ${{ github.event.inputs.upstreamRepo }}
           path: sandbox
-          token: ${{ secrets.GH_OLM_TOKEN }}
+          token: ${{ secrets.CR_TOKEN }}
           fetch-depth: 0
 
       - name: Copy the generated manifests
@@ -65,7 +65,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GH_OLM_TOKEN }}
+          token: ${{ secrets.CR_TOKEN }}
           push-to-fork: k8gb-io/community-operators
           path: sandbox
           commit-message: OLM bundle for k8gb@${{ steps.get_version.outputs.bundleDir }}


### PR DESCRIPTION
OLM bundle workflow was red https://github.com/k8gb-io/k8gb/actions/runs/1470527367 with not enough access rights on the https://github.com/k8gb-io/community-operators repo

Use machine user with proper access rights to fix olm bundle  workflow

The pipe is green https://github.com/k8gb-io/k8gb/actions/runs/1470544948 and upstream PR created
https://github.com/k8s-operatorhub/community-operators/pull/409 
Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>