### PR TITLE
Add Linux Foundation trademarks

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -59,6 +59,13 @@
           </a>
           sandbox project.
         </div>
+        <div>
+          <br>
+          Copyright © 2022 k8gb.io Project Authors. All rights reserved.
+          <br>
+          <br>
+          The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/"> Trademark Usage</a> page.
+        </div>
       </footer>
     </main>
   </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,7 +61,7 @@
         </div>
         <div>
           <br>
-          Copyright © 2022 k8gb.io Project Authors. All rights reserved.
+          Copyright 2022 The k8gb Contributors. All rights reserved.
           <br>
           <br>
           The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage/"> Trademark Usage</a> page.


### PR DESCRIPTION
Add k8gb.io copyright and Linux Foundation trademarks 
See https://clomonitor.io/docs/topics/checks/#trademark-disclaimer

Signed-off-by: Timofey Ilinykh <ilinytim@gmail.com>