### PR TITLE
Fix helm docs for hostAliases entries

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -23,14 +23,17 @@ k8gb:
   clusterGeoTag: "eu"
   # -- comma-separated list of external gslb geo tags to pair with
   extGslbClustersGeoTags: "us"
-  # -- use https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ inside operator pod. Useful for advanced testing scenarios and to break dependency on EdgeDNS for cross k8gb collaboration
-  hostAliases:
+  # -- use [/etc/hosts](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/)
+  # inside operator pod. Useful for advanced testing scenarios and to break dependency on EdgeDNS for cross k8gb collaboration
+  # example: `[{"ip": "172.17.0.1", "hostnames": ["gslb-ns-us-cloud.example.com"]}]`
+  hostAliases: []
   #   - ip: "172.17.0.1"
   #     hostnames: 
   #      - "gslb-ns-us-cloud.example.com"
   #   - ip: "172.17.0.2"
   #     hostnames: 
   #      - "gslb-ns-eu-cloud.example.com"
+
   # -- Reconcile time in seconds
   reconcileRequeueSeconds: 30
   log:


### PR DESCRIPTION
this will produce:

```diff
 | k8gb.extGslbClustersGeoTags | string | `"us"` | comma-separated list of external gslb geo tags to pair with |
-| k8gb.hostAlias.enabled | bool | `false` | use https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/ inside operator pod. Useful for advanced testing scenarios and to break dependency on EdgeDNS for cross k8gb collaboration |
-| k8gb.hostAlias.hostnames[0] | string | `"gslb-ns-us-cloud.example.com"` |  |
-| k8gb.hostAlias.ip | string | `"172.17.0.1"` |  |
+| k8gb.hostAliases | list | `[]` | use [/etc/hosts](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) inside operator pod. Useful for advanced testing scenarios and to break dependency on EdgeDNS for cross k8gb collaboration example: `[{"ip": "172.17.0.1", "hostnames": ["gslb-ns-us-cloud.example.com"]}]` |
 | k8gb.imageRepo | string | `"absaoss/k8gb"` | image repository |
 | k8gb.imageTag |  string  | `nil` | image tag defaults to Chart.AppVersion, see Chart.yaml, but can be overrided with imageTag key |
 | k8gb.log.format | string | `"simple"` | log format (simple,json) |
```

(the empty line needs to be there to not merge those two comments)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>