### PR TITLE
Switching of licence headers from 2021 to 2022

### DIFF
--- a/.golic.yaml
+++ b/.golic.yaml
@@ -16,7 +16,7 @@
 golic:
   licenses:
     apache2: |
-        Copyright 2021 The k8gb Contributors.
+        Copyright 2022 The k8gb Contributors.
 
         Licensed under the Apache License, Version 2.0 (the "License");
         you may not use this file except in compliance with the License.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 The k8gb Contributors.
+# Copyright 2022 The k8gb Contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 The k8gb Contributors.
+# Copyright 2022 The k8gb Contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -7,7 +7,7 @@
 package depresolver
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -1,7 +1,7 @@
 package depresolver
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/depresolver/depresolver_spec.go
+++ b/controllers/depresolver/depresolver_spec.go
@@ -1,7 +1,7 @@
 package depresolver
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/depresolver/depresolver_test.go
+++ b/controllers/depresolver/depresolver_test.go
@@ -1,7 +1,7 @@
 package depresolver
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/depresolver/depresolver_validator.go
+++ b/controllers/depresolver/depresolver_validator.go
@@ -1,7 +1,7 @@
 package depresolver
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -1,7 +1,7 @@
 package controllers
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/finalize.go
+++ b/controllers/finalize.go
@@ -1,7 +1,7 @@
 package controllers
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -1,7 +1,7 @@
 package controllers
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -1,7 +1,7 @@
 package controllers
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/ingress.go
+++ b/controllers/ingress.go
@@ -1,7 +1,7 @@
 package controllers
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/annotations.go
+++ b/controllers/internal/utils/annotations.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/annotations_test.go
+++ b/controllers/internal/utils/annotations_test.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/dns.go
+++ b/controllers/internal/utils/dns.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/dns_test.go
+++ b/controllers/internal/utils/dns_test.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/fakedns.go
+++ b/controllers/internal/utils/fakedns.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/fakedns_test.go
+++ b/controllers/internal/utils/fakedns_test.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/reconciler_result.go
+++ b/controllers/internal/utils/reconciler_result.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/reflection.go
+++ b/controllers/internal/utils/reflection.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/reflection_test.go
+++ b/controllers/internal/utils/reflection_test.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/regex.go
+++ b/controllers/internal/utils/regex.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/regex_test.go
+++ b/controllers/internal/utils/regex_test.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/internal/utils/yaml.go
+++ b/controllers/internal/utils/yaml.go
@@ -2,7 +2,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/logging/log.go
+++ b/controllers/logging/log.go
@@ -1,7 +1,7 @@
 package logging
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/logging/logr.go
+++ b/controllers/logging/logr.go
@@ -1,7 +1,7 @@
 package logging
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/logging/singleton.go
+++ b/controllers/logging/singleton.go
@@ -1,7 +1,7 @@
 package logging
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/assistant/assistant.go
+++ b/controllers/providers/assistant/assistant.go
@@ -1,7 +1,7 @@
 package assistant
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/assistant/assistant_mock.go
+++ b/controllers/providers/assistant/assistant_mock.go
@@ -5,7 +5,7 @@
 package assistant
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/assistant/gslb.go
+++ b/controllers/providers/assistant/gslb.go
@@ -1,7 +1,7 @@
 package assistant
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/dns.go
+++ b/controllers/providers/dns/dns.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/dns_mock.go
+++ b/controllers/providers/dns/dns_mock.go
@@ -5,7 +5,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/empty.go
+++ b/controllers/providers/dns/empty.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/external.go
+++ b/controllers/providers/dns/external.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/external_test.go
+++ b/controllers/providers/dns/external_test.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/factory.go
+++ b/controllers/providers/dns/factory.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/factory_test.go
+++ b/controllers/providers/dns/factory_test.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/infoblox-client.go
+++ b/controllers/providers/dns/infoblox-client.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/infoblox-client_mock.go
+++ b/controllers/providers/dns/infoblox-client_mock.go
@@ -5,7 +5,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/infoblox-connection_mock.go
+++ b/controllers/providers/dns/infoblox-connection_mock.go
@@ -5,7 +5,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/infoblox-sort.go
+++ b/controllers/providers/dns/infoblox-sort.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/infoblox.go
+++ b/controllers/providers/dns/infoblox.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/dns/infoblox_test.go
+++ b/controllers/providers/dns/infoblox_test.go
@@ -1,7 +1,7 @@
 package dns
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/metrics/prometheus.go
+++ b/controllers/providers/metrics/prometheus.go
@@ -1,7 +1,7 @@
 package metrics
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/metrics/prometheus_result.go
+++ b/controllers/providers/metrics/prometheus_result.go
@@ -1,7 +1,7 @@
 package metrics
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/metrics/prometheus_test.go
+++ b/controllers/providers/metrics/prometheus_test.go
@@ -1,7 +1,7 @@
 package metrics
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/providers/metrics/singleton.go
+++ b/controllers/providers/metrics/singleton.go
@@ -1,7 +1,7 @@
 package metrics
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -1,7 +1,7 @@
 package controllers
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/deploy/test-apps/curldemo/Dockerfile
+++ b/deploy/test-apps/curldemo/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 The k8gb Contributors.
+# Copyright 2022 The k8gb Contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deploy/test-apps/curldemo/Makefile
+++ b/deploy/test-apps/curldemo/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 The k8gb Contributors.
+# Copyright 2022 The k8gb Contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/examples/route53/Makefile
+++ b/docs/examples/route53/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2021 The k8gb Contributors.
+# Copyright 2022 The k8gb Contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate.go.txt
+++ b/hack/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 package main
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/init.go
+++ b/terratest/test/init.go
@@ -1,7 +1,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/k8gb_abstract_full_roundrobin_test.go
+++ b/terratest/test/k8gb_abstract_full_roundrobin_test.go
@@ -1,7 +1,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/k8gb_basic_app_test.go
+++ b/terratest/test/k8gb_basic_app_test.go
@@ -3,7 +3,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/k8gb_failover_playground_test.go
+++ b/terratest/test/k8gb_failover_playground_test.go
@@ -3,7 +3,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/k8gb_full_failover_test.go
+++ b/terratest/test/k8gb_full_failover_test.go
@@ -3,7 +3,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/k8gb_full_roundrobin_test.go
+++ b/terratest/test/k8gb_full_roundrobin_test.go
@@ -3,7 +3,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/k8gb_ingress_annotation_failover_test.go
+++ b/terratest/test/k8gb_ingress_annotation_failover_test.go
@@ -3,7 +3,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/k8gb_ingress_annotation_rr_test.go
+++ b/terratest/test/k8gb_ingress_annotation_rr_test.go
@@ -3,7 +3,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/k8gb_lifecycle_test.go
+++ b/terratest/test/k8gb_lifecycle_test.go
@@ -3,7 +3,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/test/k8gb_split_failover_test.go
+++ b/terratest/test/k8gb_split_failover_test.go
@@ -3,7 +3,7 @@
 package test
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/utils/extensions.go
+++ b/terratest/utils/extensions.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/utils/test_settings.go
+++ b/terratest/utils/test_settings.go
@@ -1,7 +1,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/terratest/utils/utils.go
+++ b/terratest/utils/utils.go
@@ -2,7 +2,7 @@
 package utils
 
 /*
-Copyright 2021 The k8gb Contributors.
+Copyright 2022 The k8gb Contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
```shell
golic remove -t apache2
# editing year in .golic.yaml
golic inject -t apache2
```
Signed-off-by: kuritka <kuritka@gmail.com>