### PR TITLE
Fix Grafana makefile target (use correct cluster name)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,17 +250,14 @@ uninstall-prometheus:
 
 .PHONY: deploy-grafana
 deploy-grafana:
-	@echo "\n$(YELLOW)Local cluster $(CYAN)$(CLUSTER_GSLB1)$(NC)"
+	@echo "\n$(YELLOW)Local cluster $(CYAN)$(CLUSTER_NAME)1$(NC)"
 	@echo "\n$(YELLOW)install grafana $(NC)"
-	@$(eval PREVIOUS_CONTEXT := $(shell kubectl config current-context))
 	helm repo add grafana https://grafana.github.io/helm-charts
 	helm repo update
 	helm -n k8gb upgrade -i grafana grafana/grafana -f deploy/grafana/values.yaml \
-		--wait --timeout=2m0s \
-		--kube-context=k3d-$(CLUSTER_GSLB1)
-	kubectl config use-context k3d-$(CLUSTER_GSLB1)
-	kubectl apply -f deploy/grafana/dashboard-cm.yaml -n k8gb
-	@kubectl config use-context $(PREVIOUS_CONTEXT)
+		--wait --timeout=2m30s \
+		--kube-context=k3d-$(CLUSTER_NAME)1
+	kubectl --context k3d-$(CLUSTER_NAME)1 apply -f deploy/grafana/dashboard-cm.yaml -n k8gb
 	@echo "\nGrafana is listening on http://localhost:3000\n"
 	@echo "🖖 credentials are admin:admin\n"
 
@@ -269,11 +266,8 @@ deploy-grafana:
 uninstall-grafana:
 	@echo "\n$(YELLOW)Local cluster $(CYAN)$(CLUSTER_GSLB1)$(NC)"
 	@echo "\n$(YELLOW)uninstall grafana $(NC)"
-	@$(eval PREVIOUS_CONTEXT := $(shell kubectl config current-context))
-	kubectl config use-context k3d-$(CLUSTER_GSLB1)
-	-kubectl delete -f deploy/grafana/dashboard-cm.yaml
-	@kubectl config use-context $(PREVIOUS_CONTEXT)
-	helm uninstall grafana -n k8gb --kube-context=k3d-$(CLUSTER_GSLB1)
+	kubectl --context k3d-$(CLUSTER_NAME)1 delete -f deploy/grafana/dashboard-cm.yaml -n k8gb
+	helm uninstall grafana -n k8gb --kube-context=k3d-$(CLUSTER_NAME)1
 
 .PHONY: dns-tools
 dns-tools: ## Run temporary dnstools pod for debugging DNS issues


### PR DESCRIPTION
Fix #796

my bad, I am pretty sure I was updating this, but it was probably lost during conflict resolutions

```bash
❯ make deploy-grafana

Local cluster test-gslb1

install grafana
helm repo add grafana https://grafana.github.io/helm-charts
"grafana" already exists with the same configuration, skipping
helm repo update
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "k8gb" chart repository
...Successfully got an update from the "podinfo" chart repository
...Successfully got an update from the "crossplane-alpha" chart repository
...Successfully got an update from the "nginx-stable" chart repository
...Successfully got an update from the "crossplane-stable" chart repository
...Successfully got an update from the "grafana" chart repository
...Successfully got an update from the "prometheus-community" chart repository
Update Complete. ⎈Happy Helming!⎈
helm -n k8gb upgrade -i grafana grafana/grafana -f deploy/grafana/values.yaml \
	--wait --timeout=2m30s \
	--kube-context=k3d-test-gslb1
W1209 19:51:55.545645   24958 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1209 19:51:55.551626   24958 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1209 19:51:55.562716   24958 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1209 19:51:55.566113   24958 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1209 19:51:55.569463   24958 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
W1209 19:51:55.574458   24958 warnings.go:70] policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
Release "grafana" has been upgraded. Happy Helming!
NAME: grafana
LAST DEPLOYED: Thu Dec  9 19:51:55 2021
NAMESPACE: k8gb
STATUS: deployed
REVISION: 2
NOTES:
1. Get your 'admin' user password by running:

   kubectl get secret --namespace k8gb grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo

2. The Grafana server can be accessed via port 3000 on the following DNS name from within your cluster:

   grafana.k8gb.svc.cluster.local

   Get the Grafana URL to visit by running these commands in the same shell:
export NODE_PORT=$(kubectl get --namespace k8gb -o jsonpath="{.spec.ports[0].nodePort}" services grafana)
     export NODE_IP=$(kubectl get nodes --namespace k8gb -o jsonpath="{.items[0].status.addresses[0].address}")
     echo http://$NODE_IP:$NODE_PORT


3. Login with the password from step 1 and the username: admin
#################################################################################
######   WARNING: Persistence is disabled!!! You will lose your data when   #####
######            the Grafana pod is terminated.                            #####
#################################################################################
kubectl --context k3d-test-gslb1 apply -f deploy/grafana/dashboard-cm.yaml -n k8gb
configmap/podinfo-dashboard unchanged

Grafana is listening on http://localhost:3000

🖖 credentials are admin:admin
```

..there are some warnings about PodSecurityPolicy being deprecated, updating the chart can help, I can look into that later on

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>