### PR TITLE
Fix OLM workflow reference

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -46,7 +46,7 @@ jobs:
         continue-on-error: true
         uses: benc-uk/workflow-dispatch@25b02cc069be46d637e8fe2f1e8484008e9e9609
         with:
-          workflow: OLM bundle and PR
+          workflow: olm_pr.yaml
           token: ${{ secrets.CR_TOKEN }}
           inputs: '{ "bundleVersion": "master" }' # during the release 'master' is what we want here
       - name: Invoke workflow for OLM (community-operators-prod)
@@ -54,7 +54,7 @@ jobs:
         continue-on-error: true
         uses: benc-uk/workflow-dispatch@25b02cc069be46d637e8fe2f1e8484008e9e9609
         with:
-          workflow: OLM bundle and PR
+          workflow: olm_pr.yaml
           token: ${{ secrets.CR_TOKEN }}
           inputs: |
             {


### PR DESCRIPTION
Attempt to fix failing https://github.com/k8gb-io/k8gb/actions/runs/7289262682

The theory here is that we can fix
<img width="857" alt="image" src="https://github.com/k8gb-io/k8gb/assets/518532/7e564776-5ace-41de-9d13-80ec38bd6950">

with explicit reference.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
