### PR TITLE
Unify make version and stick to 4.3 and later

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,14 @@ ifndef GOBIN
 GOBIN=$(shell go env GOPATH)/bin
 endif
 
+# Check Make version (we need at least GNU Make 4.3). Fortunately,
+# 'grouped-target' directive has been introduced exactly in GNU Make 4.3.
+ifeq ($(filter grouped-target,$(value .FEATURES)),)
+$(error Unsupported Make version. \
+    The build system does not work properly with GNU Make $(MAKE_VERSION), \
+    please use GNU Make 4.3 or above.)
+endif
+
 ###############################
 #		TARGETS
 ###############################

--- a/docs/local.md
+++ b/docs/local.md
@@ -21,6 +21,11 @@
     brew install gnu-sed
     ```
 
+- If you are on a Mac, install updated `make` with Homebrew (version 4.3 is required)
+    ```shell script
+    brew install make
+    ```
+
 - [Install **Docker**](https://docs.docker.com/get-docker/)
   > Ensure you are able to push/pull from your docker registry
 


### PR DESCRIPTION
On Mac make is quite old and produce unintended behaviour. This intends
to unify make across MacOS and Linux worlds.
```shell script
make --version
GNU Make 4.3
Built for x86_64-apple-darwin20.1.0
Copyright (C) 1988-2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

make
check                     Check project integrity
demo                      Execute end-to-end demo
deploy-full-local-setup   Deploy full local multicluster setup (k3d >= 4.2.0)
deploy-gslb-operator      Deploy k8gb operator
deploy-test-apps          Deploy Podinfo (example app) and Apply Gslb Custom Resources
deploy-test-version       Upgrade k8gb to the test version on existing clusters
destroy-full-local-setup  Destroy full local multicluster setup
dns-tools                 Run temporary dnstools pod for debugging DNS issues
help                      Show this help
```
```shell script
/usr/bin/make --version
GNU Make 3.81
Copyright (C) 2006  Free Software Foundation, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A
PARTICULAR PURPOSE.

This program built for i386-apple-darwin11.3.0

13:39:45 ❯ /usr/bin/make
Makefile:94: *** Unsupported Make version. The build system does not work properly with GNU Make 3.81, please use GNU Make 4.3 or above..  Stop.
```
Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>