### PR TITLE
Fix #881: gslbs and/or ingresses require the ingressClassName to be there

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ metadata:
   namespace: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx # or any other existing ingressclasses.networking.k8s.io
     rules:
       - host: failover.test.k8gb.io # Desired GSLB enabled FQDN
         http:

--- a/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml
+++ b/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: notfound.cloud.example.com # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host

--- a/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr_failover.yaml
+++ b/deploy/crds/k8gb.absa.oss_v1beta1_gslb_cr_failover.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: failover.cloud.example.com
         http:

--- a/docs/deploy_infoblox.md
+++ b/docs/deploy_infoblox.md
@@ -92,6 +92,7 @@ metadata:
   namespace: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: podinfo.cloud.example.com
         http:

--- a/docs/examples/route53/k8gb/gslb-failover.yaml
+++ b/docs/examples/route53/k8gb/gslb-failover.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: failover.test.k8gb.io # Desired GSLB enabled FQDN
         http:

--- a/docs/examples/route53/k8gb/gslb-roundrobin.yaml
+++ b/docs/examples/route53/k8gb/gslb-roundrobin.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: notfound.test.k8gb.io # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,15 +54,18 @@ kind: Gslb
 metadata:
   name: app
 spec:
-  host: app.cloud.example.com # This is the GSLB enabled host that clients would use
-  http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
-    paths:
-    - path: /
-      backend:
-        service:
-          name: app
-          port:
-            name: http
+  ingress:
+    ingressClassName: nginx
+    rules:
+    - host: app.cloud.example.com # This is the GSLB enabled host that clients would use
+      http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
+        paths:
+        - path: /
+          backend:
+            service:
+              name: app
+              port:
+                name: http
   strategy: roundRobin # Use a round robin load balancing strategy, when deciding which downstream clusters to route clients too
   tls:
     secretName: app-glsb-tls # Use this Secret to add to the TLS configuration for the new Ingress resource that will be created for the GSLB host

--- a/terratest/examples/broken-gslb-no-http.yaml
+++ b/terratest/examples/broken-gslb-no-http.yaml
@@ -4,6 +4,7 @@ metadata:
   name: broken-test-gslb1
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: broken-no-http.cloud.example.com
   strategy:

--- a/terratest/examples/broken-gslb.yaml
+++ b/terratest/examples/broken-gslb.yaml
@@ -4,6 +4,7 @@ metadata:
   name: broken-test-gslb2
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: terratest-broken.cloud.example.com
         https:

--- a/terratest/examples/broken-ingress-annotation.yaml
+++ b/terratest/examples/broken-ingress-annotation.yaml
@@ -6,5 +6,6 @@ metadata:
     k8gb.io/primary-geotag: eu
   name: broken-test-gslb-annotation-failover
 spec:
+  ingressClassName: nginx
   rules:
   - host: notfound-broken.cloud.example.com

--- a/terratest/examples/failover-lifecycle.yaml
+++ b/terratest/examples/failover-lifecycle.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-gslb-lifecycle
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: lifecycle.cloud.example.com
         http:

--- a/terratest/examples/failover-playground.yaml
+++ b/terratest/examples/failover-playground.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: playground-failover.cloud.example.com
         http:

--- a/terratest/examples/failover.yaml
+++ b/terratest/examples/failover.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: terratest-failover.cloud.example.com
         http:

--- a/terratest/examples/failover1.yaml
+++ b/terratest/examples/failover1.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: terratest-failover-split.cloud.example.com
         http:

--- a/terratest/examples/failover2.yaml
+++ b/terratest/examples/failover2.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: terratest-failover-split.cloud.example.com
         http:

--- a/terratest/examples/ingress-annotation-failover-simple.yaml
+++ b/terratest/examples/ingress-annotation-failover-simple.yaml
@@ -7,6 +7,7 @@ metadata:
     k8gb.io/primary-geotag: "eu"
     k8gb.io/dns-ttl-seconds: "5"
 spec:
+  ingressClassName: nginx
   rules:
     - host: ingress-failover-simple.cloud.example.com
       http:

--- a/terratest/examples/ingress-annotation-failover.yaml
+++ b/terratest/examples/ingress-annotation-failover.yaml
@@ -8,6 +8,7 @@ metadata:
     k8gb.io/splitbrain-threshold-seconds: "600"
   name: test-gslb-annotation-failover
 spec:
+  ingressClassName: nginx
   rules:
   - host: ingress-failover-notfound.cloud.example.com
     http:

--- a/terratest/examples/ingress-annotation-rr.yaml
+++ b/terratest/examples/ingress-annotation-rr.yaml
@@ -6,6 +6,7 @@ metadata:
     k8gb.io/dns-ttl-seconds: "5"
   name: test-gslb-annotation
 spec:
+  ingressClassName: nginx
   rules:
   - host: ingress-rr-notfound.cloud.example.com
     http:

--- a/terratest/examples/roundrobin.yaml
+++ b/terratest/examples/roundrobin.yaml
@@ -4,6 +4,7 @@ metadata:
   name: test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: terratest-notfound.cloud.example.com # This is the GSLB enabled host that clients would use
         http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host

--- a/terratest/examples/roundrobin2.yaml
+++ b/terratest/examples/roundrobin2.yaml
@@ -4,6 +4,7 @@ metadata:
   name: roundrobin-test-gslb
 spec:
   ingress:
+    ingressClassName: nginx
     rules:
       - host: roundrobin-test.cloud.example.com
         http:

--- a/terratest/test/k8gb_ingress_annotation_rr_test.go
+++ b/terratest/test/k8gb_ingress_annotation_rr_test.go
@@ -61,7 +61,7 @@ func TestK8gbIngressAnnotationRR(t *testing.T) {
 
 	ingress := k8s.GetIngress(t, options, "test-gslb-annotation")
 	require.Equal(t, ingress.Name, "test-gslb-annotation")
-	utils.AssertGslbStatus(t, options, "test-gslb-annotation", "ingress-roundrobin."+settings.DNSZone+":NotFound ingress-rr-notfound."+settings.DNSZone+":NotFound ingress-rr-unhealthy."+settings.DNSZone+":NotFound")
+	utils.AssertGslbStatus(t, options, "test-gslb-annotation", "ingress-rr-notfound."+settings.DNSZone+":NotFound ingress-rr-unhealthy."+settings.DNSZone+":NotFound ingress-rr."+settings.DNSZone+":NotFound")
 	utils.AssertGslbSpec(t, options, "test-gslb-annotation", ".spec.strategy.type", "roundRobin")
 
 	t.Run("Gslb is getting deleted together with the annotated Ingress", func(t *testing.T) {


### PR DESCRIPTION
If the field is empty, the nginx controller simply ignores it:

```
I0429 12:58:43.255500       8 store.go:390] "Ignoring ingress because of error while validating ingress class" ingress="k8gb-test-split-failover-un3egx/test-gslb" error="ingress does not contain a valid IngressClass"
```
However, if nginx-controller ignores it, it does not populate the IPs under Ingress' `status.loadBalancer` field and our k8gb controller won't get the IPs.

There is also a way to say nginx to handle ingresses w/o any class on it (https://github.com/nginxinc/kubernetes-ingress/blob/main/deployments/helm-chart/values.yaml#L158) but it's turned-off by default and I think we should be explicit here.


The change in `terratest/test/k8gb_ingress_annotation_rr_test.go` was necessary, because the order of things in the map is different now + the name was different. The way how we check the equivalency on the maps is quite bad though.. it's string based. it would require more love, but I wanted to have a quick fix ready, so that the terratests are green again.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>