### PR TITLE
Run terratests for upgrade testing against only 2 clusters

### DIFF
--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -52,17 +52,11 @@ jobs:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
 
-      - name: Create 3rd k3s Cluster
-        uses: AbsaOSS/k3d-action@v2
-        with:
-          cluster-name: "test-gslb3"
-          args: -c k3d/test-gslb3.yaml
-
       - name: K8GB deploy stable version
-        run: make deploy-stable-version list-running-pods CLUSTERS_NUMBER=3
+        run: make deploy-stable-version list-running-pods
 
       - name: K8GB deploy test version
-        run: make deploy-test-version list-running-pods CLUSTERS_NUMBER=3
+        run: make deploy-test-version list-running-pods
 
       - name: Terratest
         run: make terratest


### PR DESCRIPTION
We test round-robin strategy against 3 clusters in https://github.com/k8gb-io/k8gb/blob/master/.github/workflows/terratest-more-clusters.yaml#L49:L73 so there is no need to do that also in here. In fact it's little bit "undef land" to run failover tests against 3 or more interconnected clusters.



Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>