### PR TITLE
add k8gb to community-operators-prod

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -35,9 +35,20 @@ jobs:
           helm repo add k8gb https://k8gb.io/
           helm repo update
           helm -n k8gb upgrade -i k8gb k8gb/k8gb --wait --create-namespace --version=$(make version)
-      - name: Invoke workflow for OLM
+      - name: Invoke workflow for OLM (community-operators)
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385
         with:
           workflow: OLM bundle and PR
           token: ${{ secrets.CR_TOKEN }}
-          inputs: '{ "bundleVersion": "master" }'
+          inputs: '{ "bundleVersion": "master" }' # during the release 'master' is what we want here
+      - name: Invoke workflow for OLM
+        uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385
+        with:
+          workflow: OLM bundle and PR (community-operators-prod)
+          token: ${{ secrets.CR_TOKEN }}
+          inputs: |
+            {
+              "bundleVersion": "master",
+              "downstreamRepo": "k8gb-io/community-operators-prod",
+              "upstreamRepo": "redhat-openshift-ecosystem/community-operators-prod"
+            }

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -33,15 +33,23 @@ jobs:
       - name: Smoke test helm installation
         run: |
           helm repo add k8gb https://k8gb.io/
-          helm repo update
-          helm -n k8gb upgrade -i k8gb k8gb/k8gb --wait --create-namespace --version=$(make version)
+          for i in $(seq 16)
+          do
+            helm repo update
+            helm -n k8gb upgrade -i k8gb k8gb/k8gb --wait --create-namespace --version=$(make version) && exit 0
+            _sec=$(echo "1.5^$i" | bc)
+            echo "Waiting ${_sec} seconds.."
+            sleep ${_sec}
+          done
       - name: Invoke workflow for OLM (community-operators)
+        if: always()
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385
         with:
           workflow: OLM bundle and PR
           token: ${{ secrets.CR_TOKEN }}
           inputs: '{ "bundleVersion": "master" }' # during the release 'master' is what we want here
       - name: Invoke workflow for OLM
+        if: always()
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385
         with:
           workflow: OLM bundle and PR (community-operators-prod)

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -7,6 +7,10 @@ on:
         description: Version of the bundle that should be generated. If not provided, the latest release tag is taken. Use 'master' for incorporating the latest changes in repo
         required: false
         default: ""
+      downstreamRepo:
+          description: "The pull request will be opened from this repository"
+          required: true
+          default: "k8gb-io/community-operators"
       upstreamRepo:
         description: "The pull request will be opened against this repository"
         required: true
@@ -74,7 +78,7 @@ jobs:
         uses: peter-evans/create-pull-request@0cd7ff0e63a08ac27378fc70cf0df976be6bbbfa
         with:
           token: ${{ secrets.CR_TOKEN }}
-          push-to-fork: k8gb-io/community-operators
+          push-to-fork: ${{ github.event.inputs.downstreamRepo }}
           path: sandbox
           commit-message: OLM bundle for k8gb@${{ env.bundleDir }}
           title: operators k8gb (${{ env.bundleDir }})


### PR DESCRIPTION
This should now open two PRs: 
- to `k8s-operatorhub/community-operators`
- to `redhat-openshift-ecosystem/community-operators-prod`

it also fixes the "helm smoke tests" - context: https://cloud-native.slack.com/archives/C021P656HGB/p1697629319760079

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
