### PR TITLE
Fix 1078: don't use -i for sed (platform differences)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -482,9 +482,9 @@ define deploy-edgedns
 endef
 
 define apply-cr
-	sed -i 's/cloud\.example\.com/$(GSLB_DOMAIN)/g' "$1"
-	kubectl apply -f "$1"
-	git checkout -- "$1"
+	sed 's/cloud\.example\.com/$(GSLB_DOMAIN)/g' "$1" > "$1-cr"
+	-kubectl apply -f "$1-cr"
+	-rm "$1-cr"
 endef
 
 define get-cluster-geo-tag

--- a/docs/local.md
+++ b/docs/local.md
@@ -26,11 +26,6 @@ For more user-centric targets in that makefile consult `make help`.
 
 - [Install **Git**](https://git-scm.com/downloads)
 
-- Install **gnu-sed** if you don't have it. If you are on a Mac, install `gnu-sed` with Homebrew
-    ```sh
-    brew install gnu-sed
-    ```
-
 - [Install **Docker**](https://docs.docker.com/get-docker/)
   > Ensure you are able to push/pull from your docker registry
 


### PR DESCRIPTION
Fix: https://github.com/k8gb-io/k8gb/issues/1078
this works with both gnu-sed and Mac/BSD-based sed