### PR TITLE
Bring RFC2136 doc reference to front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Internal k8gb architecture and its components are described [here](/docs/compone
 * [AWS based deployment with NS1 integration](/docs/deploy_ns1.md)
 * [Azure based deployment with Windows DNS integration](/docs/deploy_windowsdns.md)
 * [General deployment with Cloudflare integration](/docs/deploy_cloudflare.md)
+* [Seamless DDNS Integration with Bind9 and other RFC2136-Compatible DNS Environments](/docs/provider_rfc2136.md)
 * [Local playground for testing and development](/docs/local.md)
 * [Local playground with Kuar web app](/docs/local-kuar.md)
 * [Metrics](/docs/metrics.md)

--- a/docs/provider_rfc2136.md
+++ b/docs/provider_rfc2136.md
@@ -1,6 +1,6 @@
 # Enabling RFC2136 for ExternalDNS
 
-In order to enable the provider RFC2136 on ExternalDNS, the following [configurations](/chart/k8gb/README.md) should be changed in the values.yaml of the K8GB helm chart:
+In order to enable the provider RFC2136 on ExternalDNS, the following `rfc2136.*` [parameters](https://github.com/k8gb-io/k8gb/blob/master/chart/k8gb/README.md#values) should be changed in the values.yaml of the K8GB helm chart:
 
 * One authentication method should be enabled on the values:
   * Insecure
@@ -9,7 +9,7 @@ In order to enable the provider RFC2136 on ExternalDNS, the following [configura
     * This method uses TSIG authentication that relies on a token provided for the DNS records update.
   * GSS-TSIG
     * This method uses GSS-TSIG authentication, which is a variation of the TSIG method, but uses Kerberos for the generation of tokens for authentication and authorization
-    * Method used by Active Directory Windows DNS 
+    * Method used by Active Directory Windows DNS
 
 * GSS-TSIG
   * kerberos-username
@@ -25,10 +25,10 @@ In order to enable the provider RFC2136 on ExternalDNS, the following [configura
 rfc2136:
   enabled: true
   rfc2136Opts:
-    - host: yourAcDc.k8gb.local 
+    - host: yourAcDc.k8gb.local
     - port: 53
   rfc2136auth:
-    insecure: 
+    insecure:
       enabled: false
     tsig:
       enabled: false


### PR DESCRIPTION
Reference RFC2136 doc in the main README/website front page for visiblity

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
