### PR TITLE
Let renovate automatically update the SECURITY-INSIGHTS.yml file 

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,17 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "group:allNonMajor",
+  ],
+  "ignoreDeps": [
+    "infobloxopen/infoblox-go-client",
+    "zricethezav/gitleaks-action",
+    "actions/setup-go",
   ],
   "ignorePaths": [
     ".github/workflows/release.yaml",
-    ".github/workflows/cut_release.yaml"
+    ".github/workflows/cut_release.yaml",
   ],
+  "labels": ["dependencies", "renovate"],
   "prConcurrentLimit": 5,
   "packageRules": [
     {
       "matchDatasources": [
-        "go"
+        "go",
       ],
       "groupName": "kubernetes packages",
       "groupSlug": "kubernetes-go",
@@ -28,7 +35,7 @@
         "k8s.io/component-base",
         "k8s.io/controller-manager",
         "k8s.io/cri-api",
-        "k8s.io/csi-translation-lib",
+        "k8s.io/csi-translation-lib", 
         "k8s.io/kube-aggregator",
         "k8s.io/kube-controller-manager",
         "k8s.io/kube-proxy",
@@ -41,23 +48,44 @@
         "k8s.io/pod-security-admission",
         "k8s.io/sample-apiserver",
         "k8s.io/sample-cli-plugin",
-        "k8s.io/sample-controller"
+        "k8s.io/sample-controller",
       ]
     }, {
       "matchPackagePatterns": [
-        "*"
+        "*",
       ],
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
       ],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
     }, {
       "matchDepTypes": [
-        "action"
+        "action",
       ],
       "pinDigests": true
-    }
-  ]
+    },
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^SECURITY-INSIGHTS.yml$"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "k8gb-io/k8gb",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "matchStrings": [
+        "\\s*project-release: ['\"]?v?(?<currentValue>.+)['\"]?",
+      ],
+    },
+    {
+      "fileMatch": ["^SECURITY-INSIGHTS.yml$"],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "k8gb-io/k8gb",
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "matchStrings": [
+        "\\s*- sbom-file: ['\"](.+)\\/download\\/v(?<currentValue>.+)\\/(.+)",
+      ],
+      "autoReplaceStringTemplate": "  - sbom-file: https://github.com/{{{depName}}}/releases/download/v{{{newValue}}}/k8gb_{{{newValue}}}_linux_amd64.tar.gz.sbom.json"
+    },
+  ],
 }


### PR DESCRIPTION
when there is a new release on GitHub

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
