### PR TITLE
Fix failover strategy with 3 or more clusters

### DIFF
--- a/controllers/gslb_controller_reconciliation_test.go
+++ b/controllers/gslb_controller_reconciliation_test.go
@@ -704,7 +704,6 @@ func TestReturnsExternalRecordsUsingFailoverStrategy(t *testing.T) {
 	}
 	dnsEndpoint := &externaldns.DNSEndpoint{}
 	customConfig := predefinedConfig
-	customConfig.ClusterGeoTag = "za"
 	customConfig.EdgeDNSServers = []utils.DNSServer{
 		{
 			Host: "localhost",
@@ -728,7 +727,7 @@ func TestReturnsExternalRecordsUsingFailoverStrategy(t *testing.T) {
 
 			// enable failover strategy
 			settings.gslb.Spec.Strategy.Type = depresolver.FailoverStrategy
-			settings.gslb.Spec.Strategy.PrimaryGeoTag = "eu"
+			settings.gslb.Spec.Strategy.PrimaryGeoTag = "us-east-1"
 			err = settings.client.Update(context.TODO(), settings.gslb)
 			require.NoError(t, err, "Can't update gslb")
 
@@ -771,7 +770,6 @@ func TestReturnsExternalRecordsUsingFailoverStrategyAndFallbackDNSserver(t *test
 	}
 	dnsEndpoint := &externaldns.DNSEndpoint{}
 	customConfig := predefinedConfig
-	customConfig.ClusterGeoTag = "za"
 	customConfig.EdgeDNSServers = []utils.DNSServer{
 		{ // this one will be tried frist, but fails
 			Host: "localhost",
@@ -802,7 +800,7 @@ func TestReturnsExternalRecordsUsingFailoverStrategyAndFallbackDNSserver(t *test
 
 			// enable failover strategy
 			settings.gslb.Spec.Strategy.Type = depresolver.FailoverStrategy
-			settings.gslb.Spec.Strategy.PrimaryGeoTag = "eu"
+			settings.gslb.Spec.Strategy.PrimaryGeoTag = "us-east-1"
 			err = settings.client.Update(context.TODO(), settings.gslb)
 			require.NoError(t, err, "Can't update gslb")
 


### PR DESCRIPTION
In a setup with 3 or more clusters the `failover` strategy is not returning the correct targets if the DNS query hits a non-primary region.

### How to reproduce

Create a 3 cluster setup that contains a GSLB with failover strategy with `eu` as primary cluster. The podinfo app is up on all clusters:
```
K8GB_LOCAL_VERSION=test CLUSTERS_NUMBER=3 make deploy-full-local-setup
```

Retrieve the local targets to see which IP addresses are exposed by each cluster (`eu`, `us` and `cz` respectively):
```
➜  ~ dig +short -p 5053 @localhost localtargets-failover.cloud.example.com
172.19.0.6
172.19.0.7
➜  ~ dig +short -p 5054 @localhost localtargets-failover.cloud.example.com
172.19.0.10
172.19.0.11
➜  ~ dig +short -p 5055 @localhost localtargets-failover.cloud.example.com
172.19.0.14
172.19.0.15
```

Query the domain `failover.cloud.example` on each cluster:
```
➜  ~ dig +short -p 5053 @localhost failover.cloud.example.com
172.19.0.6
172.19.0.7
➜  ~ dig +short -p 5054 @localhost failover.cloud.example.com
172.19.0.6
172.19.0.7
172.19.0.14
172.19.0.15
➜  ~ dig +short -p 5055 @localhost failover.cloud.example.com
172.19.0.6
172.19.0.7
172.19.0.10
172.19.0.11
```
We would expect all clusters to return 172.19.0.6 and 172.19.0.7, however the non-primary clusters return also the IP addresses of the other non-primary cluster:
* `eu` returns `eu`
* `us` returns `eu` and `cz`
* `cz` returns `eu` and `us`

This happens because a non-primary cluster returns the IP addresses of all other clusters, which is correct in a 2 cluster setup but not on a 3 cluster setup.

### Fix

To fix the issue the login for non-primary clusters needs to be adapted. If the app is healthy on the primary cluster then these the targets on that cluster must be returned. If the application is unhealthy on the primary cluster then the addresses of all healthy clusters should be returned.

After the change:
```
➜  ~ dig +short -p 5053 @localhost failover.cloud.example.com
172.19.0.6
172.19.0.7
➜  ~ dig +short -p 5054 @localhost failover.cloud.example.com
172.19.0.6
172.19.0.7
➜  ~ dig +short -p 5055 @localhost failover.cloud.example.com
172.19.0.6
172.19.0.7
```

After scaling down podinfo on the primary cluster (`eu`):
```
➜  ~ k scale deploy frontend-podinfo --replicas=0 -n test-gslb --context k3d-test-gslb1
deployment.apps/frontend-podinfo scaled
```

```
➜  ~ dig +short -p 5053 @localhost failover.cloud.example.com
172.19.0.10
172.19.0.11
172.19.0.14
172.19.0.15
➜  ~ dig +short -p 5054 @localhost failover.cloud.example.com
172.19.0.10
172.19.0.11
172.19.0.14
172.19.0.15
➜  ~ dig +short -p 5055 @localhost failover.cloud.example.com
172.19.0.14
172.19.0.15
172.19.0.10
172.19.0.11
```

### Tests

Two unit tests needed to be adapted since they did not have the correct geo tags.
The tests were overwriting the `ClusterGeoTag` to `za` and the GSLB's `PrimaryGeoTag` to `eu` which resulted in evaluating the targets on a non-primary cluster (`za` != `eu`). However, the external targets only contain records from `us-east-1` (value of `ExtClustersGeoTags`). Interestingly, non-intentionally this actually simulates a 3 cluster setup in a non-conventional way with:
* `za` -> localtargets up
* `eu` -> down
* `us-east-1` -> external targets up

Due to the bug described above, the addresses of `us-east-1` (all external targets) were being returned and the test was passing. But with the fix the correct output is the targets of both `za` and `us-east-1` (local targets + external targets), that is why the tests failed.

To fix this the tags were updated to have only two clusters: `us-east-1` and `us-west-1`, since this was the intended scenario for the test.