### PR TITLE
workflow optimization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,23 @@ on:
       - '**.drawio'
       - '.spelling'
 jobs:
+  skip-check:
+    runs-on: ubuntu-latest
+    name: Skip the job?
+    outputs:
+          should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+    - id: skip_check
+      uses: fkirc/skip-duplicate-actions@v3.4.1
+      with:
+        skip_after_successful_duplicate: 'true'
+        do_not_skip: '["workflow_dispatch", "schedule"]'
+
   go-inspect:
     name: Inspect packages
     runs-on: ubuntu-20.04
+    needs: skip-check
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2
       # see: https://golangci-lint.run/usage/configuration/#config-file

--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -17,8 +17,22 @@ on:
       - '.spelling'
 
 jobs:
+  skip-check:
+    runs-on: ubuntu-latest
+    name: Skip the job?
+    outputs:
+          should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+    - id: skip_check
+      uses: fkirc/skip-duplicate-actions@v3.4.1
+      with:
+        skip_after_successful_duplicate: 'true'
+        do_not_skip: '["workflow_dispatch", "schedule"]'
+
   terratest-n-clusters:
     runs-on: ubuntu-20.04
+    needs: skip-check
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -17,8 +17,22 @@ on:
       - '.spelling'
 
 jobs:
+  skip-check:
+    runs-on: ubuntu-latest
+    name: Skip the job?
+    outputs:
+          should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+    - id: skip_check
+      uses: fkirc/skip-duplicate-actions@v3.4.1
+      with:
+        skip_after_successful_duplicate: 'true'
+        do_not_skip: '["workflow_dispatch", "schedule"]'
+
   terratest:
     runs-on: ubuntu-20.04
+    needs: skip-check
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -17,8 +17,22 @@ on:
       - '.spelling'
 
 jobs:
+  skip-check:
+    runs-on: ubuntu-latest
+    name: Skip the job?
+    outputs:
+          should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+    - id: skip_check
+      uses: fkirc/skip-duplicate-actions@v3.4.1
+      with:
+        skip_after_successful_duplicate: 'true'
+        do_not_skip: '["workflow_dispatch", "schedule"]'
+
   upgrade-testing:
     runs-on: ubuntu-20.04
+    needs: skip-check
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
related to #840

skipping already finished workflows, NOT concurrent (different PR). See [skip detail](https://github.com/k8gb-io/k8gb/actions/runs/1751931140).

I've been doing investigations about canceling workflows (https://github.com/fkirc/skip-duplicate-actions). The action works by checking in pre_job whether the pipe has already been run. Then in the main job there is a condition that either continues processing or skips the job.

This results in ALWAYS running all workflows, even duplicate ones. The difference is that the duplicates will terminate at a different point. We will still see a lot of green runs.

_It's a bit different than I imagined (not starting or CANCEL the duplicate at all).
I found out that I can cancel the workflow programmatically via HTTP POST. 
So if we create custom action, we can cancel on top of workflow and probably delete 
cancelled job from workflows page. Such behaviour would be more expected._

Signed-off-by: kuritka <kuritka@gmail.com>