### PR TITLE
Drop resolv.conf hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ REPO = absaoss/k8gb
 VALUES_YAML ?= ""
 PODINFO_IMAGE_REPO ?= ghcr.io/stefanprodan/podinfo
 HELM_ARGS ?=
-K8GB_COREDNS_IP ?= kubectl get svc k8gb-coredns -n k8gb -o custom-columns='IP:spec.clusterIP' --no-headers
+K8GB_COREDNS_IP ?= $(shell kubectl get svc k8gb-coredns -n k8gb -o custom-columns='IP:spec.clusterIP' --no-headers)
 LOG_FORMAT ?= simple
 LOG_LEVEL ?= debug
 CONTROLLER_GEN_VERSION  ?= v0.7.0
@@ -478,9 +478,9 @@ kubectl config use-context $1 > /dev/null
 endef
 
 define hit-testapp-host
-	kubectl run -it --rm busybox --restart=Never --image=busybox -- sh -c \
-	"echo 'nameserver `$(K8GB_COREDNS_IP)`' > /etc/resolv.conf && \
-	wget -qO - $1"
+	kubectl run -it --rm busybox --restart=Never --image=busybox --command \
+	--overrides='{"spec": {"dnsConfig": {"nameservers": ["$(K8GB_COREDNS_IP)"]}, \"dnsPolicy\": \"None\"}}' \
+	-- wget -qO - $1
 endef
 
 define init-test-strategy

--- a/terratest/utils/extensions.go
+++ b/terratest/utils/extensions.go
@@ -361,10 +361,10 @@ func (i *Instance) HitTestApp() (result *TestAppResult) {
 	require.True(i.w.t, i.w.state.testApp.isInstalled)
 	var err error
 	result = new(TestAppResult)
-	coreDDNSIP := i.GetCoreDNSIP()
-	command := fmt.Sprintf("echo nameserver %s > /etc/resolv.conf && wget -qO - %s", coreDDNSIP, i.w.state.gslb.host)
+	coreDNSIP := i.GetCoreDNSIP()
+	command := []string{"sh", "-c", fmt.Sprintf("wget -qO - %s", i.w.state.gslb.host)}
 	for t := 0; t < 3; t++ {
-		result.Body, err = RunBusyBoxCommand(i.w.t, i.w.k8sOptions, command)
+		result.Body, err = RunBusyBoxCommand(i.w.t, i.w.k8sOptions, coreDNSIP, command)
 		require.NoError(i.w.t, err, "busybox", command, result.Body)
 		if strings.HasPrefix(result.Body, "{") {
 			break


### PR DESCRIPTION
This commit drops resolv.conf hack and uses POD's dnsConfig instead

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>