### PR TITLE
Add Makefile target for building the website for netlify pr preview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,12 @@ else
 	@echo "Local generation requires a GitHub PAT token with the 'public_repo' scope (https://github.com/settings/tokens/new)."
 	@echo "The token should be assigned to the JEKYLL_GITHUB_TOKEN environment variable."
 endif
+
+# Used by netlify to prepare the PR preview
+.PHONY: website
+website:
+	@if [ "$(CI)" = "true" ]; then\
+		mv CNAME EMANC ;\
+		bundle install ;\
+		bundle exec jekyll build ;\
+	fi

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  command = "make website"
+  publish = "_site/"
+


### PR DESCRIPTION
Deploy the previews of our website also for pull-requests opened against the `gh-pages` branch. These can contain changes to CSS, layout, etc. and it would be nice to have a way to check them too before merging (w/o the need to deploy the stuff locally for reviewer).

If/once this get merged I will open a follow-up PR that removes the redundant code from [here](https://github.com/k8gb-io/k8gb/blob/v0.8.6/Makefile#L442:L444) and call this target instead.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>