### PR TITLE
Fail if pipe fails during terratest

### DIFF
--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -85,5 +85,4 @@ jobs:
           kubectl get no -owide --context=k3d-test-gslb3
 
       - name: Run Terratest
-        continue-on-error: true
         run: make terratest

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -78,8 +78,9 @@ jobs:
 
       - name: Run Terratest
         run: |
-          mkdir -p ${{ github.workspace }}/tmp/terratest 
-          echo "::group::Terratest logs" 
+          mkdir -p ${{ github.workspace }}/tmp/terratest
+          set -o pipefail
+          echo "::group::Terratest logs"
           make terratest | tee ${{ github.workspace }}/tmp/terratest/all.log
           echo "::endgroup::"
 

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -76,7 +76,8 @@ jobs:
 
       - name: Run Terratest
         run: |
-          mkdir -p ${{ github.workspace }}/tmp/terratest 
+          mkdir -p ${{ github.workspace }}/tmp/terratest
+          set -o pipefail
           make terratest | tee ${{ github.workspace }}/tmp/terratest/all.log
           echo "::endgroup::"
 


### PR DESCRIPTION
Fix #883 

by default, the non-0 exit code is swallowed
```
false | tee /dev/stdout
echo $?
0
```

so we need to:
```
set -o pipefail
false | tee /dev/stdout
echo $?
1
```

tested in https://github.com/jkremser/k8gb/runs/6257620790?check_suite_focus=true

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>