### PR TITLE
Add optionally servicemonitor service and object

### DIFF
--- a/chart/k8gb/templates/_helpers.tpl
+++ b/chart/k8gb/templates/_helpers.tpl
@@ -121,3 +121,6 @@ k8gb-{{ .Values.k8gb.dnsZone }}-{{ .Values.k8gb.clusterGeoTag }}
               key: secret
 {{- end -}}
 {{- end -}}
+{{- define "k8gb.metrics_port" -}}
+{{ print (split ":" .Values.k8gb.metricsAddress)._1 }}
+{{- end -}}

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -21,7 +21,8 @@ spec:
       containers:
         - name: k8gb
           ports:
-          - containerPort: {{ (split ":" .Values.k8gb.metricsAddress)._1 }}
+          - containerPort: {{ include "k8gb.metrics_port" . }}
+            name: metrics
           image: {{ .Values.k8gb.imageRepo }}:{{ .Values.k8gb.imageTag | default .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
           {{- if .Values.k8gb.securityContext }}

--- a/chart/k8gb/templates/metrics-service.yaml
+++ b/chart/k8gb/templates/metrics-service.yaml
@@ -1,0 +1,16 @@
+{{- if or .Values.k8gb.exposeMetrics .Values.k8gb.serviceMonitor.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8gb-metrics
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ include "k8gb.metrics_port" . }}
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "chart.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/chart/k8gb/templates/servicemonitor.yaml
+++ b/chart/k8gb/templates/servicemonitor.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.k8gb.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: k8gb
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+{{- end -}}

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -287,6 +287,13 @@
                 },
                 "securityContext": {
                     "$ref": "#/definitions/k8gbSecurityContext"
+                },
+                "exposeMetrics": {
+                    "type": "boolean",
+                    "default": false
+                },
+                "serviceMonitor": {
+                    "$ref": "#/definitions/k8gbServiceMonitor"
                 }
             },
             "required": [
@@ -351,6 +358,15 @@
                 }
             },
             "title": "k8gbSecurityContext"
+        },
+        "k8gbServiceMonitor": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
         },
         "Ns1": {
             "type": "object",

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -47,6 +47,11 @@ k8gb:
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
     runAsUser: 1000
+  # -- Exposing metrics
+  exposeMetrics: false
+  # -- enable ServiceMonitor
+  serviceMonitor:
+    enabled: false
 
 externaldns:
   # -- external-dns image repo:tag


### PR DESCRIPTION
Build on the top of @k0da https://github.com/k8gb-io/k8gb/pull/1245
..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
