### PR TITLE
Change gh token to avoid 1k limit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           echo "previous_tag=${previous_tag}" >> $GITHUB_ENV
       - uses: heinrichreimer/github-changelog-generator-action@854576bb5274851427527d8199fba0061552dff5
         with:
-          token: ${{ secrets.CHANGELOG_GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           project: k8gb
           sinceTag: ${{ env.previous_tag }}
           output: changes


### PR DESCRIPTION
#979 Github token would solve 1k limit issue, because it's unique and created per job, after it's destroyed. More info: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow