### PR TITLE
Sending HTTP get request to doc.crds.dev to index new version

### DIFF
--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -41,3 +41,7 @@ jobs:
           base: master
           signoff: true
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Send http get to doc.crds.dev to index a new version
+        run: |
+          curl -sL https://doc.crds.dev/github.com/k8gb-io/k8gb@${{ github.event.release.tag_name }} | grep -A2 'class="container"'


### PR DESCRIPTION
Fix #765 

Piggy-backing on the `changelog_pr` action because creating a standalone workflow just for this would be over-kill (we have already 17 yamls there and it's hard to find and match things in there).

When this action runs the tag should be already created (it runs after the draft release is pronounced as published)

the response from the "curl-grep" will look like this:

```
curl -sL https://doc.crds.dev/github.com/k8gb-io/k8gb@v0.9.5 | grep -A2 'class="container"'
    <div class="container">
        <h2>Oops! Looks like we haven't indexed this version of this repo yet. We are working on that now...</h2>
    </div>
```
or this (when it has already been done, perhaps re-running the action or doing it manually)

```
curl -sL https://doc.crds.dev/github.com/k8gb-io/k8gb@v0.9.0 | grep -A2 'class="container"'
    <div class="container">
        <div class="content">
            <h1><a href="/github.com/k8gb-io/k8gb@v0.9.0">k8gb-io/k8gb@v0.9.0</a></h1>
```

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>