### PR TITLE
Azure secret reference refactoring and enhancement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,7 +148,7 @@ deploy-test-version: ## Upgrade k8gb to the test version on existing clusters
 
 	@for c in $(CLUSTER_IDS); do \
 		echo -e "\n$(CYAN)$(CLUSTER_NAME)$$c:$(NC)" ;\
-		k3d image import $(REPO):$(SEMVER)-$$(arch) -c $(CLUSTER_NAME)$$c ;\
+		k3d image import $(REPO):$(SEMVER)-$$(uname -m) -c $(CLUSTER_NAME)$$c ;\
 	done
 
 	@for c in $(CLUSTER_IDS); do \

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ endif
 ###############################
 #		CONSTANTS
 ###############################
+ARCH ?= $(shell uname -m)
+ifeq ($(ARCH), x86_64)
+	ARCH=amd64
+endif
 CLUSTERS_NUMBER ?= 2
 CLUSTER_IDS = $(shell seq $(CLUSTERS_NUMBER))
 CLUSTER_NAME ?= test-gslb
@@ -148,7 +152,7 @@ deploy-test-version: ## Upgrade k8gb to the test version on existing clusters
 
 	@for c in $(CLUSTER_IDS); do \
 		echo -e "\n$(CYAN)$(CLUSTER_NAME)$$c:$(NC)" ;\
-		k3d image import $(REPO):$(SEMVER)-$$(uname -m) -c $(CLUSTER_NAME)$$c ;\
+		k3d image import $(REPO):$(SEMVER)-$(ARCH) -c $(CLUSTER_NAME)$$c ;\
 	done
 
 	@for c in $(CLUSTER_IDS); do \

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,9 @@ debug-idea:
 demo: ## Execute end-to-end demo
 	@$(call demo-host, $(DEMO_URL))
 
-# spin-up local environment
+K8GB_LOCAL_VERSION ?= stable
+# Spin-up local environment. Deploys stable released version by default
+# Use `K8GB_LOCAL_VERSION=test make deploy-full-local-setup`
 .PHONY: deploy-full-local-setup
 deploy-full-local-setup: ensure-cluster-size ## Deploy full local multicluster setup (k3d >= 5.1.0)
 	@echo -e "\n$(YELLOW)Creating $$(( $(CLUSTERS_NUMBER) + 1 )) k8s clusters$(NC)"
@@ -129,8 +131,8 @@ deploy-full-local-setup: ensure-cluster-size ## Deploy full local multicluster s
 	@for c in $(CLUSTER_IDS); do \
 		$(MAKE) create-local-cluster CLUSTER_NAME=$(CLUSTER_NAME)$$c ;\
 	done
-
-	$(MAKE) deploy-stable-version DEPLOY_APPS=true
+	@if [ "$(K8GB_LOCAL_VERSION)" = test ]; then $(MAKE) release-images ; fi
+	$(MAKE) deploy-$(K8GB_LOCAL_VERSION)-version DEPLOY_APPS=true
 
 .PHONY: deploy-stable-version
 deploy-stable-version:
@@ -146,11 +148,11 @@ deploy-test-version: ## Upgrade k8gb to the test version on existing clusters
 
 	@for c in $(CLUSTER_IDS); do \
 		echo -e "\n$(CYAN)$(CLUSTER_NAME)$$c:$(NC)" ;\
-		k3d image import $(REPO):$(SEMVER)-amd64 -c $(CLUSTER_NAME)$$c ;\
+		k3d image import $(REPO):$(SEMVER)-$$(arch) -c $(CLUSTER_NAME)$$c ;\
 	done
 
 	@for c in $(CLUSTER_IDS); do \
-		$(MAKE) deploy-local-cluster CLUSTER_ID=$$c VERSION=$(SEMVER)-amd64 CHART='./chart/k8gb' ;\
+		$(MAKE) deploy-local-cluster CLUSTER_ID=$$c VERSION=$(SEMVER)-$$(arch) CHART='./chart/k8gb' ;\
 		kubectl apply -n k8gb -f ./deploy/test/coredns-tcp-svc.yaml ;\
 	done
 

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ deploy-test-version: ## Upgrade k8gb to the test version on existing clusters
 	done
 
 	@for c in $(CLUSTER_IDS); do \
-		$(MAKE) deploy-local-cluster CLUSTER_ID=$$c VERSION=$(SEMVER)-$$(arch) CHART='./chart/k8gb' ;\
+		$(MAKE) deploy-local-cluster CLUSTER_ID=$$c VERSION=$(SEMVER)-$(ARCH) CHART='./chart/k8gb' ;\
 		kubectl apply -n k8gb -f ./deploy/test/coredns-tcp-svc.yaml ;\
 	done
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Internal k8gb architecture and its components are described [here](/docs/compone
 * [General deployment with Infoblox integration](/docs/deploy_infoblox.md)
 * [AWS based deployment with Route53 integration](/docs/deploy_route53.md)
 * [AWS based deployment with NS1 integration](/docs/deploy_ns1.md)
+* [Using Azure Public DNS provider](/docs/deploy_azuredns.md)
 * [Azure based deployment with Windows DNS integration](/docs/deploy_windowsdns.md)
 * [General deployment with Cloudflare integration](/docs/deploy_cloudflare.md)
 * [Seamless DDNS Integration with Bind9 and other RFC2136-Compatible DNS Environments](/docs/provider_rfc2136.md)

--- a/chart/k8gb/templates/_helpers.tpl
+++ b/chart/k8gb/templates/_helpers.tpl
@@ -164,21 +164,21 @@ k8gb-{{ .Values.k8gb.dnsZone }}-{{ .Values.k8gb.clusterGeoTag }}
 {{- end -}}
 
 {{- define "external-dns.azure-credentials" -}}
-{{- if and (eq .Values.azuredns.enabled true) (eq .Values.azuredns.createAuthSecret true) -}}
+{{- if and (eq .Values.azuredns.enabled true) (eq .Values.azuredns.createAuthSecret.enabled true) -}}
 {
   "tenantId": "{{ .Values.azuredns.createAuthSecret.tenantId }}",
   "subscriptionId": "{{ .Values.azuredns.createAuthSecret.subscriptionId }}",
   "resourceGroup": "{{ .Values.azuredns.createAuthSecret.resourceGroup }}",
-  {{- if .Values.azuredns.createAuthSecret.aadClientId -}}
+  {{- if .Values.azuredns.createAuthSecret.aadClientId }}
   "aadClientId": "{{ .Values.azuredns.createAuthSecret.aadClientId }}",
-  {{- end -}}
-  {{- if .Values.azuredns.createAuthSecret.aadClientSecret -}}
+  {{- end }}
+  {{- if .Values.azuredns.createAuthSecret.aadClientSecret }}
   "aadClientSecret": "{{ .Values.azuredns.createAuthSecret.aadClientSecret }}",
-  {{- end -}}
+  {{- end }}
   "useManagedIdentityExtension": {{ .Values.azuredns.createAuthSecret.useManagedIdentityExtension | default false }},
-  {{- if .Values.azuredns.createAuthSecret.userAssignedIdentityID -}}
+  {{- if .Values.azuredns.createAuthSecret.userAssignedIdentityID }}
   "userAssignedIdentityID": "{{ .Values.azuredns.createAuthSecret.userAssignedIdentityID }}",
-  {{- end -}}
+  {{- end }}
   "useWorkloadIdentityExtension": {{ .Values.azuredns.createAuthSecret.useWorkloadIdentityExtension | default false }}
 }
 {{- end -}}

--- a/chart/k8gb/templates/_helpers.tpl
+++ b/chart/k8gb/templates/_helpers.tpl
@@ -164,22 +164,22 @@ k8gb-{{ .Values.k8gb.dnsZone }}-{{ .Values.k8gb.clusterGeoTag }}
 {{- end -}}
 
 {{- define "external-dns.azure-credentials" -}}
-{{- if .Values.azuredns.enabled -}}
+{{- if and (eq .Values.azuredns.enabled true) (eq .Values.azuredns.createAuthSecret true) -}}
 {
-  "tenantId": "{{ .Values.azuredns.tenantId }}",
-  "subscriptionId": "{{ .Values.azuredns.subscriptionId }}",
-  "resourceGroup": "{{ .Values.azuredns.resourceGroup }}",
-  {{- if .Values.azuredns.aadClientId -}}
-  "aadClientId": "{{ .Values.azuredns.aadClientId }}",
+  "tenantId": "{{ .Values.azuredns.createAuthSecret.tenantId }}",
+  "subscriptionId": "{{ .Values.azuredns.createAuthSecret.subscriptionId }}",
+  "resourceGroup": "{{ .Values.azuredns.createAuthSecret.resourceGroup }}",
+  {{- if .Values.azuredns.createAuthSecret.aadClientId -}}
+  "aadClientId": "{{ .Values.azuredns.createAuthSecret.aadClientId }}",
   {{- end -}}
-  {{- if .Values.azuredns.aadClientSecret -}}
-  "aadClientSecret": "{{ .Values.azuredns.aadClientSecret }}",
+  {{- if .Values.azuredns.createAuthSecret.aadClientSecret -}}
+  "aadClientSecret": "{{ .Values.azuredns.createAuthSecret.aadClientSecret }}",
   {{- end -}}
-  "useManagedIdentityExtension": {{ .Values.azuredns.useManagedIdentityExtension | default false }},
-  {{- if .Values.azuredns.userAssignedIdentityID -}}
-  "userAssignedIdentityID": "{{ .Values.azuredns.userAssignedIdentityID }}",
+  "useManagedIdentityExtension": {{ .Values.azuredns.createAuthSecret.useManagedIdentityExtension | default false }},
+  {{- if .Values.azuredns.createAuthSecret.userAssignedIdentityID -}}
+  "userAssignedIdentityID": "{{ .Values.azuredns.createAuthSecret.userAssignedIdentityID }}",
   {{- end -}}
-  "useWorkloadIdentityExtension": {{ .Values.azuredns.useWorkloadIdentityExtension | default false }}
+  "useWorkloadIdentityExtension": {{ .Values.azuredns.createAuthSecret.useWorkloadIdentityExtension | default false }}
 }
 {{- end -}}
 {{- end -}}

--- a/chart/k8gb/templates/external-dns/external-dns-azure-auth.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-azure-auth.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.azuredns.enabled .Values.azuredns.createAuthSecret }}
+{{- if and .Values.azuredns.enabled .Values.azuredns.createAuthSecret.enabled }}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -622,51 +622,54 @@
                 "enabled": {
                     "type": "boolean"
                 },
-                "createAuthSecret": {
-                    "type": "boolean",
-                    "default": true
-                },
                 "authSecretName": {
                     "type": "string",
                     "default": "external-dns-secret-azure"
                 },
-                "tenantId": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "subscriptionId": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "resourceGroup": {
-                    "type": "string",
-                    "minLength": 1
-                },
-                "aadClientId": {
-                    "type": "string"
-                },
-                "aadClientSecret": {
-                    "type": "string"
-                },
-                "useManagedIdentityExtension": {
-                    "type": "boolean",
-                    "default": false
-                },
-                "userAssignedIdentityID": {
-                    "type": "string"
-                },
-                "useWorkloadIdentityExtension": {
-                    "type": "boolean",
-                    "default": false
-                }
+                "createAuthSecret": {
+                    "type": "object",
+		    "additionalProperties": false,
+		    "properties": {
+			"enabled": {
+			    "type": "boolean"
+			},
+			"tenantId": {
+			    "type": "string",
+			    "minLength": 1
+			},
+			"subscriptionId": {
+			    "type": "string",
+			    "minLength": 1
+			},
+			"resourceGroup": {
+			    "type": "string",
+			    "minLength": 1
+			},
+			"aadClientId": {
+			    "type": "string"
+			},
+			"aadClientSecret": {
+			    "type": "string"
+			},
+			"useManagedIdentityExtension": {
+			    "type": "boolean",
+			    "default": false
+			},
+			"userAssignedIdentityID": {
+			    "type": "string"
+			},
+			"useWorkloadIdentityExtension": {
+			    "type": "boolean",
+			    "default": false
+			}
+		    }
+		}
             },
             "required": [
-                "tenantId",
-                "subscriptionId",
-                "resourceGroup"
+                "enabled"
             ],
             "title": "azuredns"
-        },        
+        },
         "Cloudflare": {
             "type": "object",
             "additionalProperties": false,

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -153,15 +153,30 @@ rfc2136:
 
 azuredns:
   enabled: false
-  # -- Create an authentication secret for Azure DNS based on the values below
-  # alternatively, you can create the secret manually and pass its name in the `authSecretName` value
-  createAuthSecret: true
-  # -- Azure tenant ID which holds the managed identity
-  tenantId: myTenantId
-  # -- subscription id which holds the Azure DNS zone
-  subscriptionId: mySubscriptionId
-  # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'edgeDNSZone')
-  resourceGroup: myDnsResourceGroup
+  # -- External-dns secret name which contains Azure credentials.
+  # See https://github.com/k8gb-io/external-dns/blob/master/docs/tutorials/azure.md#configuration-file for expected format
+  authSecretName: external-dns-secret-azure
+  createAuthSecret:
+    # -- Create an authentication secret for Azure DNS based on the values below
+    # alternatively, you can create the secret manually and pass its name in the `azuredns.authSecretName` value
+    enabled: true
+    # -- Azure tenant ID which holds the managed identity
+    tenantId: myTenantId
+    # -- subscription id which holds the Azure DNS zone
+    subscriptionId: mySubscriptionId
+    # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'k8gb.edgeDNSZone')
+    resourceGroup: myDnsResourceGroup
+    # -- Azure client ID that is associated with the Service Principal.
+    aadClientId: myAadClientId
+    # -- Azure client secret that is associated with the Service Principal.
+    aadClientSecret: myAadClientSecret
+    # -- Use either AKS Kubelet Identity or AAD Pod Identities
+    useManagedIdentityExtension : false
+    # -- Client id from the Managed identitty when using the AAD Pod Identities
+    userAssignedIdentityID: myUserAssignedIdentityID
+    # -- Use AKS workload identity extension
+    useWorkloadIdentityExtension: false
+
 
 cloudflare:
   # -- Enable Cloudflare provider

--- a/docs/deploy_azuredns.md
+++ b/docs/deploy_azuredns.md
@@ -23,7 +23,7 @@ Configurable resources:
 
 ## Run the sample
 
-* To run the provided sample, please use the provided Makefile [here](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/azuredns/).
+* To run the provided sample, please use the provided Makefile [here](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/azure/).
     * Deploys all the required infrastructure and configurations
     * Before executing, please fill all the local variables in the scripts with the correct naming for the resources in order to avoid having problems with your Azure policies
     * Scripts will use Az CLI, please ensure that it is installed and logged when trying to execute the command
@@ -47,7 +47,7 @@ make setup-clusters
 
 ### Install K8gb
 
-This action will install K8gb in both clusters using the provided [sample](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/azuredns/k8gb/) values.yaml for each cluster. Please ensure that the are correctly updated before execution
+This action will install K8gb in both clusters using the provided [sample](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/azure/) values.yaml for each cluster. Please ensure that the are correctly updated before execution
 
 ```sh
 make deploy-k8gb
@@ -55,7 +55,7 @@ make deploy-k8gb
 
 ### Install demo app
 
-Deploys the sample Podinfo workload with failover GLSB configured using annotations in the Ingress resource [samples](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/azuredns/demo/).
+Deploys the sample Podinfo workload with failover GLSB configured using annotations in the Ingress resource [samples](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/azure/demo/).
 Ensure that the hosts on the samples are correctly updated before execution
 
 ```sh

--- a/docs/examples/azure/k8gb/aks1-helm-values.yaml
+++ b/docs/examples/azure/k8gb/aks1-helm-values.yaml
@@ -24,10 +24,12 @@ azuredns:
   # -- Enable Azure DNS provider
   enabled: true
   # -- Azure tenant ID which holds the managed identity
-  tenantId: myTenantID
-  # -- subscription id which holds the Azure DNS zone
-  subscriptionId: mySubscriptionID
-  # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'edgeDNSZone')
-  resourceGroup: k8gb-kubeconeu2023
-  aadClientId: myAADClientID
-  aadClientSecret: myAADClientSecret
+  createAuthSecret:
+    enabled: true
+    tenantId: myTenantID
+    # -- subscription id which holds the Azure DNS zone
+    subscriptionId: mySubscriptionID
+    # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'edgeDNSZone')
+    resourceGroup: k8gb-kubeconeu2023
+    aadClientId: myAADClientID
+    aadClientSecret: myAADClientSecret

--- a/docs/examples/azure/k8gb/aks2-helm-values.yaml
+++ b/docs/examples/azure/k8gb/aks2-helm-values.yaml
@@ -23,11 +23,12 @@ externaldns:
 azuredns:
   # -- Enable Azure DNS provider
   enabled: true
-  # -- Azure tenant ID which holds the managed identity
-  tenantId: myTenantID
-  # -- subscription id which holds the Azure DNS zone
-  subscriptionId: mySubscriptionID
-  # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'edgeDNSZone')
-  resourceGroup: k8gb-kubeconeu2023
-  aadClientId: myAADClientID
-  aadClientSecret: myAADClientSecret
+  createAuthSecret:
+    enabled: true
+    tenantId: myTenantID
+    # -- subscription id which holds the Azure DNS zone
+    subscriptionId: mySubscriptionID
+    # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'edgeDNSZone')
+    resourceGroup: k8gb-kubeconeu2023
+    aadClientId: myAADClientID
+    aadClientSecret: myAADClientSecret


### PR DESCRIPTION
* Explicitly mention azure control variables in the `values.yaml` for proper visibility and documentation
* Scope the azure credentials related values under `azuredns.createAuthSecret.*`
* Bring up the Azure public DNS doc to README/website frontpage 
* Enhance `make deploy-full-local-setup` with ability to deploy test k8gb chart and k8gb controller versions
* Update value examples in the Azure tutorial
* Fix newline control in  `-}}` templating function to create properly formatted secret 
* Fixes #1585  

All changes tested e2e locally:
* The azure external secret is getting created with:
```
azuredns:
  # -- Enable Azure DNS provider
  enabled: true
  # -- Azure tenant ID which holds the managed identity
  createAuthSecret:
    enabled: true
    tenantId: myTenantID
    # -- subscription id which holds the Azure DNS zone
    subscriptionId: mySubscriptionID
    # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'edgeDNSZone')
    resourceGroup: k8gb-kubeconeu2023
    aadClientId: myAADClientID
    aadClientSecret: myAADClientSecret
```
```
k view-secret -n k8gb external-dns-secret-azure
Choosing key: azure.json
{
  "tenantId": "myTenantID",
  "subscriptionId": "mySubscriptionID",
  "resourceGroup": "k8gb-kubeconeu2023",
  "aadClientId": "myAADClientID",
  "aadClientSecret": "myAADClientSecret",
  "useManagedIdentityExtension": false,
  "userAssignedIdentityID": "myUserAssignedIdentityID",
  "useWorkloadIdentityExtension": false
}
```

In case of 

```
azuredns:
  # -- Enable Azure DNS provider
  enabled: true
  authSecretName: external-dns-secret-azure-test
  # -- Azure tenant ID which holds the managed identity
  createAuthSecret:
    enabled: false
```

The `external-dns-secret-azure-test` was created separately from the helm chart installation and was properly picked up by extenral-dns deployment.

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
