### PR TITLE
Adding Darede to the ADOPTERS list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -18,3 +18,4 @@ This list is sorted in the order that organizations were added to it.
 [Eficode](https://eficode.com/) | @punasusi | As a cloud-native and devops consulting firm, we have used k8gb in customer engagements
 [Open Systems](https://www.open-systems.com/) | @abaguas | Multi-cluster load balancing in private WAN
 [PagBank](https://pagbank.com/) | @altieresfreitas | Multicloud global load balancing across multiple regions
+[Darede](https://darede.com.br/) | @diego7marques | As a cloud consulting company, we support customers using k8gb


### PR DESCRIPTION
Adding Darede to the ADOPTERS list

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
