### PR TITLE
v3 should not install golang 1.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,9 +36,10 @@ jobs:
       - uses: actions/checkout@v2
       # see: https://golangci-lint.run/usage/configuration/#config-file
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           version: v1.42.1
+          skip-pkg-cache: true
       - name: golic
         run: |
           go install github.com/AbsaOSS/golic@v0.7.2


### PR DESCRIPTION
Fix #870 

edit: bummer, v3 didn't help, so closing

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>