### PR TITLE
Fix coredns based exposure

### DIFF
--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -99,7 +99,7 @@ spec:
             - name: EXTDNS_ENABLED
               value: "true"
             {{- end }}
-            {{- if eq "LoadBalancer" ( quote .Values.coredns.serviceType ) }}
+            {{- if eq "LoadBalancer" quote .Values.coredns.serviceType }}
             - name: COREDNS_EXPOSED
               value: "true"
             {{- end }}


### PR DESCRIPTION
The issue was detected with AWS reference setup

* The condition was not working as expected
* It led to degraded state when we expected `k8gb-ns-*` DNSEndpoint
  IP addresses to be populated with exposed coredns service ip addresses
  Instead it was not detecting the rule and was populated by Ingress IPs
  creating non-obvious mess in the configuration.

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>