### PR TITLE
Fix flaky terratests

### DIFF
--- a/terratest/test/k8gb_abstract_full_roundrobin_test.go
+++ b/terratest/test/k8gb_abstract_full_roundrobin_test.go
@@ -35,7 +35,6 @@ func abstractTestFullRoundRobin(t *testing.T, n int) {
 	tags := []string{"eu", "us", "cz", "af", "ru", "ap", "uk", "ca"}
 	var instances []*utils.Instance
 
-	t.Parallel()
 	const host = "roundrobin-test.cloud.example.com"
 	const gslbPath = "../examples/roundrobin2.yaml"
 

--- a/terratest/test/k8gb_failover_playground_test.go
+++ b/terratest/test/k8gb_failover_playground_test.go
@@ -32,7 +32,6 @@ import (
 // TestFailoverPlayground is equal to k8gb failover test running on local playground.
 // see: https://github.com/k8gb-io/k8gb/blob/master/docs/local.md#failover
 func TestFailoverPlayground(t *testing.T) {
-	t.Parallel()
 	const host = "playground-failover.cloud.example.com"
 	const gslbPath = "../examples/failover-playground.yaml"
 	const euGeoTag = "eu"

--- a/terratest/test/k8gb_full_failover_test.go
+++ b/terratest/test/k8gb_full_failover_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestFullFailover(t *testing.T) {
-	t.Parallel()
 	const host = "terratest-failover.cloud.example.com"
 	const gslbPath = "../examples/failover.yaml"
 

--- a/terratest/test/k8gb_lifecycle_test.go
+++ b/terratest/test/k8gb_lifecycle_test.go
@@ -37,7 +37,6 @@ import (
 // TestK8gbRepeatedlyRecreatedFromIngress creates GSLB, then keeps operator live and than recreates GSLB again from Ingress.
 // This is usual lifecycle scenario and we are testing spec strategy has expected values.
 func TestK8gbRepeatedlyRecreatedFromIngress(t *testing.T) {
-	t.Parallel()
 	// name of ingress and gslb
 	const name = "test-gslb-failover-simple"
 

--- a/terratest/test/k8gb_split_failover_test.go
+++ b/terratest/test/k8gb_split_failover_test.go
@@ -39,7 +39,6 @@ import (
 // Relies on two local clusters deployed by `$make deploy-two-local-clusters`
 // Tests expected behavior for https://github.com/k8gb-io/k8gb/issues/67
 func TestK8gbSplitFailoverExample(t *testing.T) {
-	t.Parallel()
 
 	// Path to the Kubernetes resource config we will test
 	kubeResourcePath1, err := filepath.Abs("../examples/failover1.yaml")


### PR DESCRIPTION
* Disable parallelisation for the frequently failing tests that invoke the podinfo scale down 
* Fixes #902 
* Tested this change here and within https://github.com/k8gb-io/k8gb/pull/1338 (commit already removed there, the tests were green) 
<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
