### PR TITLE
kube-linter pipeline and helm template fix

### DIFF
--- a/.github/workflows/kube-linter.yaml
+++ b/.github/workflows/kube-linter.yaml
@@ -15,8 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Scan repo
+
+      - name: Create ../results directory for sarif files
+        shell: bash
+        run: mkdir -p ../results
+
+      - name: Scan k8gb chart
         id: kube-lint-repo
-        uses: stackrox/kube-linter-action@v1.0.2
+        uses: stackrox/kube-linter-action@v1
         with:
-          directory: chart
+          directory: chart/k8gb
+          version: 0.2.5
+          format: sarif
+          output-file: ../results/kube-linter.sarif
+
+      - name: Upload sarif output to GitHub
+        uses: github/codeql-action/upload-sarif@v1
+        continue-on-error: true

--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -1,5 +1,5 @@
----
 {{- if or .Values.ns1.enabled .Values.route53.enabled .Values.rfc2136.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/chart/k8gb/templates/operator.yaml
+++ b/chart/k8gb/templates/operator.yaml
@@ -99,7 +99,7 @@ spec:
             - name: EXTDNS_ENABLED
               value: "true"
             {{- end }}
-            {{- if eq "LoadBalancer" quote .Values.coredns.serviceType }}
+            {{- if eq "LoadBalancer" ( toString .Values.coredns.serviceType ) }}
             - name: COREDNS_EXPOSED
               value: "true"
             {{- end }}


### PR DESCRIPTION
Fixes #800 

- Updated kuber-linter-actions to v1 (=v1.0.4)
- Fixed kube-linter version to 0.2.5
- Added support for [sarif analysis](https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github)
- Fixed problematic helm templates

kudos to @jkremser for finding the [proper fix for `COREDNS_EXPOSED` env var rendering](https://github.com/k8gb-io/k8gb/pull/799#issuecomment-992956154)!


Signed-off-by: Timofey Ilinykh <ilinytim@gmail.com>
Co-authored-by: Yury Tsarev <yury.tsarev@absa.africa>
