### PR TITLE
Add histogram metrics for infoblox calls

### DIFF
--- a/controllers/providers/metrics/prometheus_result.go
+++ b/controllers/providers/metrics/prometheus_result.go
@@ -26,7 +26,7 @@ type MetricResult struct {
 	value prometheus.Collector
 }
 
-// Get gets actual copy of metric defined by it's name
+// Get gets actual copy of metric defined by its name
 func (m *PrometheusMetrics) Get(name string) (r *MetricResult) {
 	return &MetricResult{value: m.registry()[name]}
 }

--- a/controllers/providers/metrics/prometheus_test.go
+++ b/controllers/providers/metrics/prometheus_test.go
@@ -77,8 +77,8 @@ func TestPrometheusRegistry(t *testing.T) {
 	items := []string{K8gbGslbErrorsTotal, K8gbGslbHealthyRecords, K8gbGslbReconciliationLoopsTotal,
 		K8gbGslbServiceStatusNum, K8gbGslbStatusCountForFailover, K8gbGslbStatusCountForRoundrobin,
 		K8gbGslbStatusCountForGeoIP, K8gbInfobloxHeartbeatsTotal, K8gbInfobloxHeartbeatErrorsTotal,
-		K8gbInfobloxZoneUpdatesTotal, K8gbInfobloxZoneUpdateErrorsTotal, K8gbEndpointStatusNum,
-		K8gbRuntimeInfo}
+		K8gbInfobloxRequestDuration, K8gbInfobloxZoneUpdatesTotal, K8gbInfobloxZoneUpdateErrorsTotal,
+		K8gbEndpointStatusNum, K8gbRuntimeInfo}
 	// act
 	registry := m.registry()
 	// assert


### PR DESCRIPTION
Fix issue #713

Introducing a new metric called `k8gb_infoblox_request_duration_bucket` of type histogram with labels:
- request (name of the method that was called on infoblox client ~ those CRUD methods for txt record and zone delegation call)
- success (true/false) did the call ended up ok?

It's a histogram, so it splits the space into buckets (in our case it's exponential scale - [0 -.2], [.2 -.8] , [.8 - 3.2], [3.2 - 12.8], [12.8 - 51.2], [51.2- infinity]) and the value of the metric denotes the number of hits that fell into that buckets, i.e. how many calls took that many seconds.
+ there are two special records w/ `_sum` and `_count` prefix to be able to calculate mean and what not

Note: I did not use the common labels we have on gauge metrics (gslb name and namespace), because I don't think they are useful in this context and the "combinatoric explosion" w/ all the possible vector(/label) values would be too huge.

`ibclient` was renamed to `ibcl` because the line were too long and linter was not happy about it

I did some manual testing and it looks like this:

```
bash-5.1# curl 10.42.0.7:8080/metrics | grep infoblo
# HELP k8gb_infoblox_request_duration How long it took for Infoblox requests to complete, partitioned by request type. Round-trip time of http communication is included.
# TYPE k8gb_infoblox_request_duration histogram
k8gb_infoblox_request_duration_bucket{request="TXTRecordCreate",success="false",le="0.2"} 0
k8gb_infoblox_request_duration_bucket{request="TXTRecordCreate",success="false",le="0.8"} 0
k8gb_infoblox_request_duration_bucket{request="TXTRecordCreate",success="false",le="3.2"} 1
k8gb_infoblox_request_duration_bucket{request="TXTRecordCreate",success="false",le="12.8"} 1
k8gb_infoblox_request_duration_bucket{request="TXTRecordCreate",success="false",le="51.2"} 2
k8gb_infoblox_request_duration_bucket{request="TXTRecordCreate",success="false",le="+Inf"} 3
k8gb_infoblox_request_duration_sum{request="TXTRecordCreate",success="false"} 221.0000727
k8gb_infoblox_request_duration_count{request="TXTRecordCreate",success="false"} 3
k8gb_infoblox_request_duration_bucket{request="TXTRecordDelete",success="false",le="0.2"} 0
k8gb_infoblox_request_duration_bucket{request="TXTRecordDelete",success="false",le="0.8"} 0
k8gb_infoblox_request_duration_bucket{request="TXTRecordDelete",success="false",le="3.2"} 1
k8gb_infoblox_request_duration_bucket{request="TXTRecordDelete",success="false",le="12.8"} 1
k8gb_infoblox_request_duration_bucket{request="TXTRecordDelete",success="false",le="51.2"} 2
k8gb_infoblox_request_duration_bucket{request="TXTRecordDelete",success="false",le="+Inf"} 3
k8gb_infoblox_request_duration_sum{request="TXTRecordDelete",success="false"} 221.00009020000002
k8gb_infoblox_request_duration_count{request="TXTRecordDelete",success="false"} 3
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="false",le="0.2"} 0
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="false",le="0.8"} 1
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="false",le="3.2"} 6
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="false",le="12.8"} 6
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="false",le="51.2"} 10
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="false",le="+Inf"} 13
k8gb_infoblox_request_duration_sum{request="TXTRecordUpdate",success="false"} 718.3002365
k8gb_infoblox_request_duration_count{request="TXTRecordUpdate",success="false"} 13
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="true",le="0.2"} 0
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="true",le="0.8"} 0
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="true",le="3.2"} 0
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="true",le="12.8"} 0
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="true",le="51.2"} 2
k8gb_infoblox_request_duration_bucket{request="TXTRecordUpdate",success="true",le="+Inf"} 3
k8gb_infoblox_request_duration_sum{request="TXTRecordUpdate",success="true"} 300.0000806
k8gb_infoblox_request_duration_count{request="TXTRecordUpdate",success="true"} 3
```

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>