### PR TITLE
Give external-dns assume role capabilities with route53 provider (helm)

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -100,6 +100,7 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | route53.enabled | bool | `false` | Enable Route53 provider |
 | route53.hostedZoneID | string | `"ZXXXSSS"` | Route53 ZoneID |
 | route53.irsaRole | string | `"arn:aws:iam::111111:role/external-dns"` | specify IRSA Role in AWS ARN format or disable it by setting to `false` |
+| route53.assumeRoleArn | string | `null` | specify IRSA Role in AWS ARN format for assume role permissions. Needed when Route53 is handled in a separate AWS account. Disable it by setting to `null` |
 | tracing.deployJaeger | bool | `false` | should the Jaeger be deployed together with the k8gb operator? In case of using another OpenTracing solution, make sure that configmap for OTEL agent has the correct exporters set up (`tracing.otelConfig`). |
 | tracing.enabled | bool | `false` | if the application should be sending the traces to OTLP collector (env var `TRACING_ENABLED`) |
 | tracing.endpoint | string | `"localhost:4318"` | `host:port` where the spans from the applications (traces) should be sent, sets the `OTEL_EXPORTER_OTLP_ENDPOINT` env var This is not the final destination where all the traces are going. Otel collector has its configuration in the associated configmap (`tracing.otelConfig`). |

--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -99,7 +99,7 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | rfc2136.rfc2136Opts[3].tsig-keyname | string | `"externaldns-key"` |  |
 | route53.enabled | bool | `false` | Enable Route53 provider |
 | route53.hostedZoneID | string | `"ZXXXSSS"` | Route53 ZoneID |
-| route53.irsaRole | string | `"arn:aws:iam::111111:role/external-dns"` | specify IRSA Role in AWS ARN format or disable it by setting to `false` |
+| route53.irsaRole | string | `"arn:aws:iam::111111:role/external-dns"` | specify IRSA Role in AWS ARN format or disable it by setting to `null` |
 | route53.assumeRoleArn | string | `null` | specify IRSA Role in AWS ARN format for assume role permissions. Needed when Route53 is handled in a separate AWS account. Disable it by setting to `null` |
 | tracing.deployJaeger | bool | `false` | should the Jaeger be deployed together with the k8gb operator? In case of using another OpenTracing solution, make sure that configmap for OTEL agent has the correct exporters set up (`tracing.otelConfig`). |
 | tracing.enabled | bool | `false` | if the application should be sending the traces to OTLP collector (env var `TRACING_ENABLED`) |

--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -31,6 +31,9 @@ spec:
         - --annotation-filter=k8gb.absa.oss/dnstype=extdns # filter out only relevant DNSEntrypoints
         - --txt-owner-id={{ include "k8gb.extdnsOwnerID" . }}
         - --provider={{ include "k8gb.extdnsProvider" . }}
+        {{- if .Values.route53.assumeRoleArn }}
+        - --aws-assume-role={{ .Values.route53.assumeRoleArn }}
+        {{- end }}
         {{ include "k8gb.extdnsProviderOpts" . }}
         resources:
           requests:

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -416,9 +416,16 @@
                     "minLength": 2
                 },
                 "irsaRole": {
-                    "type": "string",
-                    "pattern": "^arn:aws:iam:.+$",
-                    "minLength": 20
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "pattern": "^arn:aws:iam:.+$",
+                            "minLength": 20
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "assumeRoleArn": {
                     "oneOf": [

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -144,21 +144,21 @@
             "properties": {
                 "imagePullSecrets": {
                     "type": [
-                        "array", 
+                        "array",
                         "null"
-                    ], 
+                    ],
                     "items": {
                         "type": "object",
                         "properties": {
                             "name": {
-                              "type": [
-                                "string", 
-                                "null"
-                              ], 
-                              "description": "Name of secret"
+                                "type": [
+                                    "string",
+                                    "null"
+                                ],
+                                "description": "Name of secret"
                             }
                         }
-                    }, 
+                    },
                     "description": "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: http://kubernetes.io/docs/user-guide/secrets#manually-specifying-an-imagepullsecret"
                 }
             },
@@ -230,7 +230,10 @@
                     "minLength": 1
                 },
                 "imageTag": {
-                    "type": ["string", "null"]
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 },
                 "deployCrds": {
                     "type": "boolean"
@@ -297,10 +300,21 @@
             "additionalProperties": false,
             "properties": {
                 "format": {
-                    "enum": ["simple", "json"]
+                    "enum": [
+                        "simple",
+                        "json"
+                    ]
                 },
                 "level": {
-                    "enum": ["panic", "fatal", "error", "warn", "info", "debug", "trace"]
+                    "enum": [
+                        "panic",
+                        "fatal",
+                        "error",
+                        "warn",
+                        "info",
+                        "debug",
+                        "trace"
+                    ]
                 }
             },
             "title": "Log"
@@ -405,6 +419,18 @@
                     "type": "string",
                     "pattern": "^arn:aws:iam:.+$",
                     "minLength": 20
+                },
+                "assumeRoleArn": {
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "pattern": "^arn:aws:iam:.+$",
+                            "minLength": 20
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 }
             },
             "required": [
@@ -435,7 +461,10 @@
                     "pattern": "^(0(\\.\\d{1,3})?|1(\\.0)?)$"
                 },
                 "otelConfig": {
-                    "type": ["object", "null"],
+                    "type": [
+                        "object",
+                        "null"
+                    ],
                     "additionalProperties": true
                 },
                 "sidecarImage": {

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -94,7 +94,7 @@ route53:
   enabled: false
   # -- Route53 ZoneID
   hostedZoneID: ZXXXSSS
-  # -- specify IRSA Role in AWS ARN format or disable it by setting to `false`
+  # -- specify IRSA Role in AWS ARN format or disable it by setting to `null`
   irsaRole: arn:aws:iam::111111:role/external-dns
   # -- specify IRSA Role in AWS ARN format for assume role permissions or disable it by setting to `null`
   assumeRoleArn: null

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -1,5 +1,5 @@
 global:
-  # -- Reference to one or more secrets to be used when pulling images 
+  # -- Reference to one or more secrets to be used when pulling images
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   imagePullSecrets: []
   # - name: "image-pull-secret"
@@ -96,6 +96,8 @@ route53:
   hostedZoneID: ZXXXSSS
   # -- specify IRSA Role in AWS ARN format or disable it by setting to `false`
   irsaRole: arn:aws:iam::111111:role/external-dns
+  # -- specify IRSA Role in AWS ARN format for assume role permissions or disable it by setting to `null`
+  assumeRoleArn: null
 
 ns1:
   # -- Enable NS1 provider


### PR DESCRIPTION
Hello,

I would like to add the capability for `external-dns` to assume role, using `route53` provider when the hosted zones are handled in a different AWS account by adding `--aws-assume-role` argument (see [this external-dns PR](https://github.com/kubernetes-sigs/external-dns/pull/524#issue-181256561)).
The change was successfully deployed on our clusters and is now, able to access the given hosted zone.

Besides this change, I've also fixed `route53.irsaRole` when disabled. The json schema validation regex was not allowing any other value than a valid ARN string.

If anything is unclear/missing please let me know 🙂 