### PR TITLE
use upstream coreDNS chart instead of fork

### DIFF
--- a/chart/k8gb/Chart.lock
+++ b/chart/k8gb/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: coredns
-  repository: https://k8gb-io.github.io/coredns-helm
-  version: 1.15.3
-digest: sha256:6e8906f6d2e0772826658468a0ff436fe0b1f6b7e2daeb4a03b27edfedcba41c
-generated: "2024-09-06T11:25:39.309536+02:00"
+  repository: https://coredns.github.io/helm
+  version: 1.36.1
+digest: sha256:55c867121c6aa4e926387802c02cd44e4c0f26439b79a73dbf4ff750c1e6f743
+generated: "2024-11-11T06:50:48.270246+01:00"

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -9,8 +9,8 @@ kubeVersion: ">= 1.19.0-0"
 
 dependencies:
   - name: coredns
-    repository: https://k8gb-io.github.io/coredns-helm
-    version: 1.15.3
+    repository: https://coredns.github.io/helm
+    version: 1.36.1
 
 home: https://www.k8gb.io/
 sources:

--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -1,10 +1,11 @@
 {{- if .Values.coredns.deployment.enabled }}
+apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: {{ .Release.Name }}-coredns
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "chart.labels" . | indent 4  }}
-  name: {{ .Release.Name }}-coredns
-apiVersion: v1
 data:
   Corefile: |-
     {{ .Values.k8gb.dnsZone }}:5353 {

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -100,6 +100,17 @@ coredns:
   serviceAccount:
     create: true
     name: coredns
+  # -- Disables all permissions since we don't open privileged ports
+  securityContext:
+    capabilities:
+      add: []
+  # -- Only meant to open the correct service and container ports, has no other impact on the coredns configuration
+  servers:
+  - port: 5353
+    servicePort: 53
+    plugins:
+    - name: prometheus
+      parameters: 0.0.0.0:9153
 
 infoblox:
   # -- infoblox provider enabled

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: k8gb


### PR DESCRIPTION
CoreDNS is a core component of the K8GB application. Until now we were installing it using a fork of the official helm chart with the following [diff](https://github.com/coredns/helm/compare/master...k8gb-io:coredns-helm:master). The fork was necessary because Kubernetes did not support services of type load balancer with both udp and tcp ports, and to reduce the attack surface by running K8GB on a non-privileged port.

Since [version 1.26](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancers-with-mixed-protocol-types) Kubernetes supports load balancers with mixed ports.
The coredns helm chart also evolved over the years, and with [this contribution](https://github.com/coredns/helm/pull/175) we are able to use coredns without opening privileged ports.

### Generated configuration

The generated configuration by the base chart has only the following differences:
* Ports exposed by the coredns service (fixes #1741)
```
<   - {port: 53, targetPort: 5353, protocol: UDP, name: udp-5353}
---
>   - {"name":"udp-5353","port":53,"protocol":"UDP","targetPort":5353}
>   - {"name":"tcp-5353","port":53,"protocol":"TCP","targetPort":5353}
```
* Ports exposed by the coredns container (allows prometheus metrics scraping)
```
<         - {containerPort: 5353, protocol: UDP, name: udp-5353}
<         - {containerPort: 5353, protocol: TCP, name: tcp-5353}
---
>         - {"containerPort":5353,"name":"udp-5353","protocol":"UDP"}
>         - {"containerPort":5353,"name":"tcp-5353","protocol":"TCP"}
>         - {"containerPort":9153,"name":"tcp-9153","protocol":"TCP"}
```
* coredns container security context (to disable the `NET_BIND_SERVICE` capability)
```
>         securityContext:
>           capabilities:
>             add: []
```

### Abusing the `servers` block

Since the service ports and the prometheus port configuration are taken from the `servers` block of the configuration we need to configure it as follows:
```
  servers:
  - port: 5353
    servicePort: 53
    plugins:
    - name: prometheus
      parameters: 0.0.0.0:9153
```
This opens the ports that we need on the coredns pod and service, nothing more.
In the coredns chart this configuration would be used to create the configmap that configures the served zones. But we are creating that config ourselves (by setting `coredns.deployment.skipConfig=true`) to reuse helm values.

### User configuration
The are no changes to the user configuration

### Conclusion

With this change we are now able to use the upstream chart instead of a fork. We can profit from all the features the coredns community offers, expose TCP port 53 publicly (fixes #1741) and expose the metrics port on the container which allows Prometheus metrics scraping.

---

### Others

#### Creating namespaces in "Upgrade Testing"

In the "Upgrade Testing" pipeline we install k8gb twice, first the stable and then the test version. While reading the upgrade testing logs I noticed errors on the second namespace creation with `kubectl create`. By using `kubectl apply` these errors are no longer thrown if the namespace already exists.

#### Istio version pinning

While updating the Makefile I noticed the istio version of the ingress controller was not pinned, so I pinned it.