### PR TITLE
fix: update the minimum required version of k3d

### DIFF
--- a/docs/local.md
+++ b/docs/local.md
@@ -45,7 +45,7 @@ For more user-centric targets in that makefile consult `make help`.
 
  - [install **helm3**](https://helm.sh/docs/intro/install/) to deploy k8gb and related test workloads
 
- - [install **k3d**](https://k3d.io/#installation) to run local [k3s](https://k3s.io/) clusters (minimum v5.1.0 version is required)
+ - [install **k3d**](https://k3d.io/#installation) to run local [k3s](https://k3s.io/) clusters (minimum v5.3.0 version is required)
 
  - [install **golangci-lint**](https://golangci-lint.run/usage/install/#local-installation) for code quality checks
 


### PR DESCRIPTION
Signed-off-by: charlie <qianglin98@qq.com>

According to my test, I found that the minimum required version of k3d is v5.3.0

```
[root@master k8gb]# k3d cluster create -c k3d/edge-dns.yaml  # version: v5.1.0
FATA[0000] Cannot validate config file k3d/edge-dns.yaml: unsupported apiVersion 'k3d.io/v1alpha4' 
[root@master k8gb]# rm /usr/local/bin/k3d 
rm: remove regular file ‘/usr/local/bin/k3d’? y


[root@master k8gb]# curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.2.0 bash
Preparing to install k3d into /usr/local/bin
k3d installed into /usr/local/bin/k3d
Run 'k3d --help' to see what you can do with it.
[root@master k8gb]# k3d cluster create -c k3d/edge-dns.yaml
FATA[0000] Cannot validate config file k3d/edge-dns.yaml: unsupported apiVersion 'k3d.io/v1alpha4' 
[root@master k8gb]# rm /usr/local/bin/k3d 
rm: remove regular file ‘/usr/local/bin/k3d’? y


[root@master k8gb]# curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.2.1 bash
Preparing to install k3d into /usr/local/bin
k3d installed into /usr/local/bin/k3d
Run 'k3d --help' to see what you can do with it.
[root@master k8gb]# k3d cluster create -c k3d/edge-dns.yaml
FATA[0000] Cannot validate config file k3d/edge-dns.yaml: unsupported apiVersion 'k3d.io/v1alpha4' 
[root@master k8gb]# rm /usr/local/bin/k3d 
rm: remove regular file ‘/usr/local/bin/k3d’? y


[root@master k8gb]# curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.2.2 bash
Preparing to install k3d into /usr/local/bin
k3d installed into /usr/local/bin/k3d
Run 'k3d --help' to see what you can do with it.
[root@master k8gb]# k3d cluster create -c k3d/edge-dns.yaml
FATA[0000] Cannot validate config file k3d/edge-dns.yaml: unsupported apiVersion 'k3d.io/v1alpha4' 
[root@master k8gb]# rm /usr/local/bin/k3d 
rm: remove regular file ‘/usr/local/bin/k3d’? y


[root@master k8gb]# curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | TAG=v5.3.0 bash
Preparing to install k3d into /usr/local/bin
k3d installed into /usr/local/bin/k3d
Run 'k3d --help' to see what you can do with it.
[root@master k8gb]# k3d cluster create -c k3d/edge-dns.yaml
INFO[0000] Using config file k3d/edge-dns.yaml (k3d.io/v1alpha4#simple) 
INFO[0000] Prep: Network                                
INFO[0000] Created network 'k3d-action-bridge-network'  
INFO[0000] Created image volume k3d-edgedns-images      
INFO[0000] Starting new tools node...                   
INFO[0001] Creating node 'k3d-edgedns-server-0'         
INFO[0008] Pulling image 'docker.io/rancher/k3d-tools:5.3.0' 
```