### PR TITLE
Makefile: remove --mode=tools-node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ deploy-test-version: ## Upgrade k8gb to the test version on existing clusters
 
 	@for c in $(CLUSTER_IDS); do \
 		echo -e "\n$(CYAN)$(CLUSTER_NAME)$$c:$(NC)" ;\
-		k3d image import $(REPO):$(SEMVER)-amd64 --mode=tools-node -c $(CLUSTER_NAME)$$c ;\
+		k3d image import $(REPO):$(SEMVER)-amd64 -c $(CLUSTER_NAME)$$c ;\
 	done
 
 	@for c in $(CLUSTER_IDS); do \


### PR DESCRIPTION
New release of k3d-action solved the problem with importing images [#1020](https://github.com/k3d-io/k3d/issues/1020).
We don't need to explicitly specify `--mode=tools-node` anymore, because this value is now the default.

Signed-off-by: kuritka <kuritka@gmail.com>