### PR TITLE
Invoke the OLM pipeline from release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,3 +49,9 @@ jobs:
           args: release --rm-dist --release-notes=changes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Invoke workflow for OLM
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: OLM bundle and PR
+          token: ${{ secrets.CR_TOKEN }}
+          inputs: '{ "bundleVersion": "master" }'


### PR DESCRIPTION
manually tested on my fork: https://github.com/jkremser/k8gb/actions/workflows/test.yaml

this action will send [HTTP post](https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event) to trigger the workflow dispatch type of pipeline. This way we will still have a way to run the pipeline manually to hot-fix issues in OLM's manifests (no need to make a release for this).

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>