### PR TITLE
Local registry setup optimization

### DIFF
--- a/k3d/edge-dns.yaml
+++ b/k3d/edge-dns.yaml
@@ -28,9 +28,15 @@ registries:
     proxy:
       remoteURL: https://registry-1.docker.io # proxy DockerHub
     volumes:
-      - /tmp/reg:/var/lib/registry # persist data locally in /tmp/reg
+      - /tmp/k3d-docker-io:/var/lib/registry # persist data locally in /tmp/
   config: | # tell K3s to use this registry when pulling from DockerHub
     mirrors:
       "docker.io":
         endpoint:
           - http://k3d-docker-io:5000
+      "ghcr.io":
+        endpoint:
+          - http://k3d-ghcr-io:5000
+      "k8s.gcr.io":
+        endpoint:
+          - http://k3d-k8s-gcr-io:5000

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -35,8 +35,20 @@ options:
         nodeFilters:
           - server:*
 registries:
+  create:
+    name: k3d-ghcr-io # name of the registry container
+    proxy:
+      remoteURL: https://ghcr.io # proxy ghcr.io
+    volumes:
+      - /tmp/k3d-ghcr-io:/var/lib/registry # persist data locally in /tmp/
   config: | # tell K3s to use this registry when pulling from DockerHub
     mirrors:
       "docker.io":
         endpoint:
           - http://k3d-docker-io:5000
+      "ghcr.io":
+        endpoint:
+          - http://k3d-ghcr-io:5000
+      "k8s.gcr.io":
+        endpoint:
+          - http://k3d-k8s-gcr-io:5000

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -32,8 +32,20 @@ options:
         nodeFilters:
           - server:*
 registries:
+  create:
+    name: k3d-k8s-gcr-io # name of the registry container
+    proxy:
+      remoteURL: https://k8s.gcr.io # proxy k8s.gcr.io
+    volumes:
+      - /tmp/k3d-k8s-gcr-io:/var/lib/registry # persist data locally in /tmp/
   config: | # tell K3s to use this registry when pulling from DockerHub
     mirrors:
       "docker.io":
         endpoint:
           - http://k3d-docker-io:5000
+      "ghcr.io":
+        endpoint:
+          - http://k3d-ghcr-io:5000
+      "k8s.gcr.io":
+        endpoint:
+          - http://k3d-k8s-gcr-io:5000

--- a/k3d/test-gslb3.yaml
+++ b/k3d/test-gslb3.yaml
@@ -37,3 +37,9 @@ registries:
       "docker.io":
         endpoint:
           - http://k3d-docker-io:5000
+      "ghcr.io":
+        endpoint:
+          - http://k3d-ghcr-io:5000
+      "k8s.gcr.io":
+        endpoint:
+          - http://k3d-k8s-gcr-io:5000


### PR DESCRIPTION
* Enhancement to https://github.com/k8gb-io/k8gb/pull/1509
* Mirror also `ghcr.io` and `k8s.gcr.io` as we are pulling from them
* Create separate registry per upstream one

Before:
```
make deploy-full-local-setup  11.81s user 2.89s system 4% cpu 4:55.30 total
```

After:
```
make deploy-full-local-setup  11.68s user 3.18s system 11% cpu 2:06.20 total
```

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
