### PR TITLE
unset deprecated envvars

### DIFF
--- a/controllers/depresolver/depresolver_test.go
+++ b/controllers/depresolver/depresolver_test.go
@@ -1442,6 +1442,8 @@ func cleanup() {
 }
 
 func configureEnvVar(config Config) {
+	_ = os.Unsetenv(EdgeDNSServerKey)
+	_ = os.Unsetenv(EdgeDNSServerPortKey)
 	_ = os.Setenv(ReconcileRequeueSecondsKey, strconv.Itoa(config.ReconcileRequeueSeconds))
 	_ = os.Setenv(ClusterGeoTagKey, config.ClusterGeoTag)
 	_ = os.Setenv(ExtClustersGeoTagsKey, strings.Join(config.ExtClustersGeoTags, ","))


### PR DESCRIPTION
resolves #835

`EDGE_DNS_SERVER`, `EDGE_DNS_SERVER_PORT` are deprecated.
We still keep them because of previous versions of k8gb and set
them explicitly in tests. We have several tests which are inspecting deprecated variables, and count with them to be initially unset. Such tests creates and assert them if needed.

This patch ensures that the variables will not be set before running the tests.
I tested with all supported environment variables in `.env` file:

```env
RECONCILE_REQUEUE_SECONDS=dummy
CLUSTER_GEO_TAG=dummy
EXT_GSLB_CLUSTERS_GEO_TAGS=dummy
EXTDNS_ENABLED=dummy
EDGE_DNS_SERVERS=dummy
EDGE_DNS_ZONE=dummy
DNS_ZONE=dummy
INFOBLOX_GRID_HOST=dummy
INFOBLOX_WAPI_VERSION=dummy
INFOBLOX_WAPI_PORT=dummy
INFOBLOX_WAPI_USERNAME=dummy
INFOBLOX_WAPI_PASSWORD=dummy
INFOBLOX_HTTP_REQUEST_TIMEOUT=dummy
INFOBLOX_HTTP_POOL_CONNECTIONS=dummy
POD_NAMESPACE=dummy
COREDNS_EXPOSED=dummy
LOG_LEVEL=dummy
LOG_FORMAT=dummy
NO_COLOR=dummy
SPLIT_BRAIN_CHECK=dummy
METRICS_ADDRESS=dummy
EDGE_DNS_SERVER=8.8.8.8
EDGE_DNS_SERVER_PORT=53
```

Signed-off-by: kuritka <kuritka@gmail.com>