### PR TITLE
Rancher changed the suffix from k3s2 back to k3s1

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -72,7 +72,7 @@
       "matchStrings": [
         "repo: (?<depName>.*)\n(\\s*)image: \"?.+:(?<currentValue>.*?)\"?\n",
       ],
-      "extractVersionTemplate": "^(?<version>.+)(-k3s2)?$",
+      "extractVersionTemplate": "^(?<version>.+)(-k3s1|-k3s2)?$",
     },
   ],
 }


### PR DESCRIPTION
https://hub.docker.com/r/rancher/k3s/tags

I guess the k3s2 suffix was some temporary thing, but we can support both just in case it's gonna be there again