### PR TITLE
(un)deploying prometheus is broken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -553,7 +553,7 @@ define deploy-prometheus
 	helm -n k8gb upgrade -i prometheus prometheus-community/prometheus -f deploy/prometheus/values.yaml \
 		--version 14.2.0 \
 		--wait --timeout=2m0s \
-		--kube-context=k3d-$1 ;
+		--kube-context=k3d-$1
 endef
 
 define uninstall-prometheus
@@ -561,5 +561,5 @@ define uninstall-prometheus
 	echo "\n$(YELLOW)uninstall prometheus $(NC)" ;\
 	helm uninstall prometheus -n k8gb --kube-context=k3d-$1 ;\
 	kubectl annotate pods -l name=k8gb -n k8gb prometheus.io/scrape- --context=k3d-$1 ;\
-	kubectl annotate pods -l name=k8gb -n k8gb prometheus.io/port- --context=k3d-$1 ;
+	kubectl annotate pods -l name=k8gb -n k8gb prometheus.io/port- --context=k3d-$1
 endef


### PR DESCRIPTION
before:
```
make deploy-prometheus deploy-grafana
/bin/sh: -c: line 0: syntax error near unexpected token `;'
/bin/sh: -c: line 0: `for c in 1 2; do 		echo "\n\033[0;33mLocal cluster \033[1;36mtest-gslb$c\033[0m" ; echo "\n\033[0;33mSet annotations on pods that will be scraped by prometheus\033[0m" ; kubectl annotate pods -l name=k8gb -n k8gb --overwrite prometheus.io/scrape="true" --context=k3d-test-gslb$c ; kubectl annotate pods -l name=k8gb -n k8gb --overwrite prometheus.io/port="8080" --context=k3d-test-gslb$c ; echo "\n\033[0;33minstall prometheus \033[0m" ; helm repo add prometheus-community https://prometheus-community.github.io/helm-charts ; helm repo update ; helm -n k8gb upgrade -i prometheus prometheus-community/prometheus -f deploy/prometheus/values.yaml --version 14.2.0 --wait --timeout=2m0s --kube-context=k3d-test-gslb$c ; ;done'
make: *** [deploy-prometheus] Error 2
```

after:
```
make deploy-prometheus deploy-grafana

Local cluster test-gslb1

Set annotations on pods that will be scraped by prometheus
pod/k8gb-fdb8d8894-wthzw annotated
pod/k8gb-fdb8d8894-wthzw annotated
...
```

(sorry, looks like I broke it)

this PR fixes the makefile, but it still fails to start because of:

```
k8gb          0s          Normal    FailedBinding             persistentvolumeclaim/prometheus-server              no persistent volumes available for this claim and no storage class is set
```
^ prolly caused by https://github.com/k8gb-io/k8gb/commit/c36c2256e23e01f22f14a65f9d7964e101797646#diff-9a834bbeb50f074ae6a033fd21ed1840bb7363625dc52a43d1d45c1925c8803c