### PR TITLE
Switch goreleaser to buildx

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,7 @@ archives:
 dockers:
 - image_templates:
   - "absaoss/k8gb:v{{ .Version }}-amd64"
+  use: buildx
   build_flag_templates:
   - "--platform=linux/amd64"
   - &LABEL1
@@ -47,6 +48,7 @@ dockers:
     "--label=org.opencontainers.image.version={{ .Version }}"
 - image_templates:
   - "absaoss/k8gb:v{{ .Version }}-arm64"
+  use: buildx
   goarch: arm64
   build_flag_templates:
   - "--platform=linux/arm64"


### PR DESCRIPTION
* Faster builds
* `K8GB_LOCAL_VERSION=test make deploy-full-local-setup` works on modern buildx based setup

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
