### PR TITLE
Use default k3d (latest) in our build pipes

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -21,7 +21,6 @@ jobs:
       - name: Create k3s cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
       - name: Smoke test helm installation

--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -53,28 +53,24 @@ jobs:
       - name: Create edgeDNS k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
 
       - name: Create 3rd k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "test-gslb3"
           args: -c k3d/test-gslb3.yaml
 

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -53,21 +53,18 @@ jobs:
       - name: Create edgeDNS k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
 

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -53,21 +53,18 @@ jobs:
       - name: Create edgeDNS k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@v2
         with:
-          k3d-version: v5.1.0
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ deploy-test-version: ## Upgrade k8gb to the test version on existing clusters
 
 	@for c in $(CLUSTER_IDS); do \
 		echo -e "\n$(CYAN)$(CLUSTER_NAME)$$c:$(NC)" ;\
-		k3d image import $(REPO):$(SEMVER)-amd64 -c $(CLUSTER_NAME)$$c ;\
+		k3d image import $(REPO):$(SEMVER)-amd64 --mode=tools-node -c $(CLUSTER_NAME)$$c ;\
 	done
 
 	@for c in $(CLUSTER_IDS); do \


### PR DESCRIPTION
k3d-action repeatedly crashed, thats why had to downgrad k3d to v5.1.0. I found out that the problem occurs if we import several images into k3d in a row. The issue for that is opened [here](https://github.com/k3d-io/k3d/issues/1020).

I have reverted our build pipes to use the latest k3d-action (currently k3d v5.3.0) and set the import command to work with `--mode=tools-node`.

Signed-off-by: kuritka <kuritka@gmail.com>