### PR TITLE
helm: finer control over what is going to be deployed

### DIFF
--- a/chart/k8gb/templates/coredns-cm.yaml
+++ b/chart/k8gb/templates/coredns-cm.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.coredns.deployment.enabled }}
 kind: ConfigMap
 metadata:
   labels:
@@ -19,3 +20,4 @@ data:
             negttl {{ .Values.k8gb.dnsZoneNegTTL }}
         }
     }
+{{- end }}

--- a/chart/k8gb/templates/coredns/rbac.yaml
+++ b/chart/k8gb/templates/coredns/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.coredns.deployment.enabled .Values.coredns.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -31,3 +32,4 @@ subjects:
 - kind: ServiceAccount
   name: coredns
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/chart/k8gb/templates/crds/dns-endpoint-crd-manifest.yaml
+++ b/chart/k8gb/templates/crds/dns-endpoint-crd-manifest.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.k8gb.deployCrds }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -91,3 +92,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml
+++ b/chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml
@@ -1,4 +1,4 @@
-
+{{- if .Values.k8gb.deployCrds }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -320,3 +320,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/chart/k8gb/templates/role.yaml
+++ b/chart/k8gb/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.k8gb.deployRbac }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -52,4 +53,5 @@ rules:
   - ingresses/finalizers
   verbs:
   - update
+{{- end }}
 {{- end }}

--- a/chart/k8gb/templates/role_binding.yaml
+++ b/chart/k8gb/templates/role_binding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.k8gb.deployRbac }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -10,3 +11,4 @@ roleRef:
   kind: ClusterRole
   name: k8gb
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/chart/k8gb/templates/service_account.yaml
+++ b/chart/k8gb/templates/service_account.yaml
@@ -1,6 +1,8 @@
+{{- if .Values.k8gb.deployRbac }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: k8gb
   namespace: {{ .Release.Namespace }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -9,6 +9,10 @@ k8gb:
   imageRepo: "absaoss/k8gb"
   # -- ( string ) image tag defaults to Chart.AppVersion, see Chart.yaml, but can be overrided with imageTag key
   imageTag:
+  # -- whether it should also deploy the gslb and dnsendpoints CRDs
+  deployCrds: true
+  # -- whether it should also deploy the service account, cluster role and cluster role binding
+  deployRbac: true
   # -- dnsZone controlled by gslb
   dnsZone: "cloud.example.com"
   # -- Negative TTL for SOA record
@@ -19,7 +23,7 @@ k8gb:
   edgeDNSServers:
       # -- use this DNS server as a main resolver to enable cross k8gb DNS based communication
       - "1.1.1.1"
-  # -- used for places where we need to distinguish between differnet Gslb instances
+  # -- used for places where we need to distinguish between different Gslb instances
   clusterGeoTag: "eu"
   # -- comma-separated list of external gslb geo tags to pair with
   extGslbClustersGeoTags: "us"


### PR DESCRIPTION
 * Respect the coredns values (`coredns.deployment.enabled` & `coredns.rbac.create`)
 * control whether crds (`k8gb.deployCrds`) and/or rbac (`k8gb.deployRbac`) for k8gb should be deployed

Main reason for this change is that I would like to add a terratest for a new feature I am working on (optimisation 2 described in https://github.com/k8gb-io/k8gb/issues/720) and currently it is not possible to deploy the k8gb AGAIN in the same cluster to a different namespace. I know that the behavior might be undef, because two controllers will be fighting against each other for the C~R~UD events. But I want to test only the startup of the operator and if it's able to recognize the labels on node and set the geo tag appropriately. Unfortunatelly, I can't do that w/ current helm chart, because some resources are created globaly in the default namespace (crd, cluster role and cluster role binding). This PR aims to make the deployment of these "global" resources optional. We choose not to be opinionated about the deployment mechanisms people can have so making it more configurable can't hurt.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>