### PR TITLE
Revert "RELEASE: v0.10.0 (#973)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+  packages: read
+
 jobs:
   release:
     runs-on: ubuntu-20.04

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -3,8 +3,8 @@ name: k8gb
 description: A Helm chart for Kubernetes Global Balancer
 icon: https://www.k8gb.io/assets/images/icon-192x192.png
 type: application
-version: v0.10.0
-appVersion: v0.10.0
+version: v0.9.0
+appVersion: v0.9.0
 kubeVersion: ">= 1.19.0-0"
 
 dependencies:


### PR DESCRIPTION
This reverts commit 1f34c7fc1b1ad712826c084e735707d1e38169fd.

+

adding the permission to the implicit `GITHUB_TOKEN` to avoid:

```
• failed to upload artifact, will retry artifact=k8gb_0.10.0_linux_arm64.tar.gz.sbom.json error=POST https://uploads.github.com/repos/k8gb-io/k8gb/releases/80201405/assets?name=k8gb_0.10.0_linux_arm64.tar.gz.sbom.json: 403 API rate limit exceeded for installation ID 16862322. [] try=10
```

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>