### PR TITLE
Always run terratest_log_parser and upload the artifact

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -85,6 +85,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Terratest log parser
+        if: always()
         run: |
           curl --location --silent --fail --show-error -o terratest_log_parser https://github.com/gruntwork-io/terratest/releases/download/v0.38.8/terratest_log_parser_linux_amd64
           chmod +x terratest_log_parser
@@ -98,6 +99,7 @@ jobs:
           echo Separated log files will be available under artifact section at https://github.com/k8gb-io/k8gb/actions/runs/${{ github.run_id }}
 
       - uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: terratest-logs
           path: ${{ github.workspace }}/tmp/terratest

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -82,6 +82,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Terratest log parser
+        if: always()
         run: |
           curl --location --silent --fail --show-error -o terratest_log_parser https://github.com/gruntwork-io/terratest/releases/download/v0.38.8/terratest_log_parser_linux_amd64
           chmod +x terratest_log_parser
@@ -95,6 +96,7 @@ jobs:
           echo Separated log files will be available under artifact section at https://github.com/k8gb-io/k8gb/actions/runs/${{ github.run_id }}
 
       - uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: terratest-logs
           path: ${{ github.workspace }}/tmp/terratest


### PR DESCRIPTION
Running the `terratest_log_parser` and uploading the zip with the logs makes especially sense if there is an error so that one can debug it. However currently, if there is a failure the subsequent tasks are not being run.

Other option would be having `if failure()` there but why not to have the nice logs even for success?

`continue-on-error: true` would not work because it would make the pipeline green even if there is an issue.


Example of such pipeline with an error but the logs were not processed: https://github.com/k8gb-io/k8gb/runs/6706323648?check_suite_focus=true

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>