### PR TITLE
PATCH: downgrade k3d version

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -21,6 +21,7 @@ jobs:
       - name: Create k3s cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
       - name: Smoke test helm installation

--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -39,24 +39,28 @@ jobs:
       - name: Create edgeDNS k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
 
       - name: Create 3rd k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "test-gslb3"
           args: -c k3d/test-gslb3.yaml
 

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -39,18 +39,21 @@ jobs:
       - name: Create edgeDNS k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
 

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -39,18 +39,21 @@ jobs:
       - name: Create edgeDNS k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
+          k3d-version: v5.1.0
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
 


### PR DESCRIPTION
In our build pipe, k3d started crashing quite often when image-import was being executed.
Process locked up during image import and produced error `write unix @->/run/docker.sock: use of closed network connection` on manual stop.
I checked that the image actually exists in the virtual environment and it exists.
Since we encountered this bug with the latest version of k3d, I downgraded back to
the latest stable k3d (but still latest k3d-action).

**TEST:**
The bug was so frequent that I did a rerun of our workflow five times to get the bug to show up. The bug didn't occured.