### PR TITLE
docs: reflecting the breaking change on the documentation level

### DIFF
--- a/.github/workflows/helm_docs.yaml
+++ b/.github/workflows/helm_docs.yaml
@@ -12,8 +12,10 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
-    - name: Check all charts README.md
-      uses: docker://jnorwood/helm-docs:v1.5.0
+    - name: Generate docs for helm chart - chart/k8gb/README.md
+      uses: docker://jnorwood/helm-docs:v1.7.0
+      with:
+        args: --template-files=_helm-docs-template.gotmpl
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:

--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ Internal k8gb architecture and its components are described [here](/docs/compone
 
 k8gb is very well tested with the following environment options
 
-| Type                             | Implementation                                                          |
-|----------------------------------|-------------------------------------------------------------------------|
-| Kubernetes Version               | >= 1.15                                                                 |
-| Environment                      | Self-managed, AWS(EKS) [*](#clarify)                                |
-| Ingress Controller               | NGINX, AWS Load Balancer Controller [*](#clarify)                       |
-| EdgeDNS                          | Infoblox, Route53, NS1                                                  |
+| Type                             | Implementation                                                               |
+|----------------------------------|------------------------------------------------------------------------------|
+| Kubernetes Version               | for k8s `< 1.19` use k8gb `<= 0.8.8`; since k8s `1.19` use `0.9.0` or newer  |
+| Environment                      | Self-managed, AWS(EKS) [*](#clarify)                                         |
+| Ingress Controller               | NGINX, AWS Load Balancer Controller [*](#clarify)                            |
+| EdgeDNS                          | Infoblox, Route53, NS1                                                       |
 
 <a name="clarify"></a>* We only mention solutions where we have tested and verified a k8gb installation.
 If your Kubernetes version or Ingress controller is not included in the table above, it does not mean that k8gb will not work for you. k8gb is architected to run on top of any compliant Kubernetes cluster and Ingress controller.

--- a/chart/k8gb/_helm-docs-template.gotmpl
+++ b/chart/k8gb/_helm-docs-template.gotmpl
@@ -1,0 +1,36 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+```
+      _    ___        _
+     | | _( _ )  __ _| |__
+     | |/ / _ \ / _` | '_ \
+     |   < (_) | (_| | |_) |
+     |_|\_\___/ \__, |_.__/ .io
+                |___/
+```
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
+
+#### Compatibility matrix:
+
+| k8gb                           |      <= 0.8.x      | >= 0.9.0           |
+| ------------------------------ | :----------------: | :----------------: |
+| Kubernetes <= 1.18             | :white_check_mark: |        :x:         |
+| Kubernetes >= 1.19 and <= 1.21 | :white_check_mark: | :white_check_mark: |
+| Kubernetes >= 1.22             |        :x:         | :white_check_mark: |
+
+{{ template "chart.valuesSection" . }}

--- a/chart/k8gb/templates/NOTES.txt
+++ b/chart/k8gb/templates/NOTES.txt
@@ -1,4 +1,10 @@
-K8GB and all dependencies are installed
+done
+   _    ___        _
+  | | _( _ )  __ _| |__
+  | |/ / _ \ / _` | '_ \
+  |   < (_) | (_| | |_) |
+  |_|\_\___/ \__, |_.__/  & all dependencies are installed
+             |___/
 
 1. Check if your DNS Zone is served by K8GB CoreDNS
   $ kubectl -n {{ .Release.Namespace }} run -it --rm --restart=Never --image=infoblox/dnstools:latest dnstools --command -- /usr/bin/dig @{{ .Release.Name }}-coredns SOA . +short


### PR DESCRIPTION
Describing what version of k8s should be used w/ what version of k8gb

For helm-docs tool, the custom template had to be used. It takes the [default template](https://github.com/norwoodj/helm-docs/blob/master/README.md?plain=1#L181:L199) (the one we are using when no args are passed) and adds some custom stuff to it, like the compatibility matrix.

Also adding some ascii art to make it prettier, if you don't like it, I can't remove it from the pr.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>