### PR TITLE
Revert "RELEASE: v0.10.0 (#981)"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,6 +79,8 @@ jobs:
           set | grep 'CONTAINER_'
           echo "container_info=$CONTAINER_INFO" >> $GITHUB_ENV
           echo "container_tags=$CONTAINER_TAGS" >> $GITHUB_ENV
+          echo "container_info=$CONTAINER_INFO" >> $GITHUB_OUTPUT
+          echo "container_tags=$CONTAINER_TAGS" >> $GITHUB_OUTPUT
       - name: Cleanup signing keys
         if: ${{ always() }}
         run: rm -f cosign.key

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -3,8 +3,8 @@ name: k8gb
 description: A Helm chart for Kubernetes Global Balancer
 icon: https://www.k8gb.io/assets/images/icon-192x192.png
 type: application
-version: v0.10.0
-appVersion: v0.10.0
+version: v0.9.0
+appVersion: v0.9.0
 kubeVersion: ">= 1.19.0-0"
 
 dependencies:


### PR DESCRIPTION
This reverts commit 3768dcc221482c1d6b4671d7e8202a0bac10f645.

The outputs of the job [are not there](https://github.com/k8gb-io/k8gb/actions/runs/3274955536/jobs/5389276791#step:5:25). The new way of sharing the outputs between jobs is this: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

Consuming/reading the data remains the same.

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>