### PR TITLE
Add mandatory endpoints field

### DIFF
--- a/chart/k8gb/templates/servicemonitor.yaml
+++ b/chart/k8gb/templates/servicemonitor.yaml
@@ -6,6 +6,8 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 spec:
+  endpoints:
+  - port: metrics
   selector:
     matchLabels:
       {{- include "chart.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
  Fixes: error validating "": error validating data:
ValidationError(ServiceMonitor.spec): missing required field "endpoints" in com.coreos.monitoring.v1.ServiceMonitor.spec

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
