### PR TITLE
Prometheus on emptyDir volumes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,10 @@ The deployed Prometheus scrapes metrics from the dedicated k8gb operator endpoin
 - http://127.0.0.1:9080
 - http://127.0.0.1:9081
 
+All the metric data is ephemeral and will be lost with pod restarts.
 To uninstall Prometheus, run `make uninstall-prometheus`
+
+Optionally, you can also install Grafana that will have the datasources configured and example dashboard ready using `make deploy-grafana`
 
 ## Code style
 

--- a/deploy/prometheus/values.yaml
+++ b/deploy/prometheus/values.yaml
@@ -1,5 +1,7 @@
 server:
   enabled: true
+  persistentVolume:
+    enabled: false # emptyDir, all data is lost when pod restarts
   service:
     nodePort: 30090 # allowed port range between 30000 and 32768
     servicePort: 9090


### PR DESCRIPTION
More light-weight approach that doesn't require persistent volumes. On the other hand all the data is ephemeral.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>