### PR TITLE
Update Release instructions with chart readme version bump

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -335,6 +335,11 @@ make demo DEMO_URL=https://failover.test.exampledns.tk DEMO_DEBUG=1
 
 * Bump the version in `Chart.yaml`, see [example PR](https://github.com/k8gb-io/k8gb/pull/749). Make sure the
 commit message starts with `RELEASE:`.
+* In addition, bump the version in `chart/k8gb/README.md` to reflect correct version tags in artifacthub after
+release, e.g.
+```
+chart/k8gb/README.md:![Version: v0.13.0](https://img.shields.io/badge/Version-v0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
+```
 * Merge the Pull Request after the review approval (make sure the squash or rebase is used, merge commit will not trigger the release pipeline)
 * At this point a DRAFT release will be created on GitHub. After the [automatic tag](https://github.com/k8gb-io/k8gb/actions/workflows/cut_release.yaml) & [release pipeline](https://github.com/k8gb-io/k8gb/actions/workflows/release.yaml)
 have been successfully completed, you check the [release DRAFT](https://github.com/k8gb-io/k8gb/releases) and if it is OK, you click on the **"Publish release"** button.

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -31,7 +31,7 @@ maintainers:
     name: Jiri Kremser
   - email: kuritka@gmail.com
     name: Michal Kuritka
-  - email: yury.tsarev@absa.africa
+  - email: yury@upbound.io
     name: Yury Tsarev
 
 annotations:

--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -22,7 +22,7 @@ A Helm chart for Kubernetes Global Balancer
 | Dinar Valeev | <dinar.valeev@absa.africa> |  |
 | Jiri Kremser | <jiri.kremser@gmail.com> |  |
 | Michal Kuritka | <kuritka@gmail.com> |  |
-| Yury Tsarev | <yury.tsarev@absa.africa> |  |
+| Yury Tsarev | <yury@upbound.io> |  |
 
 ## Source Code
 


### PR DESCRIPTION
* Update chart readme tags before the release so it is properly reflected in ArtifactHub
* Inline update of Yury's actual email address

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
