### PR TITLE
Documentation: update GOVERNANCE for incubation application - vendor neutrality

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,56 +1,57 @@
 # k8gb Governance
 
-This document defines governance policies for k8gb project.
+This document defines governance policies for the k8gb project.
 
 ## Principles
 
 The k8gb project community adheres to the following principles:
 
 - Open: k8gb is open source.
-- Welcoming and inclusive: See our [Code of Conduct](#code-of-conduct)
-- Transparent and accessible: Any changes to k8gs source code and collaborations on the project are publicly accessible (GitHub issues, PRs, and discussions).
+- Welcoming and inclusive: See our [Code of Conduct](CODE_OF_CONDUCT.md).
+- Transparent and accessible: Any changes to k8gb's source code and collaborations on the project are publicly accessible (GitHub issues, PRs, and discussions).
 - Merit: Ideas and contributions are accepted according to their technical merit and alignment with project objectives, scope, and design principles.
-
+- Vendor-neutral: k8gb is vendor-neutral as defined by [What it Means to be a Vendor Neutral Project in the CNCF](https://contribute.cncf.io/maintainers/community/vendor-neutrality/).
 
 ## Code of Conduct
 
-k8gb follows [Code of Conduct](./CODE_OF_CONDUCT.md), which is aligned with the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+k8gb follows a [Code of Conduct](CODE_OF_CONDUCT.md), which is aligned with the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
 ## Contributors
 
-Anyone can contribute to the project. More about contribution rules and technical aspects can be found in the [CONTRIBUTING](CONTRIBUTING.md) documentation.
+Anyone can contribute to the k8gb project. More about contribution rules and technical aspects can be found in the [CONTRIBUTING](CONTRIBUTING.md) documentation.
+
 ## Maintainers
 
 Maintainers are defined in the [CODEOWNERS](CODEOWNERS) file by their GitHub user handles.
 New maintainers are nominated by existing maintainers and are elected by a supermajority of votes of existing maintainers.
-If the maintainer is no longer be able to perform the maintainer duties, they should volunteer to be moved to emeritus status.
-Maintainers can be also removed from active maintainers list by a supermajority of votes of existing maintainers.
+If a maintainer is no longer able to perform their duties, they should volunteer to be moved to emeritus status.
+Maintainers can be also removed from the active maintainers list by a supermajority of votes of existing maintainers.
 
-Below is the list of maintainer's general responsibilities in additions to those defined for project contributors:
+Below is the list of a maintainer's general responsibilities in addition to those defined for project contributors:
 
 - Triages GitHub issues
 - Reviews pull requests
 - Runs k8gb releases
 - Forms k8gb architecture, strategy and roadmap
-- Actively supports k8gb community in related channels
-- Represents k8bg project in public media (events, slack channels, etc)
+- Actively supports the k8gb community in related channels
+- Represents the k8gb project in public media (events, slack channels, etc.)
 - Is involved in CNCF-related activities and projects
-- Ensures CNCF guidelines compliancy
+- Ensures compliance with CNCF guidelines
 - Owns project infrastructure
 
 ## Project Lead
 
-Project Lead is a project maintainer with the final vote on project decisions
+The Project Lead is a project maintainer with the final vote on project decisions.
 
 ## Conflict Resolutions
 
 In most cases, it is expected that conflicts are amicably resolved by involved parties.
-In case of escalation, conflicts are resolved by voting, with the ruling of a supermajority of votes of project maintainers. The project lead has the final vote on the ruling.
+In cases of escalation, conflicts are resolved by voting, with the ruling of a supermajority of votes of project maintainers. The project lead has the final vote on the ruling.
 
 ## Changes
 
 Project Governance is a living document.
-All key project changes including changes in project governance can be proposed by a GitHub PR and then reviewed and voted for by project maintainers.
+All key project changes including changes in project governance can be proposed by a GitHub PR and then reviewed and voted on by project maintainers.
 
 ## Credits
 


### PR DESCRIPTION
Documentation: update GOVERNANCE for incubation application - vendor neutrality

* add assertion that k8gb is vendor-neutral
* various minor grammar fixes

Fixes #1746

Signed-off-by: Bradley Andersen <bradley.andersen@pm.me>

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-debug/action.yaml) action more verbose.

</details>
