### PR TITLE
Don't let OLM job invocations fail the helm pipeline job + fix the second invocation

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -43,16 +43,18 @@ jobs:
           done
       - name: Invoke workflow for OLM (community-operators)
         if: always()
+        continue-on-error: true
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385
         with:
           workflow: OLM bundle and PR
           token: ${{ secrets.CR_TOKEN }}
           inputs: '{ "bundleVersion": "master" }' # during the release 'master' is what we want here
-      - name: Invoke workflow for OLM
+      - name: Invoke workflow for OLM (community-operators-prod)
         if: always()
+        continue-on-error: true
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385
         with:
-          workflow: OLM bundle and PR (community-operators-prod)
+          workflow: OLM bundle and PR
           token: ${{ secrets.CR_TOKEN }}
           inputs: |
             {


### PR DESCRIPTION
name of the workflow to be called should be "`OLM bundle and PR`" (the `workflow: foobar` part)
mea culpa, i missed that in https://github.com/k8gb-io/k8gb/pull/1308