### PR TITLE
Add missing displayName + remove existing dir

### DIFF
--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -59,6 +59,7 @@ jobs:
       - name: Copy the generated manifests
         run: |
           mkdir -p $GITHUB_WORKSPACE/sandbox/operators/k8gb/
+          rm -rf $GITHUB_WORKSPACE/sandbox/operators/k8gb/${{ steps.get_version.outputs.bundleDir }} || true
           cp -r $GITHUB_WORKSPACE/bundle/ $GITHUB_WORKSPACE/sandbox/operators/k8gb/${{ steps.get_version.outputs.bundleDir }}
 
       - name: Open Pull Request

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -46,6 +46,7 @@ annotations:
     - kind: DNSEndpoint
       name: dnsendpoints.externaldns.k8s.io
       version: v1alpha1
+      displayName: DNSEndpoint
       description: Using ExternalDNS it synchronizes exposed Kubernetes Services and Ingresses with DNS providers
   artifacthub.io/crdsExamples: |
     - apiVersion: k8gb.absa.oss/v1beta1


### PR DESCRIPTION
missing `displayName: DNSEndpoint` was causing this:
![Screenshot 2021-11-18 at 09 45 58](https://user-images.githubusercontent.com/535866/142420392-fa292627-1b81-426c-a171-e72d449df44a.png)

Deleting the directory in the GHA is there because when trying to modify the existing bundle version (bundleVersion = "master") it would copy the content to that existing directory. But we want it to be replaced.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>