### PR TITLE
Improve external dns performance

### DIFF
--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -35,7 +35,7 @@ spec:
         - --managed-record-types=CNAME
         - --managed-record-types=NS
         - --interval={{ .Values.externaldns.interval }}
-        - --annotation-filter=k8gb.absa.oss/dnstype=extdns # filter out only relevant DNSEntrypoints
+        - --label-filter=k8gb.absa.oss/dnstype=extdns # filter out only relevant DNSEntrypoints
         - --txt-owner-id={{ include "k8gb.extdnsOwnerID" . }}
         - --txt-prefix=k8gb-{{ .Values.k8gb.clusterGeoTag }}- # add custom prefix to TXT records, critical for Cloudflare NS record creation
         - --provider={{ include "k8gb.extdnsProvider" . }}

--- a/controllers/gslb_controller_reconciliation_test.go
+++ b/controllers/gslb_controller_reconciliation_test.go
@@ -954,13 +954,13 @@ func TestCreatesDNSNSRecordsForExtDNS(t *testing.T) {
 				client.ObjectKey{Namespace: predefinedConfig.K8gbNamespace, Name: "k8gb-ns-extdns-cloud-example-com"},
 				dnsEndpoint)
 			require.NoError(t, err, "Failed to get expected DNSEndpoint")
-			got := dnsEndpoint.Annotations["k8gb.absa.oss/dnstype"]
+			got := dnsEndpoint.Labels["k8gb.absa.oss/dnstype"]
 			gotEp := dnsEndpoint.Spec.Endpoints
 			prettyGot := str.ToString(gotEp)
 			prettyWant := str.ToString(wantEp)
 
 			// assert
-			assert.Equal(t, want, got, "got:\n %q annotation value,\n\n want:\n %q", got, want)
+			assert.Equal(t, want, got, "got:\n %q label value,\n\n want:\n %q", got, want)
 			assert.Equal(t, wantEp, gotEp, "got:\n %s DNSEndpoint,\n\n want:\n %s", prettyGot, prettyWant)
 		})
 }
@@ -1039,13 +1039,13 @@ func TestCreatesDNSNSRecordsForLoadBalancer(t *testing.T) {
 				client.ObjectKey{Namespace: predefinedConfig.K8gbNamespace, Name: "k8gb-ns-extdns-cloud-example-com"},
 				dnsEndpoint)
 			require.NoError(t, err, "Failed to get expected DNSEndpoint")
-			got := dnsEndpoint.Annotations["k8gb.absa.oss/dnstype"]
+			got := dnsEndpoint.Labels["k8gb.absa.oss/dnstype"]
 			gotEp := dnsEndpoint.Spec.Endpoints
 			prettyGot := str.ToString(gotEp)
 			prettyWant := str.ToString(wantEp)
 
 			// assert
-			assert.Equal(t, want, got, "got:\n %q annotation value,\n\n want:\n %q", got, want)
+			assert.Equal(t, want, got, "got:\n %q label value,\n\n want:\n %q", got, want)
 			assert.Equal(t, wantEp, gotEp, "got:\n %s DNSEndpoint,\n\n want:\n %s", prettyGot, prettyWant)
 		})
 }

--- a/controllers/providers/dns/external.go
+++ b/controllers/providers/dns/external.go
@@ -78,9 +78,9 @@ func (p *ExternalDNSProvider) CreateZoneDelegationForExternalDNS(gslb *k8gbv1bet
 	}
 	NSRecord := &externaldns.DNSEndpoint{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        domainInfo.GetExternalDNSEndpointName(),
-			Namespace:   p.config.K8gbNamespace,
-			Annotations: map[string]string{"k8gb.absa.oss/dnstype": externalDNSTypeCommon},
+			Name:      domainInfo.GetExternalDNSEndpointName(),
+			Namespace: p.config.K8gbNamespace,
+			Labels:    map[string]string{"k8gb.absa.oss/dnstype": externalDNSTypeCommon},
 		},
 		Spec: externaldns.DNSEndpointSpec{
 			Endpoints: []*externaldns.Endpoint{

--- a/controllers/providers/dns/external_test.go
+++ b/controllers/providers/dns/external_test.go
@@ -94,9 +94,9 @@ var a = struct {
 
 var expectedDNSEndpoint = &externaldns.DNSEndpoint{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:        fmt.Sprintf("k8gb-ns-%s", externalDNSTypeCommon),
-		Namespace:   a.Config.K8gbNamespace,
-		Annotations: map[string]string{"k8gb.absa.oss/dnstype": string(externalDNSTypeCommon)},
+		Name:      fmt.Sprintf("k8gb-ns-%s", externalDNSTypeCommon),
+		Namespace: a.Config.K8gbNamespace,
+		Labels:    map[string]string{"k8gb.absa.oss/dnstype": string(externalDNSTypeCommon)},
 	},
 	Spec: externaldns.DNSEndpointSpec{
 		Endpoints: []*externaldns.Endpoint{

--- a/docs/deploy_cloudflare.md
+++ b/docs/deploy_cloudflare.md
@@ -116,7 +116,7 @@ $ kubectl -n k8gb get dnsendpoints.externaldns.k8s.io k8gb-ns-extdns -o yaml
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
-  annotations:
+  labels:
     k8gb.absa.oss/dnstype: extdns
   creationTimestamp: "2023-11-12T19:55:20Z"
   generation: 3


### PR DESCRIPTION
External dns currently filters DNSEndpoint on the client side since it looks for the value of `k8gb.absa.oss/dnstype` in the annotations. Performance can be improved by using `--label-filter` since filtering will happen server-side: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/faq.md?plain=1#L271-L274

This also paves the way to using the upstream external-dns chart.