### PR TITLE
Increase number of renovate bot PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,7 @@
     ".github/workflows/scorecard.yml",
   ],
   "labels": ["dependencies", "renovate"],
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 15,
   "packageRules": [
     {
       "matchPackagePatterns": [
@@ -26,7 +26,8 @@
       ],
       "matchCurrentVersion": "!/^v?0/",
       "groupName": "all non-major dependencies",
-      "groupSlug": "all-minor-patch"
+      "groupSlug": "all-minor-patch",
+      "automerge": true,
     }, {
         "matchPackageNames": [
         "k8gb-io/k8gb",


### PR DESCRIPTION
Since #1610 was merged the number of PRs created by renovate increased, as bumps of libraries on version 0.x are handled in a dedicated PR. The maximum number of concurrent PRs is 5 which results in rate-limiting: https://github.com/k8gb-io/k8gb/issues/1048. The proposal is to increase it to 15 so that we can see and tackle the PRs containing potential breaking changes.

In addition, the `update all non-major dependencies` group should very rarely contain breaking changes (#1052) so I propose to turn on automerge (if the pipeline is green ofc). This should save the maintainers some precious minutes.