### PR TITLE
Change Extra plugins from object to string

### DIFF
--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -337,7 +337,7 @@
             "additionalProperties": false,
             "properties": {
                 "extra_plugins": {
-                    "type": "object"
+                    "type": "string"
                 }
             },
             "title": "k8gbCoredns"

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -31,7 +31,7 @@ k8gb:
   reconcileRequeueSeconds: 30
   # -- Extra CoreDNS plugins to be enabled (yaml object)
   coredns:
-    extra_plugins: {}
+    extra_plugins: ""
   log:
     # -- log format (simple,json)
     format: simple # log format (simple,json)


### PR DESCRIPTION
I need to change the schema from object to string.

fir the `values.yaml`configuration:

before:

```yaml
  coredns:
    extra_plugins: {log}
```

```yaml
cloud.example.com:5353 {
    errors
    health
    log: {}
    prometheus 0.0.0.0:9153
    forward . /etc/resolv.conf
    k8s_crd {
        filter k8gb.absa.oss/dnstype=local
        negttl 300
        loadbalance weight
    }
```


after:

```yaml
  coredns: 
    extra_plugins: |
       log
```

```yaml
cloud.example.com:5353 {
    errors
    health
    log 
    prometheus 0.0.0.0:9153
    forward . /etc/resolv.conf
    k8s_crd {
        filter k8gb.absa.oss/dnstype=local
        negttl 300
        loadbalance weight
    }
```
