### PR TITLE
Fix release tagging action

### DIFF
--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -29,7 +29,7 @@ jobs:
           echo "desired_tag=${tag}" >> $GITHUB_ENV
       - name: Push Tag
         if: startsWith(github.event.head_commit.message, 'RELEASE:')
-        uses: mathieudutour/github-tag-action@86301c823dac64d427711dd6b99d7ffdd894d2dd
+        uses: mathieudutour/github-tag-action@fcfbdceb3093f6d85a3b194740f8c6cec632f4e2 #v6.1
         with:
           github_token: ${{ secrets.CR_TOKEN }}
           create_annotated_tag: true


### PR DESCRIPTION
cut_release fails with

```
Error: File not found: '/home/runner/work/_actions/mathieudutour/github-tag-action/86301c823dac64d427711dd6b99d7ffdd894d2dd/lib/main.js'
```