### PR TITLE
Add support of secret based AuthN/Z for Route53

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -32,7 +32,7 @@ spec:
         - --txt-owner-id={{ include "k8gb.extdnsOwnerID" . }}
         - --txt-prefix=k8gb-{{ .Values.k8gb.clusterGeoTag }}- # add custom prefix to TXT records, critical for Cloudflare NS record creation
         - --provider={{ include "k8gb.extdnsProvider" . }}
-        {{- if .Values.route53.assumeRoleArn }}
+        {{- if and .Values.route53.assumeRoleArn (not .Values.route53.secret) }}
         - --aws-assume-role={{ .Values.route53.assumeRoleArn }}
         {{- end }}
         {{ include "k8gb.extdnsProviderOpts" . }}
@@ -45,6 +45,19 @@ spec:
             cpu: "500m"
         securityContext:
           readOnlyRootFilesystem: true
+      {{- if .Values.route53.secret }}
+        env:
+          - name: AWS_SHARED_CREDENTIALS_FILE
+            value: /.aws/credentials
+        volumeMounts:
+          - name: aws-credentials
+            mountPath: /.aws
+            readOnly: true
+      volumes:
+        - name: aws-credentials
+          secret:
+            secretName: {{ .Values.route53.secret }}
+      {{- end }}
       {{- if .Values.rfc2136.rfc2136auth.gssTsig.enabled }}
         volumeMounts:
           - mountPath: /etc/krb5.conf

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -567,8 +567,15 @@
                     ]
                 },
                 "secret": {
-                    "type": "string",
-                    "minLength": 1
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
                 },
                 "assumeRoleArn": {
                     "oneOf": [

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -566,6 +566,10 @@
                         }
                     ]
                 },
+                "secret": {
+                    "type": "string",
+                    "minLength": 1
+                },
                 "assumeRoleArn": {
                     "oneOf": [
                         {

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -110,6 +110,10 @@ route53:
   irsaRole: arn:aws:iam::111111:role/external-dns
   # -- specify IRSA Role in AWS ARN format for assume role permissions or disable it by setting to `null`
   assumeRoleArn: null
+  # -- alternatively specify the secret name with static credentials for IAM user (make sure this user has limited privileges)
+  # this can be useful when IRSA is not present or when using say Azure cluster and Route53
+  # docs: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#create-iam-user-and-attach-the-policy
+  secret: null
 
 ns1:
   # -- Enable NS1 provider


### PR DESCRIPTION
The preferred mechanism of AuthN,Z for aws comm from k8s cluster is using the service account -> role mapping, however in non-managed k8s (no EKS) environments where people just use pure AWS's EC2 instances with kubeadm or using cluster-api (non EKS mode), there the irsa controller (or how is it called today) is missing.

So it would be nice to have a way to make k8gb work also w/o setting this up. Another use-case for this would be a multi-cluster setup where all clusters need to talk to route53, we can't assume the irsa controller in GCP or in Azure.

it's one of the documented ways for externaldns - [docs](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#static-credentials)


<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
