### PR TITLE
Add opencontainers labels for container image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,11 +21,23 @@ dockers:
   - "absaoss/k8gb:v{{ .Version }}-amd64"
   build_flag_templates:
   - "--platform=linux/amd64"
+  - &LABEL1
+    "--label=org.opencontainers.image.title=k8gb"
+  - &LABEL2
+    "--label=org.opencontainers.image.description=A cloud native Kubernetes Global Balancer"
+  - &LABEL3
+    "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+  - &LABEL4
+    "--label=org.opencontainers.image.version={{ .Version }}"
 - image_templates:
   - "absaoss/k8gb:v{{ .Version }}-arm64"
   goarch: arm64
   build_flag_templates:
   - "--platform=linux/arm64"
+  - *LABEL1
+  - *LABEL2
+  - *LABEL3
+  - *LABEL4
 docker_manifests:
 - name_template: absaoss/k8gb:{{ .Tag }}
   image_templates:


### PR DESCRIPTION
Although, we don't produce OCI compliant images at the moment. It would be nice to adapt their [metadata standards](https://github.com/opencontainers/image-spec/blob/main/annotations.md) for start. Some tools can already [interpret](https://github.com/jkremser/log2rbac-operator/pkgs/container/log2rbac/18136364?tag=v0.0.3) them even if provided as labels in the image json manifest and not as intended (which is OCI [annotations](https://github.com/imjasonh/ImJasonH/tree/main/articles/oci-base-image-annotations#when-can-i-use-it)).

I was looking into how to produce those OCI images and it's not that easy with goreleaser. It can support podman as enterprise feature, otherwise it uses docker. I was playing with `skopeo` that can save any image as tar in OCI format. Github registries are [ready](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#about-container-registry-support) for OCI images.

There are also `org.opencontainers.image.base.name` & `org.opencontainers.image.base.digest` annotations/labels, that can help to construct the full lineage of predecessor of the image (`FROM ...` relation). These can be added later if we decide that we or community need/want them.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>