### PR TITLE
OpenShift support: add permission on ingress finalizer in k8gb rbac

### DIFF
--- a/chart/k8gb/templates/role.yaml
+++ b/chart/k8gb/templates/role.yaml
@@ -46,4 +46,10 @@ rules:
   verbs:
   - create
   - update
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses/finalizers
+  verbs:
+  - update
 {{- end }}


### PR DESCRIPTION
When creating an ingress resource (networking.k8s.io/v1) with annotations in OpenShift, k8gb does not create the corresponding gslb and logs the following error message:

`ERR github.com/AbsaOSS/k8gb/controllers/gslb_controller.go:311 > Glsb creation failed error="gslbs.k8gb.absa.oss \"frontend-podinfo\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"`

This fix grants the update permission on ingresses/finalizers in the k8gb ClusterRole so that Ingress resources can be used in OpenShift.

Tested on: OpenShift 4.8.25

Signed-off-by: Nicolas Smith <nicolasasmith@gmail.com>