### PR TITLE
Add doc entry for forgoten metric (k8gb_infoblox_request_duration)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -85,6 +85,7 @@ The k8gb exposes several metrics to help you monitor the health and behavior.
 | `k8gb_gslb_status_count_for_roundrobin` | Gauge | Gslb status count for RoundRobin strategy. | `namespace`, `name`, `status` |
 | `k8gb_infoblox_heartbeat_errors_total` | Counter | Number of k8gb Infoblox TXT record errors. | `namespace`, `name` |
 | `k8gb_infoblox_heartbeats_total` | Counter | Number of k8gb Infoblox heartbeat TXT record updates. | `namespace`, `name` |
+| `k8gb_infoblox_request_duration` | Histogram | Duration of the HTTP request to Infoblox API in seconds. | `request`, `success` |
 | `k8gb_infoblox_zone_update_errors_total` | Counter | Number of k8gb Infoblox zone update errors. | `namespace`, `name` |
 | `k8gb_infoblox_zone_updates_total` | Counter | Number of k8gb Infoblox zone updates. | `namespace`, `name` |
 | `k8gb_endpoint_status_num` | Gauge | Number of targets in DNS endpoint. | `namespace`, `name`, `dns_name` |


### PR DESCRIPTION
I forgot to add it here when working on https://github.com/k8gb-io/k8gb/pull/805

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>