### PR TITLE
Local registry mirror for local setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ deploy-k8gb-with-helm:
 		--set k8gb.log.level=$(LOG_LEVEL) \
 		--set rfc2136.enabled=true \
 		--set k8gb.edgeDNSServers[0]=$(shell $(CLUSTER_GSLB_GATEWAY)):1053 \
-		--wait --timeout=2m0s
+		--wait --timeout=10m0s
 
 .PHONY: deploy-gslb-operator
 deploy-gslb-operator: ## Deploy k8gb operator

--- a/k3d/edge-dns.yaml
+++ b/k3d/edge-dns.yaml
@@ -22,3 +22,15 @@ options:
       - arg: --disable=traefik,servicelb,metrics-server,local-storage
         nodeFilters:
           - server:*
+registries:
+  create:
+    name: k3d-docker-io # name of the registry container
+    proxy:
+      remoteURL: https://registry-1.docker.io # proxy DockerHub
+    volumes:
+      - /tmp/reg:/var/lib/registry # persist data locally in /tmp/reg
+  config: | # tell K3s to use this registry when pulling from DockerHub
+    mirrors:
+      "docker.io":
+        endpoint:
+          - http://k3d-docker-io:5000

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -34,3 +34,9 @@ options:
       - arg: --disable=traefik,servicelb,metrics-server,local-storage
         nodeFilters:
           - server:*
+registries:
+  config: | # tell K3s to use this registry when pulling from DockerHub
+    mirrors:
+      "docker.io":
+        endpoint:
+          - http://k3d-docker-io:5000

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -31,3 +31,9 @@ options:
       - arg: --disable=traefik,servicelb,metrics-server,local-storage
         nodeFilters:
           - server:*
+registries:
+  config: | # tell K3s to use this registry when pulling from DockerHub
+    mirrors:
+      "docker.io":
+        endpoint:
+          - http://k3d-docker-io:5000

--- a/k3d/test-gslb3.yaml
+++ b/k3d/test-gslb3.yaml
@@ -31,3 +31,9 @@ options:
       - arg: --disable=traefik,servicelb,metrics-server,local-storage
         nodeFilters:
           - server:*
+registries:
+  config: | # tell K3s to use this registry when pulling from DockerHub
+    mirrors:
+      "docker.io":
+        endpoint:
+          - http://k3d-docker-io:5000


### PR DESCRIPTION
* Enable local registry according to https://k3d.io/v5.4.4/usage/registries/#creating-a-registry-proxy-pull-through-registry

* Use it in local test-gslbX clusters

* This is to optimize local setup, especially to avoid dockerhub rate limiting

Before:

```
make deploy-full-local-setup  12.29s user 3.23s system 4% cpu 6:11.10 total
```

After:
```
make deploy-full-local-setup  11.81s user 2.89s system 4% cpu 4:55.30 total
```
..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
