### PR TITLE
contributing.md: don't use merge commit when doing release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ make demo DEMO_URL=https://failover.test.exampledns.tk DEMO_DEBUG=1
 
 * Bump the version in `Chart.yaml`, see [example PR](https://github.com/k8gb-io/k8gb/pull/749). Make sure the
 commit message starts with `RELEASE:`.
-* Merge the Pull Request after the review approval
+* Merge the Pull Request after the review approval (make sure the squash or rebase is used, merge commit will not trigger the release pipeline)
 * At this point a DRAFT release will be created on GitHub. After the [automatic tag](https://github.com/k8gb-io/k8gb/actions/workflows/cut_release.yaml) & [release pipeline](https://github.com/k8gb-io/k8gb/actions/workflows/release.yaml)
 have been successfully completed, you check the [release DRAFT](https://github.com/k8gb-io/k8gb/releases) and if it is OK, you click on the **"Publish release"** button.
 


### PR DESCRIPTION
minor: warn that either squash or rebase has to be used during the release process

other option would be to ban the merge strategy for PRs in here (project's settings on GH):
<img width="616" alt="Screenshot 2022-05-09 at 16 25 05" src="https://user-images.githubusercontent.com/535866/167431672-67e35400-160c-4333-942c-b0d3e6ecc29b.png">

or use an action for it that checks all the commits in the PR ([checkAllCommitMessages](https://github.com/GsActions/commit-message-checker/blob/main/README.md?plain=1#L70))

The reason why merge commit fails the release pipeline is the fact that we use something like:
`if: startsWith(github.event.head_commit.message, 'RELEASE:')` ([here](https://github.com/k8gb-io/k8gb/blob/master/.github/workflows/cut_release.yaml#L24)) and that `github.event.head_commit.message` is actually a commit msg of the newest commit in the PR, but when using the merge commit, it will be the newest one and the msg will be different.

Yet another fix could be using `github.event.commits[0].message` which should be the OLDEST commit in the pr batch, but I haven't tried this.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>