### PR TITLE
Add prometheus scraping also for external-dns and coredns pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This setup is adapted for local scenarios and works without external DNS provide
 
 Consult with [local playground](/docs/local.md) documentation to learn all the details of experimenting with local setup.
 
-Optionally, you can run `make deploy-prometheus` and check the metrics on the test clusters (http://localhost:8080, http://localhost:8081).
+Optionally, you can run `make deploy-prometheus` and check the metrics on the test clusters (http://localhost:9080, http://localhost:9081).
 
 ## Motivation and Architecture
 


### PR DESCRIPTION
Currently, when `make deploy-prometheus` is run, the Prometheus scrapes only `k8gb` and podinfo app. This PR adds the scraping also for external-dns pod and coredns pod.

`http://127.0.0.1:9081/targets` (after this change):

```bash
make deploy-prometheus

...
Set annotations on pods that will be scraped by prometheus
pod/k8gb-746d98857d-7tq4d annotated
pod/external-dns-6bd44c4856-pcdt2 annotated
pod/k8gb-coredns-5bc6689949-5f8jn annotated
...


make uninstall-prometheus
...
uninstall prometheus
release "prometheus" uninstalled
pod/k8gb-746d98857d-7tq4d annotated
pod/external-dns-6bd44c4856-pcdt2 annotated
pod/k8gb-coredns-5bc6689949-5f8jn annotated
...
```

<img width="1238" alt="Screenshot 2022-04-25 at 16 19 35" src="https://user-images.githubusercontent.com/535866/165109324-17610f95-8046-4ccf-b5a8-c1166902b999.png">

Also small change to the readme, because the port was [moved](https://github.com/k8gb-io/k8gb/commit/beda7911df957790d6d91083477d2c3157dda079) couple of months ago.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>