### PR TITLE
Allow configuration of extra coredns server blocks

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -87,7 +87,8 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | infoblox.wapiPort | int | `443` | WAPI port |
 | infoblox.wapiVersion | string | `"2.3.1"` | WAPI version |
 | k8gb.clusterGeoTag | string | `"eu"` | used for places where we need to distinguish between different Gslb instances |
-| k8gb.coredns | object | `{"extra_plugins":[]}` | Extra CoreDNS plugins to be enabled (yaml object) |
+| k8gb.coredns.extraServerBlocks | string | `""` | Extra CoreDNS server blocks |
+| k8gb.coredns.extra_plugins | list | `[]` | Extra CoreDNS plugins to be enabled |
 | k8gb.deployCrds | bool | `true` | whether it should also deploy the gslb and dnsendpoints CRDs |
 | k8gb.deployRbac | bool | `true` | whether it should also deploy the service account, cluster role and cluster role binding |
 | k8gb.dnsZone | string | `"cloud.example.com"` | dnsZone controlled by gslb |

--- a/chart/k8gb/templates/coredns-cm.yaml
+++ b/chart/k8gb/templates/coredns-cm.yaml
@@ -24,4 +24,7 @@ data:
             loadbalance weight
         }
     }
+    {{- with .Values.k8gb.coredns.extraServerBlocks -}}
+    {{- tpl . $ | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -32,7 +32,7 @@
                 },
                 "azuredns": {
                     "$ref": "#/definitions/AzureDNS"
-                },                
+                },
                 "cloudflare": {
                     "$ref": "#/definitions/Cloudflare"
                 },
@@ -360,6 +360,9 @@
                         "array",
                         "null"
                     ]
+                },
+                "extraServerBlocks": {
+                    "type": "string"
                 }
             },
             "title": "k8gbCoredns"
@@ -628,42 +631,42 @@
                 },
                 "createAuthSecret": {
                     "type": "object",
-		    "additionalProperties": false,
-		    "properties": {
-			"enabled": {
-			    "type": "boolean"
-			},
-			"tenantId": {
-			    "type": "string",
-			    "minLength": 1
-			},
-			"subscriptionId": {
-			    "type": "string",
-			    "minLength": 1
-			},
-			"resourceGroup": {
-			    "type": "string",
-			    "minLength": 1
-			},
-			"aadClientId": {
-			    "type": "string"
-			},
-			"aadClientSecret": {
-			    "type": "string"
-			},
-			"useManagedIdentityExtension": {
-			    "type": "boolean",
-			    "default": false
-			},
-			"userAssignedIdentityID": {
-			    "type": "string"
-			},
-			"useWorkloadIdentityExtension": {
-			    "type": "boolean",
-			    "default": false
-			}
-		    }
-		}
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "tenantId": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "subscriptionId": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "resourceGroup": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "aadClientId": {
+                            "type": "string"
+                        },
+                        "aadClientSecret": {
+                            "type": "string"
+                        },
+                        "useManagedIdentityExtension": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "userAssignedIdentityID": {
+                            "type": "string"
+                        },
+                        "useWorkloadIdentityExtension": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                }
             },
             "required": [
                 "enabled"

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -21,16 +21,18 @@ k8gb:
   edgeDNSZone: "example.com" # main zone which would contain gslb zone to delegate
   # -- host/ip[:port] format is supported here where port defaults to 53
   edgeDNSServers:
-      # -- use this DNS server as a main resolver to enable cross k8gb DNS based communication
-      - "1.1.1.1"
+    # -- use this DNS server as a main resolver to enable cross k8gb DNS based communication
+    - "1.1.1.1"
   # -- used for places where we need to distinguish between different Gslb instances
   clusterGeoTag: "eu"
   # -- comma-separated list of external gslb geo tags to pair with
   extGslbClustersGeoTags: "us"
   # -- Reconcile time in seconds
   reconcileRequeueSeconds: 30
-  # -- Extra CoreDNS plugins to be enabled (yaml object)
   coredns:
+    # -- Extra CoreDNS server blocks
+    extraServerBlocks: ""
+    # -- Extra CoreDNS plugins to be enabled
     extra_plugins: []
   log:
     # -- log format (simple,json)
@@ -171,12 +173,11 @@ azuredns:
     # -- Azure client secret that is associated with the Service Principal.
     aadClientSecret: myAadClientSecret
     # -- Use either AKS Kubelet Identity or AAD Pod Identities
-    useManagedIdentityExtension : false
+    useManagedIdentityExtension: false
     # -- Client id from the Managed identitty when using the AAD Pod Identities
     userAssignedIdentityID: myUserAssignedIdentityID
     # -- Use AKS workload identity extension
     useWorkloadIdentityExtension: false
-
 
 cloudflare:
   # -- Enable Cloudflare provider


### PR DESCRIPTION
The goal of this PR is to allow configuration of the glue records of the other clusters in k8gb's coreDNS. I know this defies DNS best practices because k8gb is not authoritative for the parent zone. However, it allows k8gb to do cluster discovery without depending on any infrastructure outside of the cluster.

The configuration is quite generic, giving the users freedom to configure what they desire, therefore we could add it to the chart.

Example configuration:
```
    extraServerBlocks: |
      example.com:5353 {
        errors
        health
        ready
        prometheus 0.0.0.0:9153
        forward . /etc/resolv.conf
        k8s_crd {
            filter k8gb.absa.oss/dnstype=glue
            negttl {{ .Values.k8gb.dnsZoneNegTTL }}
            loadbalance weight
        }
      }
```

Testing:
```
helm package . && helm template k8gb k8gb-v0.13.0.tgz > manifests.yaml
```
