### PR TITLE
Bump operator SDK to v1.18.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ HELM_ARGS ?=
 K8GB_COREDNS_IP ?= kubectl get svc k8gb-coredns -n k8gb -o custom-columns='IP:spec.clusterIP' --no-headers
 LOG_FORMAT ?= simple
 LOG_LEVEL ?= debug
-CONTROLLER_GEN_VERSION  ?= v0.7.0
+CONTROLLER_GEN_VERSION  ?= v0.8.0
 GOLIC_VERSION  ?= v0.7.2
 GOKART_VERSION ?= v0.2.0
 POD_NAMESPACE ?= k8gb


### PR DESCRIPTION
I have checked / made the necessary changes in our operatorSDK for the newly released versions:
 - [1.17.0](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.17.0/)
 - [1.18.0](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.18.0/)
 - [1.18.1](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.18.1/)

Modules: we had bumped versions already due to CVE exposed by dependabot. So we don't need to upgrade the modules now.
Other: it turned out that the only thing we need to update on our project is the controller-gen.

Signed-off-by: kuritka <kuritka@gmail.com>