### PR TITLE
Update docs to use a referenced instead of an embedded ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,10 @@ metadata:
   name: test-gslb-failover
   namespace: test-gslb
 spec:
-  ingress:
-    ingressClassName: nginx # or any other existing ingressclasses.networking.k8s.io
-    rules:
-      - host: failover.test.k8gb.io # Desired GSLB enabled FQDN
-        http:
-          paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: frontend-podinfo # Service name to enable GSLB for
-                port:
-                  name: http
+  resourceRef:
+    ingress:
+      matchLabels: # ingresses.networking.k8s.io resource selector
+        app: test-gslb-failover
   strategy:
     type: failover # Global load balancing strategy
     primaryGeoTag: eu-west-1 # Primary cluster geo tag

--- a/docs/deploy_cloudflare.md
+++ b/docs/deploy_cloudflare.md
@@ -74,7 +74,7 @@ kubectl -n k8gb create secret generic cloudflare --from-literal=token=<api-secre
 
 Note: you can create Cloudflare API tokens at https://dash.cloudflare.com/profile/api-tokens
 
-### Create test Gslb resource
+### Create test Ingress and Gslb resources
 
 Now we can test the setup with a pretty standard Gslb resource configuration.
 
@@ -85,19 +85,10 @@ metadata:
   name: test-gslb-failover
   namespace: test-gslb
 spec:
-  ingress:
-    ingressClassName: nginx
-    rules:
-    - host: failover.cloudflare-test.k8gb.io
-      http:
-        paths:
-        - backend:
-            service:
-              name: frontend-podinfo
-              port:
-                name: http
-          path: /
-          pathType: Prefix
+  resourceRef:
+    ingress:
+      matchLabels:
+        app: test-gslb-failover
   strategy:
     dnsTtlSeconds: 60 # Minimum for non-Enterprise Cloudflare https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/
     primaryGeoTag: eu
@@ -109,7 +100,7 @@ The only unusual thing here is `spec.strategy.dnsTtlSeconds` that should be of a
 minimum 60-second value in case you are operating a non-Enterprise Cloudflare
 subscription. The lower values will be rejected by Cloudflare API.
 
-Apply Gslb resource to each cluster.
+Apply the Gslb and Ingress resources to each cluster.
 
 ```sh
 kubectl apply -f ./docs/examples/cloudflare/test-gslb-failover.yaml

--- a/docs/deploy_infoblox.md
+++ b/docs/deploy_infoblox.md
@@ -83,29 +83,39 @@ NAME            TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)             AG
 podinfo         ClusterIP   10.96.250.84    <none>        9898/TCP,9999/TCP   9m39s
 ```
 
-* Create a custom resource `~/k8gb/podinfogslb.yaml` describing `Gslb` as per the sample below:
+* Create a custom resource `~/k8gb/podinfogslb.yaml` describing an `Ingress` and a `Gslb` as per the sample below:
 ```yaml
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: podinfo
+  namespace: test-gslb
+  labels:
+    app: podinfo
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: podinfo.cloud.example.com
+      http:
+        paths:
+        - path: /
+          backend:
+            service:
+              name: podinfo # This should point to Service name of testing application
+              port:
+                name: http
+---
 apiVersion: k8gb.absa.oss/v1beta1
 kind: Gslb
 metadata:
   name: podinfo
   namespace: test-gslb
 spec:
-  ingress:
-    ingressClassName: nginx
-    rules:
-      - host: podinfo.cloud.example.com
-        http:
-          paths:
-          - path: /
-            backend:
-              service:
-                name: podinfo # This should point to Service name of testing application
-                port:
-                  name: http
-
-  strategy:
-    type: roundRobin # Use a round robin load balancing strategy, when deciding which downstream clusters to route clients too
+  resourceRef:
+    ingress:
+      matchLabels:
+        app: podinfo
 ```
 
 * And apply the resource in the target app namespace

--- a/docs/examples/cloudflare/test-gslb-failover.yaml
+++ b/docs/examples/cloudflare/test-gslb-failover.yaml
@@ -1,22 +1,35 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-gslb-failover
+  namespace: test-gslb
+  labels:
+    app: test-gslb-failover
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: failover.cloudflare-test.k8gb.io
+    http:
+      paths:
+      - backend:
+          service:
+            name: frontend-podinfo
+            port:
+              name: http
+        path: /
+        pathType: Prefix
+---
 apiVersion: k8gb.absa.oss/v1beta1
 kind: Gslb
 metadata:
   name: test-gslb-failover
   namespace: test-gslb
 spec:
-  ingress:
-    ingressClassName: nginx
-    rules:
-    - host: failover.cloudflare-test.k8gb.io
-      http:
-        paths:
-        - backend:
-            service:
-              name: frontend-podinfo
-              port:
-                name: http
-          path: /
-          pathType: Prefix
+  resourceRef:
+    ingress:
+      matchLabels:
+        app: test-gslb-failover
   strategy:
     dnsTtlSeconds: 60 # Minimum for non-Enterprise Cloudflare https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/
     primaryGeoTag: eu

--- a/docs/examples/route53/k8gb/gslb-failover.yaml
+++ b/docs/examples/route53/k8gb/gslb-failover.yaml
@@ -1,22 +1,34 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-gslb-failover
+  namespace: test-gslb
+  labels:
+    app: failover
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: failover.test.k8gb.io # Desired GSLB enabled FQDN
+      http:
+        paths:
+        - path: /
+          backend:
+            service:
+              name: frontend-podinfo # Service name to enable GSLB for
+              port:
+                name: http
+---
 apiVersion: k8gb.absa.oss/v1beta1
 kind: Gslb
 metadata:
   name: test-gslb-failover
   namespace: test-gslb
 spec:
-  ingress:
-    ingressClassName: nginx
-    rules:
-      - host: failover.test.k8gb.io # Desired GSLB enabled FQDN
-        http:
-          paths:
-          - path: /
-            backend:
-              service:
-                name: frontend-podinfo # Service name to enable GSLB for
-                port:
-                  name: http
-
+  resourceRef:
+    ingress:
+      matchLabels:
+        app: failover
   strategy:
     type: failover # Global load balancing strategy
     primaryGeoTag: eu-west-1 # Primary cluster geo tag

--- a/docs/examples/route53/k8gb/gslb-roundrobin.yaml
+++ b/docs/examples/route53/k8gb/gslb-roundrobin.yaml
@@ -1,39 +1,52 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: test-gslb
+  namespace: test-gslb
+  labels:
+    app: test-gslb
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: notfound.test.k8gb.io # This is the GSLB enabled host that clients would use
+      http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
+        paths:
+          - path: /
+          - backend:
+              service:
+                name: non-existing-app # Gslb should reflect NotFound status
+                port:
+                  name: http
+    - host: unhealthy.test.k8gb.io
+      http:
+        paths:
+        - path: /
+          backend:
+            service:
+                name: unhealthy-app # Gslb should reflect Unhealthy status
+                port:
+                  name: http
+    - host: roundrobin.test.k8gb.io
+      http:
+        paths:
+        - path: /
+          backend:
+            service:
+                name: frontend-podinfo # Gslb should reflect Healthy status and create associated DNS records
+                port:
+                  name: http
+---
 apiVersion: k8gb.absa.oss/v1beta1
 kind: Gslb
 metadata:
   name: test-gslb
   namespace: test-gslb
 spec:
-  ingress:
-    ingressClassName: nginx
-    rules:
-      - host: notfound.test.k8gb.io # This is the GSLB enabled host that clients would use
-        http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
-          paths:
-            - path: /
-            - backend:
-                service:
-                  name: non-existing-app # Gslb should reflect NotFound status
-                  port:
-                    name: http
-      - host: unhealthy.test.k8gb.io
-        http:
-          paths:
-          - path: /
-            backend:
-              service:
-                  name: unhealthy-app # Gslb should reflect Unhealthy status
-                  port:
-                    name: http
-      - host: roundrobin.test.k8gb.io
-        http:
-          paths:
-          - path: /
-            backend:
-              service:
-                  name: frontend-podinfo # Gslb should reflect Healthy status and create associated DNS records
-                  port:
-                    name: http
+  resourceRef:
+    ingress:
+      matchLabels:
+        app: test-gslb
   strategy:
     type: roundRobin # Use a round robin load balancing strategy, when deciding which downstream clusters to route clients too
     splitBrainThresholdSeconds: 300 # Threshold after which external cluster is filtered out from delegated zone when it doesn't look alive

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ At it's simplest, an HTTP request should be handled by a healthy service. This s
 
 In the use case above, the following resources are configured by the _application_ team:
 
-**A.** The Kubernetes `Gslb` CRD (Custom Resource Definition) is created which indicates to an  k8gb controller that it should create the necessary GSLB configuration for the cluster.
+**A.** The Kubernetes `Gslb` CRD (Custom Resource Definition) is created which indicates to an k8gb controller that it should create the necessary GSLB configuration for the cluster.
 
 A potential example of what this `Gslb` resource would look like:
 
@@ -54,26 +54,16 @@ kind: Gslb
 metadata:
   name: app
 spec:
-  ingress:
-    ingressClassName: nginx
-    rules:
-    - host: app.cloud.example.com # This is the GSLB enabled host that clients would use
-      http: # This section mirrors the same structure as that of an Ingress resource and will be used verbatim when creating the corresponding Ingress resource that will match the GSLB host
-        paths:
-        - path: /
-          backend:
-            service:
-              name: app
-              port:
-                name: http
+  resourceRef:
+    ingress:
+      matchLabels:
+        app: app
   strategy: roundRobin # Use a round robin load balancing strategy, when deciding which downstream clusters to route clients too
-  tls:
-    secretName: app-glsb-tls # Use this Secret to add to the TLS configuration for the new Ingress resource that will be created for the GSLB host
 ```
 
 On creating this `Gslb` resource, the k8gb controller watching the cluster where this resource is created, will:
 
-1. Create a new `Ingress` resource that will allow requests with the GSLB host (`app.cloud.example.com`) to be handled by the cluster's Ingress controller
+1. Lookup an `Ingress` resource that allow requests with the GSLB host (`app.cloud.example.com`). The ingress is handled by the cluster's Ingress controller
 2. Configure a health check strategy on the underlying `app` Pods. The Pods here are the Pods matched by the Service configured by `service.name`
 3. Based on the health (see [Service health](#service-health)) of those Pods, if at least one of the Pods is healthy, add DNS records with the external addresses of the cluster's nodes running the Ingress controllers
 


### PR DESCRIPTION
Tackles one of the prerequisites outlined in #1698 to decommission embedded ingresses.