### PR TITLE
LICENSE & README are required by artifacthub.io, so un-.helmignoring

### DIFF
--- a/chart/k8gb/.helmignore
+++ b/chart/k8gb/.helmignore
@@ -21,5 +21,3 @@
 *.tmproj
 .vscode/
 
-LICENSE
-README.md


### PR DESCRIPTION
`LICENSE & README` are used on artifacthub.io so putting them back

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>