### PR TITLE
Change coredns extra_plugins to array type

### DIFF
--- a/chart/k8gb/templates/coredns-cm.yaml
+++ b/chart/k8gb/templates/coredns-cm.yaml
@@ -11,7 +11,9 @@ data:
         errors
         health
 {{- if .Values.k8gb.coredns.extra_plugins }}
-{{ .Values.k8gb.coredns.extra_plugins | indent 8}}
+{{- range .Values.k8gb.coredns.extra_plugins }}
+        {{ . }}
+{{- end }}
 {{- end }}
         ready
         prometheus 0.0.0.0:9153

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -344,7 +344,10 @@
             "additionalProperties": false,
             "properties": {
                 "extra_plugins": {
-                    "type": "string"
+                    "type": [
+                        "array",
+                        "null"
+                    ]
                 }
             },
             "title": "k8gbCoredns"

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -31,7 +31,7 @@ k8gb:
   reconcileRequeueSeconds: 30
   # -- Extra CoreDNS plugins to be enabled (yaml object)
   coredns:
-    extra_plugins: null
+    extra_plugins: []
   log:
     # -- log format (simple,json)
     format: simple # log format (simple,json)

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -31,7 +31,7 @@ k8gb:
   reconcileRequeueSeconds: 30
   # -- Extra CoreDNS plugins to be enabled (yaml object)
   coredns:
-    extra_plugins: ""
+    extra_plugins: null
   log:
     # -- log format (simple,json)
     format: simple # log format (simple,json)


### PR DESCRIPTION
* Specify `extra_plugins` of coredns as `array` instead of plain `string`
* Adjust schema

* Enables more intuitive and convenient plugin specification, e.g

```
coredns:
    extra_plugins:
      - log
      - prometheus
```

* Partially fixes #1267

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
