### PR TITLE
Do not group upgrades of dependencies on major version 0

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "group:allNonMajor",
   ],
   "ignoreDeps": [
     "github.com/infobloxopen/infoblox-go-client",
@@ -25,6 +24,7 @@
         "minor",
         "patch",
       ],
+      "matchCurrentVersion": "!/^v?0/",
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
     }, {


### PR DESCRIPTION
Currently there is a Renovate Bot rule grouping all minor and patch dependency updates in a single pull request. However, packages that follow SemVer are allowed to make breaking changes in any `0.x` version. This led to a situation where the PR to bump the group `all non-major dependencies` has a red pipeline (https://github.com/k8gb-io/k8gb/pull/1052) which cannot be merged since many months.

This PR attempts to fix the problem by excluding version `0.x` from the `all non-major dependencies` group (as documented in https://docs.renovatebot.com/configuration-options/#matchupdatetypes). These updates will instead be handled in a dedicated PR. This should prevent benign minor and patch upgrades from being blocked as well as allow us to easily identify the dependency bumps that introduce breaking changes. 

---

Note: the preset [group:allNonMajor](https://docs.renovatebot.com/presets-group/#groupallnonmajor) is removed since we are not using it anymore, as we override it.