### PR TITLE
Fix log message for strategy annotation detection

### DIFF
--- a/controllers/gslb_controller.go
+++ b/controllers/gslb_controller.go
@@ -320,9 +320,9 @@ func (r *GslbReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				if annotationKey == strategyAnnotation {
 					switch annotationValue {
 					case roundRobinStrategy:
-						createGslbFromIngress(annotationKey, annotationKey, a, roundRobinStrategy)
+						createGslbFromIngress(annotationKey, annotationValue, a, roundRobinStrategy)
 					case failoverStrategy:
-						createGslbFromIngress(annotationKey, annotationKey, a, failoverStrategy)
+						createGslbFromIngress(annotationKey, annotationValue, a, failoverStrategy)
 					}
 				}
 			}


### PR DESCRIPTION
- Fixed strategy type display in the "Detected strategy annotation..."
  log message:
  before the fix:
  "... annotation=(k8gb.io/strategy:k8gb.io/strategy) ..."
  after the fix:
  "... annotation=(k8gb.io/strategy:failover) ..."

Signed-off-by: Timofey Ilinykh <ilinytim@gmail.com>