### PR TITLE
Fetch the latest tag from the remote

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,9 @@ NO_VALUE ?= no_value
 #		VARIABLES
 ###############################
 PWD ?=  $(shell pwd)
-VERSION ?= $(shell git describe --tags --abbrev=0)
+ifndef VERSION
+VERSION := $(shell git fetch --force --tags &> /dev/null ; git describe --tags --abbrev=0)
+endif
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
 SEMVER ?= $(VERSION)-$(COMMIT_HASH)
 # image URL to use all building/pushing image targets


### PR DESCRIPTION
WHY:
Because if users don't regularly call the `git fetch --tags` on the repo, the tags are not updated in their git repos after the release and it may happen that old version will be deployed. However, if the user called `git pull` and has the latests manifests, those are not guaranteed to work with some old release.

It may sound quite artificial, but it [happens](https://github.com/k8gb-io/k8gb/issues/879#issue-1219178208) and I also caught myself that `make deploy-full-local-setup` deploys some older version if I didn't pull the latest tags.

HOW:
Using `:=` in the makefile so that the bash expression is evaluated only once, inside of  the `ifndef VERSION` macro, so that we can have both: overridable value passed as env var to make and lazy evaluation

git fetch is not a fast operation, for me it takes ~1.3 sec. I did some measurements with this dummy target:

```
foo:
	echo $(VERSION)
	echo $(VERSION)
	echo $(VERSION)
	echo $(VERSION)
	echo $(VERSION)
```

```
time make foo
echo v0.9.0
v0.9.0
echo v0.9.0
v0.9.0
echo v0.9.0
v0.9.0
echo v0.9.0
v0.9.0
echo v0.9.0
v0.9.0
make foo  0.05s user 0.08s system 8% cpu 1.535 total
```

```
time VERSION=42 make foo
echo 42
42
echo 42
42
echo 42
42
echo 42
42
echo 42
42
VERSION=42 make foo  0.01s user 0.01s system 27% cpu 0.086 total
```

If the `?=` and no ifndef macro was used, the results are:

```
time make foo
echo v0.9.0
v0.9.0
echo v0.9.0
v0.9.0
echo v0.9.0
v0.9.0
echo v0.9.0
v0.9.0
echo v0.9.0
v0.9.0
make foo  0.25s user 0.34s system 8% cpu 7.071 total
```

note: this change doesn't break the reproducibility of old releases in a sense that even if I checkout some old commit and run the `deploy-full-local-setup`, the correct git tag will be used (the latest released up to that checked commit, not the very latest one)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>