### PR TITLE
Skip the print debug action if the action is run redundantly

### DIFF
--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -93,11 +93,11 @@ jobs:
           echo "::endgroup::"
 
       - name: Print debug info
-        if: always()
+        if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
         uses: ./.github/actions/print-debug
 
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
         with:
           name: terratest-logs
           path: ${{ github.workspace }}/tmp/terratest

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -85,11 +85,11 @@ jobs:
           echo "::endgroup::"
 
       - name: Print debug info
-        if: always()
+        if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
         uses: ./.github/actions/print-debug
 
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
         with:
           name: terratest-logs
           path: ${{ github.workspace }}/tmp/terratest

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -82,11 +82,11 @@ jobs:
           echo "::endgroup::"
 
       - name: Print debug info
-        if: always()
+        if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
         uses: ./.github/actions/print-debug
 
       - uses: actions/upload-artifact@v2
-        if: always()
+        if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
         with:
           name: terratest-logs
           path: ${{ github.workspace }}/tmp/terratest


### PR DESCRIPTION
It looks like I broke the build with my last merged PR. The reason for that is that I was opening the pull request from my forked repo, so the action was run only once for the PR. However, we have that logic in our action that handles redundant action runs (one for push to feature branch on the repo, one for the PR, squashed commit vs the pr, etc.)

So this time I am opening the PR from the feature branch on this repo just to be sure it will be ok.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>