### PR TITLE
Remove standalone Gosec badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 [![License: MIT](https://img.shields.io/badge/License-Apache_2.0-yellow.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Build Status](https://github.com/k8gb-io/k8gb/workflows/Golang%20lint,%20golic,%20gokart%20and%20test/badge.svg?branch=master)](https://github.com/k8gb-io/k8gb/actions?query=workflow%3A%22Golang%20lint,%20golic,%20gokart%20and%20test%22+branch%3Amaster)
 [![Terratest Status](https://github.com/k8gb-io/k8gb/workflows/Terratest/badge.svg?branch=master)](https://github.com/k8gb-io/k8gb/actions?query=workflow%3ATerratest+branch%3Amaster)
-[![Gosec](https://github.com/k8gb-io/k8gb/workflows/Gosec/badge.svg?branch=master)](https://github.com/k8gb-io/k8gb/actions?query=workflow%3AGosec+branch%3Amaster)
 [![CodeQL](https://github.com/k8gb-io/k8gb/workflows/CodeQL/badge.svg?branch=master)](https://github.com/k8gb-io/k8gb/actions?query=workflow%3ACodeQL+branch%3Amaster)
 [![Go Report Card](https://goreportcard.com/badge/github.com/k8gb-io/k8gb)](https://goreportcard.com/report/github.com/k8gb-io/k8gb)
 [![Helm Publish](https://github.com/k8gb-io/k8gb/actions/workflows/helm_publish.yaml/badge.svg)](https://github.com/k8gb-io/k8gb/actions/workflows/helm_publish.yaml)


### PR DESCRIPTION
* Remove Gosec badge as it is not valid anymore
* We are actually runnin gosec as part of main golangci https://github.com/k8gb-io/k8gb/blob/master/.golangci.yaml#L10


* Before
<img width="867" alt="image" src="https://user-images.githubusercontent.com/518532/229382540-4bed69e7-ca67-4c90-8ca9-617618df2a77.png">
* After
<img width="786" alt="image" src="https://user-images.githubusercontent.com/518532/229382564-feb7e60a-030b-4dc1-b730-48aaf1087ce7.png">
