### PR TITLE
Get rid of set-output commands in the workflows

### DIFF
--- a/.github/actions/print-debug/action.yaml
+++ b/.github/actions/print-debug/action.yaml
@@ -10,7 +10,6 @@ runs:
   using: "composite"
   steps:
     - name: Check verbose
-      id: check
       shell: bash
       run: |
         if [[ "x${{ runner.debug }}" == "x1" ]]; then
@@ -26,7 +25,7 @@ runs:
         env | sort
         echo ---------------------------------------
         echo inputs.kubectl-context=${{ inputs.kubectl-context }}
-        echo verbose: ${{ steps.check.outputs.verbose }}
+        echo verbose: ${{ env.verbose }}
         echo "::endgroup::"
 
     - name: Terratest Logs
@@ -54,7 +53,7 @@ runs:
 
     - name: CoreDNS Hosts
       shell: bash
-      if: steps.check.outputs.verbose == 'true'
+      if: env.verbose == 'true'
       run: |
         echo -e "\n\n\nVerbose is on, printing all the debug stuff:\n--------------------------------------------\n\n"
         echo "::group:: ☸☸☸ cluster coredns - hosts (cluster 1)"
@@ -63,7 +62,7 @@ runs:
 
     - name: K8s Events
       shell: bash
-      if: steps.check.outputs.verbose == 'true'
+      if: env.verbose == 'true'
       run: |
         echo "::group:: ☸☸☸ k get events"
         kubectl --context=${{ inputs.kubectl-context }} get events -A || true
@@ -71,7 +70,7 @@ runs:
 
     - name: gslbs
       shell: bash
-      if: steps.check.outputs.verbose == 'true'
+      if: env.verbose == 'true'
       run: |
         echo "::group:: ☸☸☸ gslbs"
         kubectl --context=${{ inputs.kubectl-context }} get gslbs -owide -A || true
@@ -79,7 +78,7 @@ runs:
 
     - name: Dnsendpoints
       shell: bash
-      if: steps.check.outputs.verbose == 'true'
+      if: env.verbose == 'true'
       run: |
         echo "::group:: ☸☸☸ endpoints"
         kubectl --context=${{ inputs.kubectl-context }} get dnsendpoints -A || true
@@ -87,7 +86,7 @@ runs:
 
     - name: K8gb logs
       shell: bash
-      if: steps.check.outputs.verbose == 'true'
+      if: env.verbose == 'true'
       run: |
         echo "::group:: ☸☸☸ k8gb logs"
         kubectl --context=${{ inputs.kubectl-context }} logs -lname=k8gb -n k8gb --tail=-1 || true
@@ -95,7 +94,7 @@ runs:
 
     - name: Metrics
       shell: bash
-      if: steps.check.outputs.verbose == 'true'
+      if: env.verbose == 'true'
       run: |
         echo "::group:: ☸☸☸ k8gb metrics (cluster 1)"
         _IP=$(kubectl --context=${{ inputs.kubectl-context }} get pods -lname=k8gb -n k8gb -o custom-columns='IP:status.podIP' --no-headers)

--- a/.github/actions/print-debug/action.yaml
+++ b/.github/actions/print-debug/action.yaml
@@ -14,9 +14,9 @@ runs:
       shell: bash
       run: |
         if [[ "x${{ runner.debug }}" == "x1" ]]; then
-           echo ::set-output name=verbose::true
+          echo "verbose=true" >> $GITHUB_ENV
         else
-           echo ::set-output name=verbose::false
+          echo "verbose=false" >> $GITHUB_ENV
         fi
 
     - name: Env vars

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -15,11 +15,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get Desired Tag
-        id: get_desired_tag
         run: |
           tag=$(awk '/appVersion:/ {print $2}' chart/k8gb/Chart.yaml)
           echo "Version to release: ${tag}"
-          echo "::set-output name=tag::${tag}"
+          echo "desired_tag=${tag}" >> $GITHUB_ENV
       - name: Push Tag
         if: startsWith(github.event.head_commit.message, 'RELEASE:')
         uses: mathieudutour/github-tag-action@v5.6
@@ -27,26 +26,24 @@ jobs:
           github_token: ${{ secrets.CR_TOKEN }}
           create_annotated_tag: true
           tag_prefix: ""
-          custom_tag: ${{ steps.get_desired_tag.outputs.tag }}
+          custom_tag: ${{ env.desired_tag }}
       - name: Get Current Tag
         if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:')
-        id: get_current_tag
         run: |
           tag=$(git describe --tags --abbrev=0)
           echo "Version to revert: ${tag}"
-          echo "::set-output name=tag::${tag}"
+          echo "current_tag=${tag}" >> $GITHUB_ENV
       - name: Get Previous Tag
         if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:')
-        id: get_previous_tag
         run: |
           tag=$(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)
           echo "Previous tag: ${tag}"
-          echo "::set-output name=tag::${tag}"
+          echo "previous_tag=${tag}" >> $GITHUB_ENV
       - name: Delete Tag and Release
-        if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:') && steps.get_desired_tag.outputs.tag == steps.get_previous_tag.outputs.tag
+        if: startsWith(github.event.head_commit.message, 'Revert "RELEASE:') && env.desired_tag == env.previous_tag
         uses: dev-drprasad/delete-tag-and-release@v0.2.0
         with:
           delete_release: true # default: false
-          tag_name: ${{ steps.get_current_tag.outputs.tag }}
+          tag_name: ${{ env.current_tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.CR_TOKEN }}

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -25,7 +25,6 @@ jobs:
           fetch-depth: 0
 
       - name: Get version
-        id: get_version
         run: |
           if [ "${{ github.event.inputs.bundleVersion }}x" == "x" ]; then
             version=$(git describe --abbrev=0 --tags)
@@ -37,15 +36,15 @@ jobs:
           else
             bundleDir=${version}
           fi
-          echo "::set-output name=bundleDir::${bundleDir#v}"
-          echo "::set-output name=version::${version#v}"
+          echo "bundleDir=${bundleDir#v}" >> $GITHUB_ENV
+          echo "version=${version#v}" >> $GITHUB_ENV
 
       - name: Generate OLM bundle
         env:
           TOOL_VERSION: ${{ github.event.inputs.olmBundleToolVersion }}
           DEBUG: 1
         run: |
-          ./olm/generate.sh ${{ steps.get_version.outputs.version }}
+          ./olm/generate.sh ${{ env.version }}
           rm ./olm/bundle/Dockerfile
           cp -r ./olm/bundle $GITHUB_WORKSPACE/
 
@@ -59,8 +58,8 @@ jobs:
       - name: Copy the generated manifests
         run: |
           mkdir -p $GITHUB_WORKSPACE/sandbox/operators/k8gb/
-          rm -rf $GITHUB_WORKSPACE/sandbox/operators/k8gb/${{ steps.get_version.outputs.bundleDir }} || true
-          cp -r $GITHUB_WORKSPACE/bundle/ $GITHUB_WORKSPACE/sandbox/operators/k8gb/${{ steps.get_version.outputs.bundleDir }}
+          rm -rf $GITHUB_WORKSPACE/sandbox/operators/k8gb/${{ env.bundleDir }} || true
+          cp -r $GITHUB_WORKSPACE/bundle/ $GITHUB_WORKSPACE/sandbox/operators/k8gb/${{ env.bundleDir }}
 
       - name: Open Pull Request
         id: cpr
@@ -69,8 +68,8 @@ jobs:
           token: ${{ secrets.CR_TOKEN }}
           push-to-fork: k8gb-io/community-operators
           path: sandbox
-          commit-message: OLM bundle for k8gb@${{ steps.get_version.outputs.bundleDir }}
-          title: operators k8gb ({{ steps.get_version.outputs.bundleDir }})
+          commit-message: OLM bundle for k8gb@${{ env.bundleDir }}
+          title: operators k8gb (${{ env.bundleDir }})
           body: |
             :package: Update k8gb operator bundle :package:
 
@@ -92,7 +91,7 @@ jobs:
             This automated PR was created by [this action][1].
 
             [1]: https://github.com/k8gb-io/k8gb/actions/runs/${{ github.run_id }}
-          branch: k8gb-${{ steps.get_version.outputs.bundleDir }}
+          branch: k8gb-${{ env.bundleDir }}
           delete-branch: true
           signoff: true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,15 +15,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Get tag
-        id: get_tag
         run: |
           previous_tag=$(git tag --sort=v:refname | tail -2 | head -1)
-          echo "::set-output name=previous_tag::${previous_tag}"
+          echo "previous_tag=${previous_tag}" >> $GITHUB_ENV
       - uses: heinrichreimer/github-changelog-generator-action@v2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           project: k8gb
-          sinceTag: ${{ steps.get_tag.outputs.previous_tag }}
+          sinceTag: ${{ env.previous_tag }}
           output: changes
           pullRequests: true
           author: true


### PR DESCRIPTION
Fixes https://github.com/k8gb-io/k8gb/issues/965

as suggested [here](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter) and [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/), the `echo "::set-output name=foo::${bar}"` should be replaced with `echo foo=bar >> $GITHUB_ENV` and then read as normal env var in all subsequent steps in the same job.
