### PR TITLE
Add PagBank to the adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -17,3 +17,4 @@ This list is sorted in the order that organizations were added to it.
 [Millennium bcp](https://www.millenniumbcp.pt/) | @infbase | Multicloud and multi-region cloud native load balancing
 [Eficode](https://eficode.com/) | @punasusi | As a cloud-native and devops consulting firm, we have used k8gb in customer engagements
 [Open Systems](https://www.open-systems.com/) | @abaguas | Multi-cluster load balancing in private WAN
+[PagBank](https://pagbank.com/) | @altieresfreitas | Multicloud global load balancing across multiple regions


### PR DESCRIPTION
We use k8gb in a multicloud environment spanning multiple regions and data centers to enhance resilience and optimize traffic distribution across diverse infrastructures.