### PR TITLE
Switch to own external-dns fork(again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,6 @@ deploy-k8gb-with-helm:
 		--set k8gb.log.level=$(LOG_LEVEL) \
 		--set rfc2136.enabled=true \
 		--set k8gb.edgeDNSServers[0]=$(shell $(CLUSTER_GSLB_GATEWAY)):1053 \
-		--set externaldns.image=absaoss/external-dns:rfc-ns1 \
 		--wait --timeout=2m0s
 
 .PHONY: deploy-gslb-operator

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -47,6 +47,10 @@ k8gb:
 
 externaldns:
   # -- external-dns image repo:tag
+  # It is important to use the image from k8gb external-dns fork to get the full
+  # functionality. See links below
+  # https://github.com/k8gb-io/external-dns
+  # https://github.com/k8gb-io/external-dns/pkgs/container/external-dns
   image: ghcr.io/k8gb-io/external-dns:v0.13.4-azure-ns
   # -- external-dns sync interval
   interval: "20s"

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -47,7 +47,7 @@ k8gb:
 
 externaldns:
   # -- external-dns image repo:tag
-  image: registry.k8s.io/external-dns/external-dns:v0.9.0
+  image: ghcr.io/k8gb-io/external-dns:v0.13.4-azure-ns
   # -- external-dns sync interval
   interval: "20s"
   securityContext:


### PR DESCRIPTION
* Unfortunately upstream external-dns reviews take too long and we have to switch to own fork again(we did it before)
* Main motivation at the moment is to unblock Azure NS support
* Fork incorporates https://github.com/kubernetes-sigs/external-dns/pull/2835