### PR TITLE
Allow to change dnsPolicy of ExternalDNS deployment

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -50,6 +50,7 @@ spec:
           - mountPath: /etc/krb5.conf
             name: kerberos-config-volume
             subPath: krb5.conf
+      dnsPolicy: {{ .Values.externaldns.dnsPolicy }}
       volumes:
         - name: kerberos-config-volume
           configMap:

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -110,6 +110,10 @@
             "type": "object",
             "additionalProperties": false,
             "properties": {
+                "dnsPolicy": {
+                    "type": "string",
+                    "minLength": 1
+                },
                 "image": {
                     "type": "string",
                     "minLength": 1

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -54,6 +54,8 @@ k8gb:
     enabled: false
 
 externaldns:
+  # -- `.spec.template.spec.dnsPolicy` for ExternalDNS deployment
+  dnsPolicy: "ClusterFirst"
   # -- external-dns image repo:tag
   # It is important to use the image from k8gb external-dns fork to get the full
   # functionality. See links below


### PR DESCRIPTION
why?

When deploying k8gb to vanilla k8s clusters that were created using cluster API and kubeadm (no EKS, no managed control planes).

The ExternalDNS deployment has an issue with resolving `route53.amazonaws.com`. By default the dnsPolicy if not specified is `ClusterFirst` so this PR is a no-op in terms of backward compatibility, but if changed to `Default` this fixed the previous situation for me. I guess, this can be solved also by tweaking the dns server for this k8s cluster or by providing own corefile for coredns, but it can't hurt either to allow this easy fix. 


[docs](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
`Default` ... use host for resolving the dns names
`ClusterFirst` ... Any DNS query that does not match the configured cluster domain suffix, such as "www.kubernetes.io", is forwarded to an upstream nameserver by the DNS server. Cluster administrators may have extra stub-domain and upstream DNS servers configured.