### PR TITLE
Possibility to Stop Regular Reconciliation

### DIFF
--- a/controllers/depresolver/depresolver_config.go
+++ b/controllers/depresolver/depresolver_config.go
@@ -131,7 +131,7 @@ func (dr *DependencyResolver) validateConfig(config *Config, recognizedDNSTypes 
 	if err != nil {
 		return err
 	}
-	err = field(ReconcileRequeueSecondsKey, config.ReconcileRequeueSeconds).isHigherThanZero().err
+	err = field(ReconcileRequeueSecondsKey, config.ReconcileRequeueSeconds).isHigherOrEqualToZero().err
 	if err != nil {
 		return err
 	}

--- a/controllers/depresolver/depresolver_test.go
+++ b/controllers/depresolver/depresolver_test.go
@@ -236,7 +236,7 @@ func TestResolveConfigWithZeroReconcileRequeueSecondsKey(t *testing.T) {
 	expected := predefinedConfig
 	expected.ReconcileRequeueSeconds = 0
 	// act,assert
-	arrangeVariablesAndAssert(t, expected, assert.Error)
+	arrangeVariablesAndAssert(t, expected, assert.NoError)
 }
 
 func TestResolveConfigWithNegativeNSRecordTTL(t *testing.T) {


### PR DESCRIPTION
The reason for this is the heavy load on EdgeDNS, as we are running thousands of ingresses.

This will allow stopping the regular reconciliation. If the reconciliation completes successfully, the next cycle will occur after the time defined in `RECONCILIATION_REQUEUE_SECONDS`.

If requeue seconds is set to 0, reconciliation will only happen when the GSLB is created, deleted, or modified (which will trigger the following code).

The PR just modifies validation of RECONCILIATION_REQUEUE_SECONDS

*The same effect can be achieved when setting an extremely large integer value (on the order of years).
