### PR TITLE
Skip terratest for renovate PRs

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches:
       - master
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths-ignore:
       - '**.md'
       - '**.svg'
@@ -41,7 +44,7 @@ jobs:
   terratest:
     runs-on: ubuntu-22.04
     needs: skip-check
-    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }} && !contains( github.event.pull_request.labels.*.name, 'renovate')
     steps:
       - uses: actions/checkout@8530928916aaef40f59e6f221989ccb31f5759e7
         with:

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches:
       - master
+    # The specific activity types are listed here to include "labeled" and "unlabeled"
+    # (which are not included by default for the "pull_request" trigger).
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
     paths-ignore:
       - '**.md'
       - '**.svg'
@@ -41,7 +44,7 @@ jobs:
   upgrade-testing:
     runs-on: ubuntu-22.04
     needs: skip-check
-    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }} && !contains( github.event.pull_request.labels.*.name, 'renovate')
     steps:
       - uses: actions/checkout@8530928916aaef40f59e6f221989ccb31f5759e7
         with:


### PR DESCRIPTION
this depends on this pr - https://github.com/k8gb-io/k8gb/pull/1320 (which adds the `renovate` label)

Terratests can be still run when one removes the `renovate` label.

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
