### PR TITLE
renovate: fix new line + don't group the pr with library bumps

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,6 +28,12 @@
       "groupSlug": "all-minor-patch"
     }, {
         "matchPackageNames": [
+        "k8gb-io/k8gb",
+      ],
+      "groupName": "update SECURITY-INSIGHTS.yml",
+      "groupSlug": "update-security-insights"
+    }, {
+        "matchPackageNames": [
         "rancher/k3s",
       ],
       "groupName": "update k8s version",
@@ -57,7 +63,7 @@
       "matchStrings": [
         "\\s*- sbom-file: ['\"]?(.+)\\/download\\/v(?<currentValue>.+)\\/(.+)['\"]?",
       ],
-      "autoReplaceStringTemplate": "  - sbom-file: https://github.com/{{{depName}}}/releases/download/v{{{newValue}}}/k8gb_{{{newValue}}}_linux_amd64.tar.gz.sbom.json"
+      "autoReplaceStringTemplate": "\n  - sbom-file: https://github.com/{{{depName}}}/releases/download/v{{{newValue}}}/k8gb_{{{newValue}}}_linux_amd64.tar.gz.sbom.json"
     },
     // update the files in k3d/ with the up-to-date k8s version
     {


### PR DESCRIPTION
using own `groupName` so that pr is not combined with the `update all non-major dependencies` one + fixing the new line issue - https://github.com/k8gb-io/k8gb/pull/1052/files#diff-cb650ef911579f6ff1e25b1b7ab7e70a96c1a7e609cf5598a0635bca1b6984acR76

this has been tested on my fork and the resulting pr from renovate bot should look like this: https://github.com/jkremser/k8gb/pull/83/files