### PR TITLE
Add namespace label to terratests

### DIFF
--- a/terratest/utils/extensions.go
+++ b/terratest/utils/extensions.go
@@ -272,8 +272,11 @@ func (w *Workflow) Start() (*Instance, error) {
 		istioInjection = "enabled"
 	}
 	k8s.CreateNamespaceWithMetadata(w.t, w.k8sOptions, metav1.ObjectMeta{
-		Name:   w.namespace,
-		Labels: map[string]string{"istio-injection": istioInjection},
+		Name: w.namespace,
+		Labels: map[string]string{
+			"istio-injection":   istioInjection,
+			"k8gb.io/terratest": "true",
+		},
 	})
 	w.state.namespaceCreated = true
 


### PR DESCRIPTION
The reason for this PR is to simplify the cleaning process in terratests. If a test does not complete for any reason (e.g., due to debugging), the namespace remains in the testing cluster. This can later lead to confusion. Labeling namespaces significantly simplifies the cleaning of the test cluster.
