### PR TITLE
Helm supports extra env, volumes and volume mounts for externaldns

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -59,6 +59,9 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | coredns.isClusterService | bool | `false` | service: refer to https://www.k8gb.io/docs/service_upgrade.html for upgrading CoreDNS service steps |
 | coredns.serviceAccount | object | `{"create":true,"name":"coredns"}` | Creates serviceAccount for coredns |
 | externaldns.dnsPolicy | string | `"ClusterFirst"` | `.spec.template.spec.dnsPolicy` for ExternalDNS deployment |
+| externaldns.extraEnv | list | `[]` | extra environment variables |
+| externaldns.extraVolumeMounts | list | `[]` | extra volume mounts |
+| externaldns.extraVolumes | list | `[]` | extra volumes |
 | externaldns.image | string | `"ghcr.io/k8gb-io/external-dns:v0.13.4-azure-ns"` | external-dns image repo:tag It is important to use the image from k8gb external-dns fork to get the full functionality. See links below https://github.com/k8gb-io/external-dns https://github.com/k8gb-io/external-dns/pkgs/container/external-dns |
 | externaldns.interval | string | `"20s"` | external-dns sync interval |
 | externaldns.securityContext.fsGroup | int | `65534` | For ExternalDNS to be able to read Kubernetes and AWS token files |

--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -45,30 +45,48 @@ spec:
             cpu: "500m"
         securityContext:
           readOnlyRootFilesystem: true
-      {{- if .Values.route53.secret }}
+        {{- with .Values.externaldns.extraEnv }}
         env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- if .Values.route53.secret }}
+        {{- if not .Values.externaldns.extraEnv }}
+        env:
+        {{- end }}
           - name: AWS_SHARED_CREDENTIALS_FILE
             value: /.aws/credentials
         volumeMounts:
           - name: aws-credentials
             mountPath: /.aws
             readOnly: true
+          {{- with .Values.externaldns.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       volumes:
         - name: aws-credentials
           secret:
             secretName: {{ .Values.route53.secret }}
+        {{- with .Values.externaldns.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       {{- if .Values.rfc2136.rfc2136auth.gssTsig.enabled }}
         volumeMounts:
           - mountPath: /etc/krb5.conf
             name: kerberos-config-volume
             subPath: krb5.conf
+          {{- with .Values.externaldns.extraVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
       dnsPolicy: {{ .Values.externaldns.dnsPolicy }}
       volumes:
         - name: kerberos-config-volume
           configMap:
             name: {{ .Values.rfc2136.rfc2136auth.gssTsig.kerberosConfigmap }}
             defaultMode: 420
+        {{- with .Values.externaldns.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
-        
+
 {{- end }}

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -114,6 +114,15 @@
                     "type": "string",
                     "minLength": 1
                 },
+                "extraEnv": {
+                    "type": "array"
+                },
+                "extraVolumes": {
+                    "type": "array"
+                },
+                "extraVolumeMounts": {
+                    "type": "array"
+                },
                 "image": {
                     "type": "string",
                     "minLength": 1
@@ -616,7 +625,7 @@
             },
             "required": [
                 "enabled",
-		"zoneID"
+                "zoneID"
             ],
             "title": "Cloudflare"
         },

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -56,6 +56,12 @@ k8gb:
 externaldns:
   # -- `.spec.template.spec.dnsPolicy` for ExternalDNS deployment
   dnsPolicy: "ClusterFirst"
+  # -- extra environment variables
+  extraEnv: []
+  # -- extra volumes
+  extraVolumes: []
+  # -- extra volume mounts
+  extraVolumeMounts: []
   # -- external-dns image repo:tag
   # It is important to use the image from k8gb external-dns fork to get the full
   # functionality. See links below
@@ -130,7 +136,7 @@ rfc2136:
     - host: host.k3d.internal
     - port: 1053
   rfc2136auth:
-    insecure: 
+    insecure:
       enabled: false
     tsig:
       enabled: true

--- a/docs/proxy_externaldns.md
+++ b/docs/proxy_externaldns.md
@@ -1,4 +1,4 @@
-# Proxy External DNS
+# External DNS behind a proxy
 
 External DNS needs to communicate with a DNS server outside of the kubernetes cluster to update records. If there is a proxy for egress of the Kubernetes cluster the following should be configured:
 ```

--- a/docs/proxy_externaldns.md
+++ b/docs/proxy_externaldns.md
@@ -1,0 +1,20 @@
+# Proxy External DNS
+
+External DNS needs to communicate with a DNS server outside of the kubernetes cluster to update records. If there is a proxy for egress of the Kubernetes cluster the following should be configured:
+```
+externaldns:
+  extraEnv:
+  - name: HTTPS_PROXY
+    value: http://proxy.example.com:8080
+  extraVolumes:
+  - name: ca-bundle
+    secret:
+      secretName: ca-proxy
+  extraVolumeMounts:
+  - name: ca-bundle
+    mountPath: /etc/ssl/certs
+    readOnly: true
+```
+
+The `HTTPS_PROXY` environment variable should contain the address of the proxy.
+The volume mount should contain the proxy CA certificate so that the container can trust the proxy.

--- a/docs/proxy_externaldns.md
+++ b/docs/proxy_externaldns.md
@@ -1,6 +1,6 @@
 # External DNS behind a proxy
 
-External DNS needs to communicate with a DNS server outside of the kubernetes cluster to update records. If there is a proxy for egress of the Kubernetes cluster the following should be configured:
+External DNS needs to communicate with a DNS server outside of the kubernetes cluster to update records. If a proxy is used for egress from the Kubernetes cluster the following should be configured:
 ```
 externaldns:
   extraEnv:


### PR DESCRIPTION
Externaldns requires internet access to configure DNS records. In order to run it behind a proxy one needs to configure the proxy address using environment variables and to mount a volume containing the proxy CA certificate.
This can now be configured using the `externaldns.extraEnv`, `externaldns.extraVolumes` and `externaldns.extraVolumeMounts` variables. Here is an example:
```
externaldns:
  extraEnv:
  - name: HTTPS_PROXY
    value: http://proxy.example.com:8080
  extraVolumes:
  - name: ca-bundle
    secret:
      secretName: ca-proxy
  extraVolumeMounts:
  - name: ca-bundle
    mountPath: /etc/ssl/certs
    readOnly: true
```
