### PR TITLE
remove non-working auto merge

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -27,7 +27,6 @@
       "matchCurrentVersion": "!/^v?0/",
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch",
-      "automerge": true,
     }, {
         "matchPackageNames": [
         "k8gb-io/k8gb",


### PR DESCRIPTION
In #1615 auto merge was enabled for [all non-major dependencies](https://github.com/k8gb-io/k8gb/pull/1052#event-13317496471). However, the PR cannot be merged without an approving review. The missing piece would be the following app: https://github.com/apps/renovate-approve. It would approve all PRs created by the renovate bot that have auto merge enabled. Unfortunately, it cannot do it for projects that have CODEOWNERS setup, which is our case:
> Important note: Due to a GitHub limitation, it is not possible to assign any app like this one as a CODEOWNER, so unfortunately this bot won't work that way if you have CODEOWNERS set up.

Since auto merge does not work in our setup this PR removes its configuration to avoid any confusion.