### PR TITLE
Compute health of applications only once

### DIFF
--- a/controllers/dnsupdate.go
+++ b/controllers/dnsupdate.go
@@ -38,14 +38,9 @@ func (r *GslbReconciler) gslbDNSEndpoint(gslb *k8gbv1beta1.Gslb) (*externaldns.D
 	var gslbHosts []*externaldns.Endpoint
 	var ttl = externaldns.TTL(gslb.Spec.Strategy.DNSTtlSeconds)
 
-	serviceHealth, err := r.getServiceHealthStatus(gslb)
-	if err != nil {
-		return nil, err
-	}
-
 	localTargets := gslb.Status.LoadBalancer.ExposedIPs
 
-	for host, health := range serviceHealth {
+	for host, health := range gslb.Status.ServiceHealth {
 		var finalTargets = assistant.NewTargets()
 
 		if !strings.Contains(host, r.Config.EdgeDNSZone) {
@@ -149,7 +144,7 @@ func (r *GslbReconciler) gslbDNSEndpoint(gslb *k8gbv1beta1.Gslb) (*externaldns.D
 		Spec: dnsEndpointSpec,
 	}
 
-	err = controllerutil.SetControllerReference(gslb, dnsEndpoint, r.Scheme)
+	err := controllerutil.SetControllerReference(gslb, dnsEndpoint, r.Scheme)
 	if err != nil {
 		return nil, err
 	}

--- a/controllers/gslb_controller_reconciliation.go
+++ b/controllers/gslb_controller_reconciliation.go
@@ -189,6 +189,14 @@ func (r *GslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		Str("gslb", gslb.Name).
 		Msg("Resolved LoadBalancer and Server configuration referenced by Ingress")
 
+	// == health status of applications ==
+	serviceHealth, err := r.getServiceHealthStatus(gslb)
+	if err != nil {
+		m.IncrementError(gslb)
+		return result.RequeueError(err)
+	}
+	gslb.Status.ServiceHealth = serviceHealth
+
 	// == external-dns dnsendpoints CRs ==
 	dnsEndpoint, err := r.gslbDNSEndpoint(gslb)
 	if err != nil {

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -32,15 +32,10 @@ import (
 )
 
 func (r *GslbReconciler) updateGslbStatus(gslb *k8gbv1beta1.Gslb, ep *externaldns.DNSEndpoint) error {
-	var err error
-
-	gslb.Status.ServiceHealth, err = r.getServiceHealthStatus(gslb)
-	if err != nil {
-		return err
-	}
 
 	m.UpdateIngressHostsPerStatusMetric(gslb, gslb.Status.ServiceHealth)
 
+	var err error
 	gslb.Status.HealthyRecords, err = r.getHealthyRecords(gslb)
 	if err != nil {
 		return err


### PR DESCRIPTION
While investigating how we can add metric based health checks (for #1745) I noticed that we compute health checks twice. This PR reduces it to a single call.