### PR TITLE
Add unmarshalling to Percentage

### DIFF
--- a/api/v1beta1/gslb_types.go
+++ b/api/v1beta1/gslb_types.go
@@ -33,7 +33,7 @@ import (
 type Strategy struct {
 	// Load balancing strategy type:(roundRobin|failover)
 	Type string `json:"type"`
-	// roundrobin and in the future consistent may (but also may not) contain a weight
+	// weight roundrobin
 	Weight Weight `json:"weight,omitempty"`
 	// Primary Geo Tag. Valid for failover strategy only
 	PrimaryGeoTag string `json:"primaryGeoTag,omitempty"`
@@ -120,6 +120,12 @@ func (p Percentage) TryParse() (v int, err error) {
 func (p Percentage) Int() int {
 	v, _ := p.TryParse()
 	return v
+}
+
+func (p *Percentage) UnmarshalJSON(data []byte) error {
+	str := strings.ReplaceAll(string(data), "\"", "")
+	*p = Percentage(str)
+	return nil
 }
 
 func (w Weight) IsEmpty() bool {

--- a/chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml
+++ b/chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.k8gb.deployCrds }}---
+{{- if .Values.k8gb.deployCrds }}
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -321,8 +322,7 @@ spec:
                   weight:
                     additionalProperties:
                       type: string
-                    description: roundrobin and in the future consistent may (but
-                      also may not) contain a weight
+                    description: weight roundrobin
                     type: object
                 required:
                 - type

--- a/controllers/depresolver/resolver_mock.go
+++ b/controllers/depresolver/resolver_mock.go
@@ -31,31 +31,31 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockResolver is a mock of GslbResolver interface.
-type MockResolver struct {
+// MockGslbResolver is a mock of GslbResolver interface.
+type MockGslbResolver struct {
 	ctrl     *gomock.Controller
-	recorder *MockResolverMockRecorder
+	recorder *MockGslbResolverMockRecorder
 }
 
-// MockResolverMockRecorder is the mock recorder for MockResolver.
-type MockResolverMockRecorder struct {
-	mock *MockResolver
+// MockGslbResolverMockRecorder is the mock recorder for MockGslbResolver.
+type MockGslbResolverMockRecorder struct {
+	mock *MockGslbResolver
 }
 
-// NewMockResolver creates a new mock instance.
-func NewMockResolver(ctrl *gomock.Controller) *MockResolver {
-	mock := &MockResolver{ctrl: ctrl}
-	mock.recorder = &MockResolverMockRecorder{mock}
+// NewMockGslbResolver creates a new mock instance.
+func NewMockGslbResolver(ctrl *gomock.Controller) *MockGslbResolver {
+	mock := &MockGslbResolver{ctrl: ctrl}
+	mock.recorder = &MockGslbResolverMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockResolver) EXPECT() *MockResolverMockRecorder {
+func (m *MockGslbResolver) EXPECT() *MockGslbResolverMockRecorder {
 	return m.recorder
 }
 
 // ResolveGslbSpec mocks base method.
-func (m *MockResolver) ResolveGslbSpec(ctx context.Context, gslb *v1beta1.Gslb, client client.Client) error {
+func (m *MockGslbResolver) ResolveGslbSpec(ctx context.Context, gslb *v1beta1.Gslb, client client.Client) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveGslbSpec", ctx, gslb, client)
 	ret0, _ := ret[0].(error)
@@ -63,13 +63,13 @@ func (m *MockResolver) ResolveGslbSpec(ctx context.Context, gslb *v1beta1.Gslb, 
 }
 
 // ResolveGslbSpec indicates an expected call of ResolveGslbSpec.
-func (mr *MockResolverMockRecorder) ResolveGslbSpec(ctx, gslb, client interface{}) *gomock.Call {
+func (mr *MockGslbResolverMockRecorder) ResolveGslbSpec(ctx, gslb, client interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveGslbSpec", reflect.TypeOf((*MockResolver)(nil).ResolveGslbSpec), ctx, gslb, client)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveGslbSpec", reflect.TypeOf((*MockGslbResolver)(nil).ResolveGslbSpec), ctx, gslb, client)
 }
 
 // ResolveOperatorConfig mocks base method.
-func (m *MockResolver) ResolveOperatorConfig() (*Config, error) {
+func (m *MockGslbResolver) ResolveOperatorConfig() (*Config, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ResolveOperatorConfig")
 	ret0, _ := ret[0].(*Config)
@@ -78,7 +78,7 @@ func (m *MockResolver) ResolveOperatorConfig() (*Config, error) {
 }
 
 // ResolveOperatorConfig indicates an expected call of ResolveOperatorConfig.
-func (mr *MockResolverMockRecorder) ResolveOperatorConfig() *gomock.Call {
+func (mr *MockGslbResolverMockRecorder) ResolveOperatorConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveOperatorConfig", reflect.TypeOf((*MockResolver)(nil).ResolveOperatorConfig))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResolveOperatorConfig", reflect.TypeOf((*MockGslbResolver)(nil).ResolveOperatorConfig))
 }

--- a/controllers/gslb_controller_test.go
+++ b/controllers/gslb_controller_test.go
@@ -1222,7 +1222,7 @@ func reconcileAndUpdateGslb(t *testing.T, s testSettings) {
 	// resources' Status.
 	res, err := s.reconciler.Reconcile(context.TODO(), s.request)
 	if err != nil {
-		return
+		t.Fatalf("reconciliation error: %s", err)
 	}
 
 	if !s.finalCall {


### PR DESCRIPTION
if we do `kubectl apply -f ...` with GSLB having:
```yaml
   # valid values in glsb roundrobin
    weight:
      eu: 50%
      us: 50
```
the JSON masrshaller doesn't know whether values are number (50) or string (50%, "50").
The value is `type Percentage string`. Unmrashal function makes conversion, so 50, 50%, "50","50%" are valid.

I made several changes:
- change comment in CRD
- Unmarshall
- Fix one of the unit-tests
- Regenerate Mocks
