### PR TITLE
Separate helm stuff from pure (/reusable) crd definitions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ DNS_ZONE ?= cloud.example.com
 DEMO_URL ?= http://failover.cloud.example.com
 DEMO_DEBUG ?=0
 DEMO_DELAY ?=5
-GSLB_CRD_YAML ?= chart/k8gb/templates/crds/k8gb.absa.oss_gslbs.yaml
+GSLB_CRD_YAML ?= chart/k8gb/crd/k8gb.absa.oss_gslbs.yaml
 
 ifndef NO_COLOR
 YELLOW=\033[0;33m
@@ -121,7 +121,7 @@ demo: ## Execute end-to-end demo
 # spin-up local environment
 .PHONY: deploy-full-local-setup
 deploy-full-local-setup: ensure-cluster-size ## Deploy full local multicluster setup (k3d >= 5.1.0)
-	@echo -e "\n$(YELLOW)Creating $(CLUSTERS_NUMBER) k8s clusters$(NC)"
+	@echo -e "\n$(YELLOW)Creating $$(( $(CLUSTERS_NUMBER) + 1 )) k8s clusters$(NC)"
 	$(MAKE) create-local-cluster CLUSTER_NAME=edge-dns
 	@for c in $(CLUSTER_IDS); do \
 		$(MAKE) create-local-cluster CLUSTER_NAME=$(CLUSTER_NAME)$$c ;\
@@ -527,9 +527,7 @@ endef
 define crd-manifest
 	$(call install-controller-gen)
 	@echo -e "\n$(YELLOW)Generating the CRD manifests$(NC)"
-	@echo -n "{{- if .Values.k8gb.deployCrds }}" > $(GSLB_CRD_YAML)
-	$(GOBIN)/controller-gen crd:crdVersions=v1 paths="./..." output:crd:stdout >> $(GSLB_CRD_YAML)
-	@echo "{{- end }}"  >> $(GSLB_CRD_YAML)
+	$(GOBIN)/controller-gen crd:crdVersions=v1 paths="./..." output:crd:stdout > $(GSLB_CRD_YAML)
 endef
 
 define install-controller-gen

--- a/chart/k8gb/crd/dns-endpoint-crd-manifest.yaml
+++ b/chart/k8gb/crd/dns-endpoint-crd-manifest.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.k8gb.deployCrds }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -92,4 +91,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/chart/k8gb/crd/k8gb.absa.oss_gslbs.yaml
+++ b/chart/k8gb/crd/k8gb.absa.oss_gslbs.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.k8gb.deployCrds }}---
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -365,4 +365,3 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end }}

--- a/chart/k8gb/templates/crds-template.yaml
+++ b/chart/k8gb/templates/crds-template.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.k8gb.deployCrds }}
+
+{{- $files := .Files }}
+{{- range tuple "crd/k8gb.absa.oss_gslbs.yaml" "crd/dns-endpoint-crd-manifest.yaml" }}
+{{ $files.Get . }}
+
+{{- end }}
+
+{{- end }}


### PR DESCRIPTION
Fixes #925 

Using helm's `$files.Get` to include those two CRDs based on the `k8gb.deployCrds` flag. This way we can have pure CRDs that are also deployable w/o helm (or remotely referencing the github url)

side note: there is also a line with `$$(( $(CLUSTERS_NUMBER) + 1 ))`, because when doing full local setup, we are actually deploying n+1 clusters (+1 for the edge dns cluster)

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>