### PR TITLE
Bump goreleaser action and goreleaser itself

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -43,9 +43,9 @@ jobs:
           go-version: "1.17.6"
 
       - name: Build artifacts
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
-          version: v1.7.0
+          version: v1.9.2
           args: release --rm-dist --skip-publish --skip-validate --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -43,9 +43,9 @@ jobs:
           go-version: "1.17.6"
 
       - name: Build artifacts
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v3
         with:
-          version: v1.7.0
+          version: v1.9.2
           args: release --rm-dist --skip-publish --skip-validate --snapshot
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
hopefully fixing https://github.com/k8gb-io/k8gb/issues/904

Can't say for 100% because it's a non-deterministic issue that might be also caused by container registries (when pulling the base image), rate limiters, running on different VMs, etc. Currently the error is kinda swallowed by the goreleaser.

I ran the terratest and upgrade tests workflows (`terratest.yaml` & `upgrade-testing.yaml`) each 8 times and haven't seen any container build failures. Only once the terratests failed on [this](https://github.com/k8gb-io/k8gb/runs/7024181399?check_suite_focus=true#step:10:61), but that's the [race condition issue](https://github.com/k8gb-io/k8gb/issues/902), not the [container build thingy](https://github.com/k8gb-io/k8gb/issues/904).

- 8 runs for terratest: https://github.com/k8gb-io/k8gb/actions/runs/2549269598
- 8 runs for upgrade-testing: https://github.com/k8gb-io/k8gb/actions/runs/2549269605

update1: well, 9 times including the build of this pr (because I rebased on master and "`push-f`ed")
update2: haha, so the last build [failed](https://github.com/k8gb-io/k8gb/runs/7026486302?check_suite_focus=true#step:4:44) so it's not fixing the issue, but the bump can't hurt right?

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>