### PR TITLE
Add flag to support ClusterIP exposed CoreDNS

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -144,6 +144,8 @@ type Config struct {
 	Infoblox Infoblox
 	// CoreDNSExposed flag
 	CoreDNSExposed bool `env:"COREDNS_EXPOSED, default=false"`
+	// CoreDNSClusterIPs flag
+	CoreDNSClusterIPs bool `env:"COREDNS_CLUSTERIPS, default=false"`
 	// Log configuration
 	Log Log
 	// MetricsAddress in format address:port where address can be empty, IP address, or hostname, default: 0.0.0.0:8080

--- a/controllers/mocks/assistant_mock.go
+++ b/controllers/mocks/assistant_mock.go
@@ -59,6 +59,21 @@ func (m *MockAssistant) EXPECT() *MockAssistantMockRecorder {
 	return m.recorder
 }
 
+// CoreDNSClusterIPs mocks base method.
+func (m *MockAssistant) CoreDNSClusterIPs() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CoreDNSClusterIPs")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CoreDNSClusterIPs indicates an expected call of CoreDNSClusterIPs.
+func (mr *MockAssistantMockRecorder) CoreDNSClusterIPs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CoreDNSClusterIPs", reflect.TypeOf((*MockAssistant)(nil).CoreDNSClusterIPs))
+}
+
 // CoreDNSExposedIPs mocks base method.
 func (m *MockAssistant) CoreDNSExposedIPs() ([]string, error) {
 	m.ctrl.T.Helper()

--- a/controllers/providers/assistant/assistant.go
+++ b/controllers/providers/assistant/assistant.go
@@ -25,6 +25,8 @@ import (
 )
 
 type Assistant interface {
+	//CoreDNSClusterIPs retrieves a list of ClusterIPs assigned to CoreDNS
+	CoreDNSClusterIPs() ([]string, error)
 	// CoreDNSExposedIPs retrieves list of exposed IP by CoreDNS
 	CoreDNSExposedIPs() ([]string, error)
 	// GetExternalTargets retrieves slice of targets from external clusters

--- a/controllers/providers/dns/external.go
+++ b/controllers/providers/dns/external.go
@@ -66,7 +66,11 @@ func (p *ExternalDNSProvider) CreateZoneDelegationForExternalDNS(gslb *k8gbv1bet
 	var NSServerIPs []string
 	var err error
 	if p.config.CoreDNSExposed {
-		NSServerIPs, err = p.assistant.CoreDNSExposedIPs()
+		if p.config.CoreDNSClusterIPs {
+			NSServerIPs, err = p.assistant.CoreDNSClusterIPs()
+		} else {
+			NSServerIPs, err = p.assistant.CoreDNSExposedIPs()
+		}
 	} else {
 		if len(gslb.Status.LoadBalancer.ExposedIPs) == 0 {
 			// do not update DNS Endpoint for External DNS if no IPs are exposed

--- a/controllers/providers/dns/infoblox.go
+++ b/controllers/providers/dns/infoblox.go
@@ -70,7 +70,11 @@ func (p *InfobloxProvider) CreateZoneDelegationForExternalDNS(gslb *k8gbv1beta1.
 
 	var addresses []string
 	if p.config.CoreDNSExposed {
-		addresses, err = p.assistant.CoreDNSExposedIPs()
+		if p.config.CoreDNSClusterIPs {
+			addresses, err = p.assistant.CoreDNSClusterIPs()
+		} else {
+			addresses, err = p.assistant.CoreDNSExposedIPs()
+		}
 	} else {
 		addresses = gslb.Status.LoadBalancer.ExposedIPs
 	}


### PR DESCRIPTION
Some environments (Calico bare-metal, etc) may allow direct client reachability to the Service CIDR, bypassing the need to assign and use LoadBalancerIPs.  A new config flag and environment variable allows selection/return of the ClusterIPs in the assistant rather than externally assigned LoadBalancer IPs.
