### PR TITLE
.gitignoring file called 'changes' that's produced and consumed by goreleaser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _site
 
 # generated k3d configs
 k3d/test-gslb[!1-3].yaml
+
+# Required by goreleaser
+changes


### PR DESCRIPTION
This entry was removed from the .gitignore recently, but it needs to be there for the release process to finish w/o errors.

We create the file here: https://github.com/k8gb-io/k8gb/blob/master/.github/workflows/release.yaml#L27

and consume it within the same action couple of steps later here: https://github.com/k8gb-io/k8gb/blob/master/.github/workflows/release.yaml#L49

But if it's not ignored, the goreleaser fails on this issue: https://github.com/k8gb-io/k8gb/runs/4372363917?check_suite_focus=true#step:8:23
because the git is in dirty state (there are untracked files). Other workaround would be copying that file somewhere else on that filesystem, but it's imho better to `.gitignore` it as it was before.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>