### PR TITLE
Bump k8s version of k3s from 1.25 to 1.28

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -42,7 +42,7 @@ k8gb:
   # -- Metrics server address
   metricsAddress: "0.0.0.0:8080"
   securityContext:
-    # -- For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
+    # -- For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core
     runAsNonRoot: true
     readOnlyRootFilesystem: true
     allowPrivilegeEscalation: false
@@ -63,7 +63,7 @@ externaldns:
   # -- external-dns sync interval
   interval: "20s"
   securityContext:
-    # -- For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#securitycontext-v1-core
+    # -- For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core
     runAsUser: 1000
     # -- For ExternalDNS to be able to read Kubernetes and AWS token files
     fsGroup: 65534 # For ExternalDNS to be able to read Kubernetes and AWS token files

--- a/k3d/edge-dns.yaml
+++ b/k3d/edge-dns.yaml
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: edgedns
-image: docker.io/rancher/k3s:v1.25.2-k3s1
+image: docker.io/rancher/k3s:v1.28.3-k3s2
 agents: 0
 network: k3d-action-bridge-network
 ports:

--- a/k3d/gslb.yaml.tmpl
+++ b/k3d/gslb.yaml.tmpl
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb$CLUSTER_INDEX
-image: docker.io/rancher/k3s:v1.25.2-k3s1
+image: docker.io/rancher/k3s:v1.28.3-k3s2
 agents: 1
 network: k3d-action-bridge-network
 ports:

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb1
-image: docker.io/rancher/k3s:v1.25.2-k3s1
+image: docker.io/rancher/k3s:v1.28.3-k3s2
 agents: 1
 network: k3d-action-bridge-network
 ports:

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb2
-image: docker.io/rancher/k3s:v1.25.2-k3s1
+image: docker.io/rancher/k3s:v1.28.3-k3s2
 agents: 1
 network: k3d-action-bridge-network
 ports:

--- a/k3d/test-gslb3.yaml
+++ b/k3d/test-gslb3.yaml
@@ -2,7 +2,7 @@ apiVersion: k3d.io/v1alpha4
 kind: Simple
 metadata:
   name: test-gslb3
-image: docker.io/rancher/k3s:v1.25.2-k3s1
+image: docker.io/rancher/k3s:v1.28.3-k3s2
 agents: 1
 network: k3d-action-bridge-network
 ports:


### PR DESCRIPTION
deploying local setup want ok

🤞 tests

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
