### PR TITLE
docs: fix dig commands for each CoreDNS instance in local tutorial

### DIFF
--- a/docs/local.md
+++ b/docs/local.md
@@ -93,8 +93,8 @@ k3d-test-gslb2-agent-0    172.20.0.5
 
 Or you can ask specific CoreDNS instance for its local targets:
 ```sh
-dig -p 5053 +tcp @localhost localtargets-roundrobin.cloud.example.com && \
-dig -p 5054 +tcp @localhost localtargets-roundrobin.cloud.example.com
+dig -p 5053 @localhost localtargets-roundrobin.cloud.example.com && \
+dig -p 5054 @localhost localtargets-roundrobin.cloud.example.com
 ```
 As expected result you should see **two A records** divided between both clusters.
 ```sh


### PR DESCRIPTION
Fixes the commands by removing "+tcp" from them, sot hat dig uses UDP.

Error before:

```
;; communications error to 127.0.0.1#5053: connection reset
;; communications error to 127.0.0.1#5053: connection reset
;; communications error to 127.0.0.1#5053: connection reset

; <<>> DiG 9.18.30-0ubuntu0.24.04.2-Ubuntu <<>> -p 5053 @localhost localtargets-roundrobin.cloud.example.com +tcp
; (1 server found)
;; global options: +cmd
;; no servers could be reached
```

Output after (example):

```
; <<>> DiG 9.18.30-0ubuntu0.24.04.2-Ubuntu <<>> -p 5053 @localhost localtargets-roundrobin.cloud.example.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 51033
;; flags: qr rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 507a607e1c0ee13c (echoed)
;; QUESTION SECTION:
;localtargets-roundrobin.cloud.example.com. IN A

;; ANSWER SECTION:
localtargets-roundrobin.cloud.example.com. 30 IN A 172.19.0.4
localtargets-roundrobin.cloud.example.com. 30 IN A 172.19.0.5

;; Query time: 0 msec
;; SERVER: 127.0.0.1#5053(localhost) (UDP)
;; WHEN: Wed Feb 12 18:20:01 EST 2025
;; MSG SIZE  rcvd: 196


; <<>> DiG 9.18.30-0ubuntu0.24.04.2-Ubuntu <<>> -p 5054 @localhost localtargets-roundrobin.cloud.example.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 4687
;; flags: qr rd; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: 16704ecdcd80ad83 (echoed)
;; QUESTION SECTION:
;localtargets-roundrobin.cloud.example.com. IN A

;; ANSWER SECTION:
localtargets-roundrobin.cloud.example.com. 30 IN A 172.19.0.7
localtargets-roundrobin.cloud.example.com. 30 IN A 172.19.0.8

;; Query time: 0 msec
;; SERVER: 127.0.0.1#5054(localhost) (UDP)
;; WHEN: Wed Feb 12 18:20:02 EST 2025
;; MSG SIZE  rcvd: 196
```