### PR TITLE
Bump olm-bundle to 0.5.4

### DIFF
--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -14,7 +14,7 @@ on:
       olmBundleToolVersion:
         description: "Version of the olm-bundle tool that generate CSV file from Chart.yaml and yamls on FS"
         required: false
-        default: "0.5.3"
+        default: "0.5.4"
 
 jobs:
   olm-bundle-pr:

--- a/olm/generate.sh
+++ b/olm/generate.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+
 [ "${DEBUG}" == 1 ] && set -x
 
-TOOL_VERSION=${TOOL_VERSION:-"0.5.3"}
+TOOL_VERSION=${TOOL_VERSION:-"0.5.4"}
 TOOL_REPO=${TOOL_REPO:-"AbsaOSS"}
 DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 


### PR DESCRIPTION
It fixes the https://github.com/k8gb-io/k8gb/issues/866
The actual fix for olm-bundle was done [here](https://github.com/AbsaOSS/olm-bundle/pull/13), this PR only bumps the tool's version to include the fix.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>