### PR TITLE
Bump coreDNS image

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -67,7 +67,7 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | cloudflare.zoneID | string | `"replaceme"` | Cloudflare Zone ID follow https://developers.cloudflare.com/fundamentals/setup/find-account-and-zone-ids/ to find your zoneID value |
 | coredns.deployment.skipConfig | bool | `true` | Skip CoreDNS creation and uses the one shipped by k8gb instead |
 | coredns.image.repository | string | `"absaoss/k8s_crd"` | CoreDNS CRD plugin image |
-| coredns.image.tag | string | `"v0.1.0"` | image tag |
+| coredns.image.tag | string | `"v0.1.1"` | image tag |
 | coredns.isClusterService | bool | `false` | service: refer to https://www.k8gb.io/docs/service_upgrade.html for upgrading CoreDNS service steps |
 | coredns.serviceAccount | object | `{"create":true,"name":"coredns"}` | Creates serviceAccount for coredns |
 | externaldns.dnsPolicy | string | `"ClusterFirst"` | `.spec.template.spec.dnsPolicy` for ExternalDNS deployment |

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -95,7 +95,7 @@ coredns:
     # -- CoreDNS CRD plugin image
     repository: absaoss/k8s_crd
     # -- image tag
-    tag: v0.1.0
+    tag: v0.1.1
   # -- Creates serviceAccount for coredns
   serviceAccount:
     create: true


### PR DESCRIPTION
There is a new release of the coredns image where all dependencies were updated: https://github.com/k8gb-io/coredns-crd-plugin/pull/58, https://github.com/k8gb-io/coredns-crd-plugin/pull/60

This fixes multiple vulnerabilities