### PR TITLE
Fix typo in gslb crd examples in readme and helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Just a single Gslb CRD to enable the Global Load Balancing:
 ```yaml
 apiVersion: k8gb.absa.oss/v1beta1
 kind: Gslb
-metada:
+metadata:
   name: test-gslb-failover
   namespace: test-gslb
 spec:

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -51,7 +51,7 @@ annotations:
   artifacthub.io/crdsExamples: |
     - apiVersion: k8gb.absa.oss/v1beta1
       kind: Gslb
-      metada:
+      metadata:
         name: test-gslb-failover
         namespace: test-gslb
       spec:


### PR DESCRIPTION
Fix typo in gslb crd examples in the readme file and in the artifacthub.io/crdsExamples annotation in the Helm chart.

Signed-off-by: Nicolas Smith <nicolasasmith@gmail.com>