### PR TITLE
Switch to multiarch external-dns image build

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -67,7 +67,7 @@ externaldns:
   # functionality. See links below
   # https://github.com/k8gb-io/external-dns
   # https://github.com/k8gb-io/external-dns/pkgs/container/external-dns
-  image: ghcr.io/k8gb-io/external-dns:v0.13.4-azure-ns
+  image: ghcr.io/k8gb-io/external-dns:v0.13.4-azure-ns-multiarch
   # -- external-dns sync interval
   interval: "20s"
   securityContext:


### PR DESCRIPTION
* use the multiarch build https://github.com/k8gb-io/external-dns/pkgs/container/external-dns/226735861?tag=v0.13.4-azure-ns-multiarch
* Fixes #1588

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
