### PR TITLE
Allow adding custom annotations and labels to the k8gb controller

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -102,6 +102,8 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | k8gb.log.format | string | `"simple"` | log format (simple,json) |
 | k8gb.log.level | string | `"info"` | log level (panic,fatal,error,warn,info,debug,trace) |
 | k8gb.metricsAddress | string | `"0.0.0.0:8080"` | Metrics server address |
+| k8gb.podAnnotations | object | `{}` | pod annotations |
+| k8gb.podLabels | object | `{}` | pod labels |
 | k8gb.reconcileRequeueSeconds | int | `30` | Reconcile time in seconds |
 | k8gb.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | k8gb.securityContext.readOnlyRootFilesystem | bool | `true` |  |

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -14,8 +14,14 @@ spec:
     metadata:
       labels:
         name: k8gb
+        {{- with .Values.k8gb.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         kubectl.kubernetes.io/default-container: k8gb
+        {{- with .Values.k8gb.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       serviceAccountName: k8gb
       containers:

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -316,6 +316,12 @@
                 },
                 "serviceMonitor": {
                     "$ref": "#/definitions/k8gbServiceMonitor"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
                 }
             },
             "required": [

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -52,6 +52,10 @@ k8gb:
   # -- enable ServiceMonitor
   serviceMonitor:
     enabled: false
+  # -- pod annotations
+  podAnnotations: {}
+  # -- pod labels
+  podLabels: {}
 
 externaldns:
   # -- `.spec.template.spec.dnsPolicy` for ExternalDNS deployment


### PR DESCRIPTION
I faced a usecase where I needed to add an istio exception to the k8gb controller via an annotation. However, the chart did not allow it.

This PR also allows adding custom labels since this feature may be desired for other usecases.

### Testing
Modify values.yaml by adding/removing labels/annotations and run:
```
helm package . && helm template k8gb k8gb-v0.13.0.tgz > manifests.yaml
```