### PR TITLE
Expose NGINX Ingress values Path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ STABLE_VERSION := "stable"
 # default bundle image tag
 BUNDLE_IMG ?= controller-bundle:$(VERSION)
 
+NGINX_INGRESS_VALUES_PATH ?= deploy/ingress/nginx-ingress-values.yaml
+
 # options for 'bundle-build'
 ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
@@ -178,7 +180,7 @@ deploy-local-cluster:
 	helm repo add --force-update nginx-stable https://kubernetes.github.io/ingress-nginx
 	helm repo update
 	helm -n k8gb upgrade -i nginx-ingress nginx-stable/ingress-nginx \
-		--version 4.0.15 -f deploy/ingress/nginx-ingress-values.yaml
+		--version 4.0.15 -f $(NGINX_INGRESS_VALUES_PATH)
 
 	@if [ "$(DEPLOY_APPS)" = true ]; then $(MAKE) deploy-test-apps ; fi
 


### PR DESCRIPTION
NGINX ingress defines the [digest](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml#L27) value. Not all environments work correctly with this value.

I am exposing the path to `nginx-ingress-values.yaml` from our Makefile so that I can easily override these values if needed. If `NGINX_INGRESS_VALUES_PATH` is not explicitly specified, the standard file path is used, as we use now.

Signed-off-by: kuritka <kuritka@gmail.com>