### PR TITLE
Resource Extensions added

### DIFF
--- a/terratest/test/k8gb_basic_app_test.go
+++ b/terratest/test/k8gb_basic_app_test.go
@@ -67,7 +67,7 @@ func TestK8gbBasicAppExample(t *testing.T) {
 
 	utils.CreateGslb(t, options, settings, kubeResourcePath)
 
-	k8s.WaitUntilIngressAvailable(t, options, "test-gslb", 120, 1*time.Second)
+	k8s.WaitUntilIngressAvailable(t, options, "test-gslb", utils.DefaultRetries, 1*time.Second)
 	ingress := k8s.GetIngress(t, options, "test-gslb")
 	require.Equal(t, ingress.Name, "test-gslb")
 

--- a/terratest/test/k8gb_lifecycle_test.go
+++ b/terratest/test/k8gb_lifecycle_test.go
@@ -71,7 +71,7 @@ func TestK8gbRepeatedlyRecreatedFromIngress(t *testing.T) {
 
 	utils.CreateGslb(t, options, settings, ingressResourcePath)
 
-	k8s.WaitUntilIngressAvailable(t, options, name, 120, 1*time.Second)
+	k8s.WaitUntilIngressAvailable(t, options, name, utils.DefaultRetries, 1*time.Second)
 
 	ingress := k8s.GetIngress(t, options, name)
 
@@ -87,7 +87,7 @@ func TestK8gbRepeatedlyRecreatedFromIngress(t *testing.T) {
 	// recreate ingress
 	utils.CreateGslb(t, options, settings, ingressResourcePath)
 
-	k8s.WaitUntilIngressAvailable(t, options, name, 120, 1*time.Second)
+	k8s.WaitUntilIngressAvailable(t, options, name, utils.DefaultRetries, 1*time.Second)
 
 	ingress = k8s.GetIngress(t, options, name)
 
@@ -129,14 +129,14 @@ func TestK8gbSpecKeepsStableAfterIngressUpdates(t *testing.T) {
 
 	// create gslb
 	utils.CreateGslb(t, options, settings, kubeResourcePath)
-	k8s.WaitUntilIngressAvailable(t, options, name, 120, 1*time.Second)
+	k8s.WaitUntilIngressAvailable(t, options, name, utils.DefaultRetries, 1*time.Second)
 
 	assertStrategy(t, options)
 
 	// reapply ingress
 	utils.CreateGslb(t, options, settings, ingressResourcePath)
 
-	k8s.WaitUntilIngressAvailable(t, options, name, 120, 1*time.Second)
+	k8s.WaitUntilIngressAvailable(t, options, name, utils.DefaultRetries, 1*time.Second)
 
 	ingress := k8s.GetIngress(t, options, name)
 

--- a/terratest/utils/utils.go
+++ b/terratest/utils/utils.go
@@ -39,6 +39,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const DefaultRetries = 120
+
 // GetIngressIPs returns slice of IP's related to ingress
 func GetIngressIPs(t *testing.T, options *k8s.KubectlOptions, ingressName string) []string {
 	var ingressIPs []string
@@ -139,17 +141,17 @@ func InstallPodinfo(t *testing.T, options *k8s.KubectlOptions, settings TestSett
 		LabelSelector: "app.kubernetes.io/name=frontend-podinfo",
 	}
 
-	k8s.WaitUntilNumPodsCreated(t, options, testAppFilter, 1, 120, 1*time.Second)
+	k8s.WaitUntilNumPodsCreated(t, options, testAppFilter, 1, DefaultRetries, 1*time.Second)
 
 	var testAppPods []corev1.Pod
 
 	testAppPods = k8s.ListPods(t, options, testAppFilter)
 
 	for _, pod := range testAppPods {
-		k8s.WaitUntilPodAvailable(t, options, pod.Name, 120, 1*time.Second)
+		k8s.WaitUntilPodAvailable(t, options, pod.Name, DefaultRetries, 1*time.Second)
 	}
 
-	k8s.WaitUntilServiceAvailable(t, options, "frontend-podinfo", 120, 1*time.Second)
+	k8s.WaitUntilServiceAvailable(t, options, "frontend-podinfo", DefaultRetries, 1*time.Second)
 
 }
 
@@ -157,7 +159,7 @@ func CreateGslbWithHealthyApp(t *testing.T, options *k8s.KubectlOptions, setting
 
 	CreateGslb(t, options, settings, kubeResourcePath)
 
-	k8s.WaitUntilIngressAvailable(t, options, gslbName, 120, 1*time.Second)
+	k8s.WaitUntilIngressAvailable(t, options, gslbName, DefaultRetries, 1*time.Second)
 	ingress := k8s.GetIngress(t, options, gslbName)
 	require.Equal(t, ingress.Name, gslbName)
 
@@ -183,7 +185,7 @@ func AssertGslbStatus(t *testing.T, options *k8s.KubectlOptions, gslbName, servi
 	_, err := DoWithRetryWaitingForValueE(
 		t,
 		"Wait for expected ServiceHealth status...",
-		120,
+		DefaultRetries,
 		1*time.Second,
 		actualHealthStatus,
 		expectedHealthStatus)


### PR DESCRIPTION
I expanded the terratest abstraction to have easier access to resources like DNSEndpoint, or GSLB. This way I can, for example, compare the targets in DNSEndpoints with the expected values, so we can thus simplify code execution and avoid  possible racing.

see canges in `TestWeightsExistsInLocalDNSEndpoint`.

I can do:
 - easily work with External and Local DNS Endpoints, could reapply by ingress resource
  - `instanceUS.ReapplyIngress(<ingress path>)`
  - `instanceEU.WaitForExternalDNSEndpointExists()`
  - `instanceEU.WaitForLocalDNSEndpointExists()`
  - `instanceEU.Resources().GetExternalDNSEndpoint().GetEndpointByName(endpointDNSNameEU)`
  - `instanceEU.Resources().GetLocalDNSEndpoint().GetEndpointByName(host)`
  - `instanceEU.Resources().Ingress()`
  - `instanceEU.Resources().GslbSpecProperty("spec.ingress.rules[0].host")`


I also added a new waiting function using `Ticker` class:
 - `instanceUS.WaitForLocalDNSEndpointHasTargets(expectedTargets)`

Signed-off-by: kuritka <kuritka@gmail.com>