### PR TITLE
Allow override of DEPLOY_APPS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ CLUSTER_GEO_TAGS ?= eu us cz af ru ap uk ca
 CHART ?= k8gb/k8gb
 CLUSTER_GSLB_NETWORK = k3d-action-bridge-network
 CLUSTER_GSLB_GATEWAY = docker network inspect ${CLUSTER_GSLB_NETWORK} -f '{{ (index .IPAM.Config 0).Gateway }}'
+FULL_LOCAL_SETUP_WITH_APPS ?= true
 GSLB_DOMAIN ?= cloud.example.com
 REPO := absaoss/k8gb
 SHELL := bash
@@ -136,7 +137,7 @@ deploy-full-local-setup: ensure-cluster-size ## Deploy full local multicluster s
 		$(MAKE) create-local-cluster CLUSTER_NAME=$(CLUSTER_NAME)$$c ;\
 	done
 	@if [ "$(K8GB_LOCAL_VERSION)" = test ]; then $(MAKE) release-images ; fi
-	$(MAKE) deploy-$(K8GB_LOCAL_VERSION)-version DEPLOY_APPS=true
+	$(MAKE) deploy-$(K8GB_LOCAL_VERSION)-version DEPLOY_APPS=$(FULL_LOCAL_SETUP_WITH_APPS)
 
 .PHONY: deploy-stable-version
 deploy-stable-version:


### PR DESCRIPTION
When using the local setup to debug issues or develop some feature I find it useful to not deploy sample applications.
By starting with an "empty" cluster it is much easier to analyse the controller logs since there won't be any additional noise.
    
Command running locally when testing:
```
K8GB_LOCAL_VERSION=test FULL_LOCAL_SETUP_WITH_APPS=false make deploy-full-local-setup
```
    
Note: initially I tried to set the env var name to DEPLOY_APPS, however it had undesired consequences since the value is passed to the `deploy-local-cluster` target. This caused terratest to deploy the apps, leading to a change of behavior and respective test failures.