### PR TITLE
Helm values schema check

### DIFF
--- a/.github/workflows/helm_check-values-schema.yaml
+++ b/.github/workflows/helm_check-values-schema.yaml
@@ -6,8 +6,8 @@ on:
     branches:
       - master
     paths:
-      - 'chart/{repo}/values.yaml'
-      - 'chart/{repo}/values.schema.json'
+      - 'chart/k8gb/values.yaml'
+      - 'chart/k8gb/values.schema.json'
 jobs:
   check:
     name: 'Check values.yaml and its schema in PR'
@@ -17,8 +17,8 @@ jobs:
         uses: actions/checkout@v3
       - name: 'Check if values.schema.json was updated'
         run: |
-          VALUES_FILE=chart/{repo}/values.yaml
-          SCHEMA_FILE=chart/{repo}/values.schema.json
+          VALUES_FILE=chart/k8gb/values.yaml
+          SCHEMA_FILE=chart/k8gb/values.schema.json
 
           # check if the values.json is covered by the schema
           pip3 install json-spec

--- a/.github/workflows/helm_check-values-schema.yaml
+++ b/.github/workflows/helm_check-values-schema.yaml
@@ -1,0 +1,27 @@
+# thanks to https://github.com/giantswarm/devctl/blob/v5.9.0/pkg/gen/input/workflows/internal/file/check_values_schema.yaml.template for the idea
+
+name: 'Check if values schema file has been updated'
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'chart/{repo}/values.yaml'
+      - 'chart/{repo}/values.schema.json'
+jobs:
+  check:
+    name: 'Check values.yaml and its schema in PR'
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: 'Check if values.schema.json was updated'
+        run: |
+          VALUES_FILE=chart/{repo}/values.yaml
+          SCHEMA_FILE=chart/{repo}/values.schema.json
+
+          # check if the values.json is covered by the schema
+          pip3 install json-spec
+          yq -o=json eval ${VALUES_FILE} > /tmp/values.json
+          json validate --schema-file=${SCHEMA_FILE} --document-file=/tmp/values.json
+          echo "PASSED: values.yaml and values.schema.json both appear to have been updated and the document is valid against the schema"

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "values.yaml for k8gb helm chart",
     "$ref": "#/definitions/All",
     "definitions": {
         "All": {
@@ -36,8 +36,7 @@
                 "tracing": {
                     "$ref": "#/definitions/Tracing"
                 }
-            },
-            "required": []
+            }
         },
         "Coredns": {
             "type": "object",
@@ -56,7 +55,6 @@
                     "$ref": "#/definitions/CorednsServiceAccount"
                 }
             },
-            "required": [],
             "title": "Coredns"
         },
         "CorednsDeployment": {
@@ -67,7 +65,6 @@
                     "type": "boolean"
                 }
             },
-            "required": [],
             "title": "Deployment"
         },
         "CorednsImage": {
@@ -121,7 +118,6 @@
                     "$ref": "#/definitions/ExternaldnsSecurityContext"
                 }
             },
-            "required": [],
             "title": "Externaldns"
         },
         "ExternaldnsSecurityContext": {
@@ -140,7 +136,6 @@
                     "type": "boolean"
                 }
             },
-            "required": [],
             "title": "ExternaldnsSecurityContext"
         },
         "Global": {
@@ -155,12 +150,10 @@
                     }
                 }
             },
-            "required": [],
             "title": "Global"
         },
         "Image": {
             "type": "object",
-            "required": [],
             "additionalProperties": false,
             "properties": {
                 "repository": {
@@ -225,8 +218,7 @@
                     "minLength": 1
                 },
                 "imageTag": {
-                    "type": "string",
-                    "minLength": 1
+                    "type": ["string", "null"]
                 },
                 "deployCrds": {
                     "type": "boolean"
@@ -299,7 +291,6 @@
                     "enum": ["panic", "fatal", "error", "warn", "info", "debug", "trace"]
                 }
             },
-            "required": [],
             "title": "Log"
         },
         "k8gbSecurityContext": {
@@ -320,7 +311,6 @@
                     "minimum": 0
                 }
             },
-            "required": [],
             "title": "k8gbSecurityContext"
         },
         "Ns1": {
@@ -334,7 +324,6 @@
                     "type": "boolean"
                 }
             },
-            "required": [],
             "title": "Ns1"
         },
         "Openshift": {
@@ -345,7 +334,6 @@
                     "type": "boolean"
                 }
             },
-            "required": [],
             "title": "Openshift"
         },
         "Rfc2136": {
@@ -388,7 +376,6 @@
                     "minLength": 1
                 }
             },
-            "required": [],
             "title": "Rfc2136Opt"
         },
         "Route53": {


### PR DESCRIPTION
if there is a change to `values.yaml` or `values.schema.json`, this workflow will verify that `values.yaml` file is still valid against the corresponding JSON schema.

I had to remove those `required: []` lines because the python tool was failing on them. Semantically it's the same, these lines were actually redundant.