### PR TITLE
Bump k3s to v1.25.2

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -39,7 +39,7 @@ k8gb:
   # -- Metrics server address
   metricsAddress: "0.0.0.0:8080"
   securityContext:
-    # -- For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#securitycontext-v1-core
+    # -- For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -50,8 +50,8 @@ externaldns:
   image: k8s.gcr.io/external-dns/external-dns:v0.9.0
   # -- external-dns sync interval
   interval: "20s"
-  securityContext: # For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#securitycontext-v1-core
-    # -- For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#securitycontext-v1-core
+  securityContext:
+    # -- For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
     runAsUser: 1000
     # -- For ExternalDNS to be able to read Kubernetes and AWS token files
     fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files

--- a/k3d/edge-dns.yaml
+++ b/k3d/edge-dns.yaml
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: edgedns
-image: docker.io/rancher/k3s:v1.22.6-k3s1
+image: docker.io/rancher/k3s:v1.25.2-k3s1
 agents: 0
 network: k3d-action-bridge-network
 ports:
@@ -17,6 +17,6 @@ options:
     disableLoadbalancer: true
   k3s:
     extraArgs:
-      - arg: --no-deploy=traefik,servicelb,metrics-server,local-storage
+      - arg: --disable=traefik,servicelb,metrics-server,local-storage
         nodeFilters:
           - server:*

--- a/k3d/gslb.yaml.tmpl
+++ b/k3d/gslb.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb$CLUSTER_INDEX
-image: docker.io/rancher/k3s:v1.22.6-k3s1
+image: docker.io/rancher/k3s:v1.25.2-k3s1
 agents: 1
 network: k3d-action-bridge-network
 ports:
@@ -26,6 +26,6 @@ options:
     disableLoadbalancer: true
   k3s:
     extraArgs:
-      - arg: --no-deploy=traefik,servicelb,metrics-server,local-storage
+      - arg: --disable=traefik,servicelb,metrics-server,local-storage
         nodeFilters:
           - server:*

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb1
-image: docker.io/rancher/k3s:v1.22.6-k3s1
+image: docker.io/rancher/k3s:v1.25.2-k3s1
 agents: 1
 network: k3d-action-bridge-network
 ports:
@@ -29,6 +29,6 @@ options:
     disableLoadbalancer: true
   k3s:
     extraArgs:
-      - arg: --no-deploy=traefik,servicelb,metrics-server,local-storage
+      - arg: --disable=traefik,servicelb,metrics-server,local-storage
         nodeFilters:
           - server:*

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb2
-image: docker.io/rancher/k3s:v1.22.6-k3s1
+image: docker.io/rancher/k3s:v1.25.2-k3s1
 agents: 1
 network: k3d-action-bridge-network
 ports:
@@ -26,6 +26,6 @@ options:
     disableLoadbalancer: true
   k3s:
     extraArgs:
-      - arg: --no-deploy=traefik,servicelb,metrics-server,local-storage
+      - arg: --disable=traefik,servicelb,metrics-server,local-storage
         nodeFilters:
           - server:*

--- a/k3d/test-gslb3.yaml
+++ b/k3d/test-gslb3.yaml
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb3
-image: docker.io/rancher/k3s:v1.22.6-k3s1
+image: docker.io/rancher/k3s:v1.25.2-k3s1
 agents: 1
 network: k3d-action-bridge-network
 ports:
@@ -26,6 +26,6 @@ options:
     disableLoadbalancer: true
   k3s:
     extraArgs:
-      - arg: --no-deploy=traefik,servicelb,metrics-server,local-storage
+      - arg: --disable=traefik,servicelb,metrics-server,local-storage
         nodeFilters:
           - server:*


### PR DESCRIPTION
Lets see if terratests will fly on `k8s@1.25`

`--no-deploy=x,y,z` had to be changed to `--disable=..`, otherwise it fails (it's not only warning, it really fails to start) on:

`fatal log from node k3d-edgedns-server-0 (retrying 9/10): ctime="2022-10-05T13:05:05Z" level=fatal msg="no-deploy flag is deprecated. Use --disable instead."`

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>