### PR TITLE
Bump the config files for k3d to v1alpha4 format

### DIFF
--- a/k3d/edge-dns.yaml
+++ b/k3d/edge-dns.yaml
@@ -1,6 +1,7 @@
-apiVersion: k3d.io/v1alpha3
+apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: edgedns
+metadata:
+  name: edgedns
 image: docker.io/rancher/k3s:v1.22.6-k3s1
 agents: 0
 network: k3d-action-bridge-network

--- a/k3d/gslb.yaml.tmpl
+++ b/k3d/gslb.yaml.tmpl
@@ -1,6 +1,7 @@
-apiVersion: k3d.io/v1alpha3
+apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: test-gslb$CLUSTER_INDEX
+metadata:
+  name: test-gslb$CLUSTER_INDEX
 image: docker.io/rancher/k3s:v1.22.6-k3s1
 agents: 1
 network: k3d-action-bridge-network

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -1,6 +1,7 @@
-apiVersion: k3d.io/v1alpha3
+apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: test-gslb1
+metadata:
+  name: test-gslb1
 image: docker.io/rancher/k3s:v1.22.6-k3s1
 agents: 1
 network: k3d-action-bridge-network

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -1,6 +1,7 @@
-apiVersion: k3d.io/v1alpha3
+apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: test-gslb2
+metadata:
+  name: test-gslb2
 image: docker.io/rancher/k3s:v1.22.6-k3s1
 agents: 1
 network: k3d-action-bridge-network

--- a/k3d/test-gslb3.yaml
+++ b/k3d/test-gslb3.yaml
@@ -1,6 +1,7 @@
-apiVersion: k3d.io/v1alpha3
+apiVersion: k3d.io/v1alpha4
 kind: Simple
-name: test-gslb3
+metadata:
+  name: test-gslb3
 image: docker.io/rancher/k3s:v1.22.6-k3s1
 agents: 1
 network: k3d-action-bridge-network


### PR DESCRIPTION
`v1alpha3` has been [deprecated](https://github.com/k3d-io/k3d/blob/main/CHANGELOG.md#deprecated-1) in `k3d@5.3.0` and our build produces the [warnings](https://github.com/k8gb-io/k8gb/runs/6607508138?check_suite_focus=true#step:6:22).

~Unfortunately, there was a breaking change introduced between `v1alpha3` -> `v1alpha4`. Their json schema is pretty aggressive and complains about the `name` being part of the cluster config. Furthermore, if we remove it from the yaml config and don't specify it during the k3d command, it will be set to some default value (k3d-k3s-cluster or similar) so it needs to be there for the k3d command and needs to be missing in the config files.~

~Also aligning the naming for "edgedns" cluster (`edgedns` -> `edge-dns`), because it wasn't consistent, meaning the file name with the config didn't match the cluster name.~

UPDATE: The `name` was just moved under `metadata` object.

k3d-action should be [ok](https://github.com/AbsaOSS/k3d-action/blob/main/run.sh#L71) with this change.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>