### PR TITLE
Update coredns helm chart repo url

### DIFF
--- a/chart/k8gb/Chart.lock
+++ b/chart/k8gb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: coredns
-  repository: https://absaoss.github.io/coredns-helm
+  repository: https://k8gb-io.github.io/coredns-helm
   version: 1.15.3
-digest: sha256:1d0d37c5c794791fd23077b7eec889ed814b5acca9c45084c23889838c7535b3
-generated: "2021-09-22T16:22:52.020645+02:00"
+digest: sha256:6e8906f6d2e0772826658468a0ff436fe0b1f6b7e2daeb4a03b27edfedcba41c
+generated: "2024-09-06T11:25:39.309536+02:00"

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -9,7 +9,7 @@ kubeVersion: ">= 1.19.0-0"
 
 dependencies:
   - name: coredns
-    repository: https://absaoss.github.io/coredns-helm
+    repository: https://k8gb-io.github.io/coredns-helm
     version: 1.15.3
 
 home: https://www.k8gb.io/

--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -34,7 +34,7 @@ Kubernetes: `>= 1.19.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://absaoss.github.io/coredns-helm | coredns | 1.15.3 |
+| https://k8gb-io.github.io/coredns-helm | coredns | 1.15.3 |
 
 For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 


### PR DESCRIPTION
The coredns helm chart fork was moved from https://github.com/AbsaOSS/coredns-helm/ to https://github.com/k8gb-io/coredns-helm