### PR TITLE
olm-automation: use fully qualified image including the registries

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -6,7 +6,7 @@ global:
 
 k8gb:
   # -- image repository
-  imageRepo: "absaoss/k8gb"
+  imageRepo: "docker.io/absaoss/k8gb"
   # -- ( string ) image tag defaults to Chart.AppVersion, see Chart.yaml, but can be overrided with imageTag key
   imageTag:
   # -- whether it should also deploy the gslb and dnsendpoints CRDs

--- a/olm/generate.sh
+++ b/olm/generate.sh
@@ -36,7 +36,7 @@ main() {
 }
 
 generate() {
-    echo "    containerImage: absaoss/k8gb:v${_VERSION}" >> ${DIR}/annotations.yaml.tmpl
+    echo "    containerImage: docker.io/absaoss/k8gb:v${_VERSION}" >> ${DIR}/annotations.yaml.tmpl
     cd ${DIR}/../chart/k8gb && helm dependency update && cd -
     helm -n placeholder template ${DIR}/../chart/k8gb \
         --name-template=k8gb \


### PR DESCRIPTION
Our previous automatic PR to `community-operators` (https://github.com/k8s-operatorhub/community-operators/pull/1843) wasn't merged ootb, because the test suite started verifying if the container image is fully qualified (including the registry prefix). `docker.io/` is kinda implicit, but it's prolly better to be explicit

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>