### PR TITLE
Rancher Fleet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Internal k8gb architecture and its components are described [here](/docs/compone
 * [Ingress annotations](/docs/ingress_annotations.md)
 * [Integration with Admiralty](/docs/admiralty.md)
 * [Integration with Liqo](/docs/liqo.md)
+* [Integration with Rancher Fleet](/docs/rancher.md)
 
 ## Adopters
 

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -142,6 +142,9 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "fleet": {
+                    "type": "object"
+                },
                 "imagePullSecrets": {
                     "type": [
                         "array",

--- a/docs/rancher.md
+++ b/docs/rancher.md
@@ -1,0 +1,33 @@
+# Integration with Rancher Fleet
+
+The K8gb has been modified to be easily deployed using [Rancher Fleet](https://fleet.rancher.io/). All you need to supply is a 
+[fleet.yaml](https://fleet.rancher.io/ref-fleet-yaml) file  and possibly expose the labels on your cluster.
+
+## Deploy k8gb to Target clusters
+The following shows the rancher application that will be installed on the target cluster.  The values `k8gb-dnsZone`, 
+`k8gb-clusterGeoTag`, `k8gb-extGslbClustersGeoTags` will be taken from the labels that are set on the cluster.
+
+```yaml
+# fleet.yaml
+defaultNamespace: k8gb
+kustomize:
+  dir: overlays/kustomization
+labels:
+  bundle: k8gb
+helm:
+  repo: https://www.k8gb.io
+  chart: k8gb
+  version: v0.11.4
+  releaseName: k8gb
+  values:
+    k8gb:
+      dnsZone: global.fleet.clusterLabels.k8gb-dnsZone
+      edgeDNSZone: "cloud.example.com"
+      edgeDNSServers:
+        - "1.2.3.4"
+        - "5.6.7.8"
+      clusterGeoTag: global.fleet.clusterLabels.k8gb-clusterGeoTag
+      extGslbClustersGeoTags: global.fleet.clusterLabels.k8gb-extGslbClustersGeoTags
+      log:
+        format: simple
+```


### PR DESCRIPTION
Rancher fleet installs applications from the existing Helm Chart. During installation it injects at least properties into `global.fleet`. Because k8gb schema is too strict, `helm install` does not work because fleet injects its properties We solved this by deleting the schema and rebuilding Chart.

This PR whitelists the fleet object in globals, so k8gb can be installed directly.
