### PR TITLE
Add copy to clipboard button for code snippets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ifneq ($(CUSTOM_CERT_PATH),)
 	CERT_INSTALL_CMD := update-ca-certificates;
 endif
 
-JEKYLL_CMD := "$(CERT_INSTALL_CMD) bundle install; jekyll serve --host $(JEKYLL_HOST) --watch --livereload --incremental --port $(JEKYLL_PORT)"
+JEKYLL_CMD := "$(CERT_INSTALL_CMD) bundle install; /usr/local/bundle/bin/jekyll serve --host $(JEKYLL_HOST) --watch --livereload --incremental --port $(JEKYLL_PORT)"
 
 # Build and serve k8gb.io website locally with watch and livereload
 .PHONY: serve
@@ -44,7 +44,6 @@ ifneq ($(JEKYLL_GITHUB_TOKEN),)
 	@docker run --rm -it \
 		--env JEKYLL_GITHUB_TOKEN=$(JEKYLL_GITHUB_TOKEN) \
 		--volume="$(PWD):/srv/jekyll" \
-		--volume="$(PWD)/vendor/bundle:/usr/local/bundle" \
 		--volume="$(CUSTOM_CERT_PATH):/usr/local/share/ca-certificates/custom-cert" \
 		-p $(JEKYLL_PORT):$(JEKYLL_PORT) -p 35729:35729 jekyll/jekyll:$(JEKYLL_VERSION) \
  		sh -c $(JEKYLL_CMD)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,6 +11,8 @@
         gtag('config', '{{ site.google_analytics }}');
       </script>
     {% endif %}
+    <script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.10/dist/clipboard.min.js"></script>
+    <script src="/assets/js/copy-clipboard.js"></script>
     <meta charset="UTF-8">
 
 {% seo %}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -76,3 +76,42 @@ a.header-url:hover {
 .heading:hover > .heading-anchor {
     visibility: visible;
 }
+
+// don't use dark color for syntax highlighting
+.highlight .k, .highlight .kv {
+    color: #f00 !important;
+}
+
+// used by clipboard.js
+.clipboard {
+    border: 0;
+    font-size: .75em;
+    text-transform: uppercase;
+    font-weight: 500;
+    padding: 6px;
+    color: #888;
+    position: relative;
+    top: .6rem;
+    left: 95%;
+    background: transparent;
+    border-radius: 3px;
+}
+
+.pre-code {
+  position: relative;
+  padding-right: 40px;
+  background-color: #f1f1f1;
+}
+
+.clipboard:hover, .clipboard:focus, .clipboard:active {
+    outline: 0;
+    background-color: #ddd;
+}
+
+.highlight.pre-code button {
+    visibility: hidden;
+}
+
+.highlight.pre-code:hover button {
+    visibility: visible;
+}

--- a/assets/js/copy-clipboard.js
+++ b/assets/js/copy-clipboard.js
@@ -1,0 +1,40 @@
+(function() {
+    document.addEventListener('DOMContentLoaded', () => {
+        const pre = document.getElementsByTagName('pre');
+        for (let i = 0; i < pre.length; i++) {
+            // add the copy button iff
+            // iff its parent is a div with class highlight
+            if (pre[i].parentNode == null || !pre[i].parentNode.classList.contains("highlight")) {
+                continue;
+            }
+            // and parent's parent doesn't have a class 'language-text'
+            if (pre[i].parentNode.parentNode == null || pre[i].parentNode.parentNode.classList.contains("language-text")) {
+                continue;
+            }
+
+            const b = document.createElement('button');
+            b.className = 'clipboard';
+            b.textContent = 'Copy';
+            pre[i].classList.add('pre-code');
+            if (pre[i].childNodes.length === 1 && pre[i].childNodes[0].nodeType === 3) {
+                const code = document.createElement('code');
+                code.textContent = pre[i].textContent;
+                pre[i].textContent = '';
+                pre[i].appendChild(code);
+            }
+            pre[i].appendChild(b);
+        }
+        new ClipboardJS('.clipboard', {
+            target: (b) => {
+                const p = b.parentNode;
+                return p.className.includes("highlight")
+                    ? p.getElementsByTagName("code")[0]
+                    : p.childNodes[0];
+            }
+        }).on('success', (e) => {
+            e.clearSelection();
+            e.trigger.textContent = 'Copied';
+            setTimeout(() => e.trigger.textContent = 'Copy', 2000);
+        });
+    });
+}());

--- a/docs/local.md
+++ b/docs/local.md
@@ -101,7 +101,7 @@ Or you can ask specific CoreDNS instance for its local targets:
 dig @localhost localtargets-roundrobin.cloud.example.com -p 5053 && dig -p 5054 @localhost localtargets-roundrobin.cloud.example.com
 ```
 As expected result you should see **two A records** divided between both clusters.
-```sh
+```text
 ...
 ...
 ;; ANSWER SECTION:
@@ -192,7 +192,7 @@ You will see only **eu** podinfo is responsive:
 }
 ```
 Stop podinfo on **current (eu)** cluster:
-```
+```sh
 make stop-test-app
 ```
 Several times hit application again


### PR DESCRIPTION
This pr also
- fixes the Makefile target for colima environment
- don't use black text on black background for syntax highlighting (see the screenshots)

before:
<img width="849" alt="Screenshot 2022-05-06 at 14 21 17" src="https://user-images.githubusercontent.com/535866/167130292-e6c1e371-c88b-4614-8f50-49d7feabe17d.png">

after:
<img width="926" alt="Screenshot 2022-05-06 at 14 22 01" src="https://user-images.githubusercontent.com/535866/167130405-37cd0c1a-29a8-40eb-8631-c580144674bc.png">

If one doesn't want to have the copy button present on the code snippet, just use either:

``````
```
some text output from a command that doesn't need to be copied
```
``````
or
``````
```text
something
```
``````
Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>