### PR TITLE
Revert "RELEASE: v0.8.5 (#776)"

### DIFF
--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -3,8 +3,8 @@ name: k8gb
 description: A Helm chart for Kubernetes Global Balancer
 icon: https://www.k8gb.io/assets/images/icon-192x192.png
 type: application
-version: v0.8.5
-appVersion: v0.8.5
+version: v0.8.4
+appVersion: v0.8.4
 
 dependencies:
   - name: coredns


### PR DESCRIPTION
Release of 0.8.5 didn't go well, because of this [issue](https://github.com/k8gb-io/k8gb/runs/4372363917?check_suite_focus=true#step:8:23)

remedy here: https://github.com/k8gb-io/k8gb/pull/778
so once the #778 is merged, I think we should be able to release again (until then the releasing is broken)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>