### PR TITLE
Use upstream chart for external-dns for AWS integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -548,7 +548,7 @@ $(shell echo $(foreach cl,$(filter-out $1,$(shell seq $(CLUSTERS_NUMBER))),$(cal
 endef
 
 define get-helm-args
-k8gb.clusterGeoTag='$(call nth-geo-tag,$1)' --set k8gb.extGslbClustersGeoTags='$(call get-ext-tags,$1)'
+k8gb.clusterGeoTag='$(call nth-geo-tag,$1)' --set k8gb.extGslbClustersGeoTags='$(call get-ext-tags,$1)' --set extdns.txtPrefix='k8gb-$(call nth-geo-tag,$1)-' --set extdns.txtOwnerId='k8gb-$(call nth-geo-tag,$1)'
 endef
 
 define hit-testapp-host

--- a/chart/k8gb/Chart.lock
+++ b/chart/k8gb/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: coredns
   repository: https://coredns.github.io/helm
   version: 1.39.2
-digest: sha256:3e3fe1c74254f8f7698be60a6154818bfa49886c4ba2bb1ce7bb00888ce475b4
-generated: "2025-04-18T19:02:02.543694057Z"
+- name: external-dns
+  repository: https://kubernetes-sigs.github.io/external-dns
+  version: 1.15.2
+digest: sha256:02ebed7c5b4f422026f05c52bcab15e23c54d0187766315de79e4b8eb81701d9
+generated: "2025-05-03T00:25:43.123205+02:00"

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -11,6 +11,11 @@ dependencies:
   - name: coredns
     repository: https://coredns.github.io/helm
     version: 1.39.2
+  - name: external-dns
+    alias: extdns
+    condition: extdns.enabled
+    repository: https://kubernetes-sigs.github.io/external-dns
+    version: 1.15.2
 
 home: https://www.k8gb.io/
 sources:

--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -130,11 +130,6 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | rfc2136.rfc2136auth.tsig.enabled | bool | `true` |  |
 | rfc2136.rfc2136auth.tsig.tsigCreds[0].tsig-secret-alg | string | `"hmac-sha256"` |  |
 | rfc2136.rfc2136auth.tsig.tsigCreds[1].tsig-keyname | string | `"externaldns-key"` |  |
-| route53.assumeRoleArn | string | `nil` | specify IRSA Role in AWS ARN format for assume role permissions or disable it by setting to `null` |
-| route53.enabled | bool | `false` | Enable Route53 provider |
-| route53.hostedZoneID | string | `"ZXXXSSS"` | Route53 ZoneID |
-| route53.irsaRole | string | `"arn:aws:iam::111111:role/external-dns"` | specify IRSA Role in AWS ARN format or disable it by setting to `null` |
-| route53.secret | string | `nil` | alternatively specify the secret name with static credentials for IAM user (make sure this user has limited privileges) this can be useful when IRSA is not present or when using say Azure cluster and Route53 docs: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#create-iam-user-and-attach-the-policy |
 | tracing.deployJaeger | bool | `false` | should the Jaeger be deployed together with the k8gb operator? In case of using another OpenTracing solution, make sure that configmap for OTEL agent has the correct exporters set up (`tracing.otelConfig`). |
 | tracing.enabled | bool | `false` | if the application should be sending the traces to OTLP collector (env var `TRACING_ENABLED`) |
 | tracing.endpoint | string | `"localhost:4318"` | `host:port` where the spans from the applications (traces) should be sent, sets the `OTEL_EXPORTER_OTLP_ENDPOINT` env var This is not the final destination where all the traces are going. Otel collector has its configuration in the associated configmap (`tracing.otelConfig`). |

--- a/chart/k8gb/templates/_helpers.tpl
+++ b/chart/k8gb/templates/_helpers.tpl
@@ -66,9 +66,6 @@ Create the name of the service account to use
 {{- if .Values.ns1.enabled -}}
 {{- print "ns1" -}}
 {{- end -}}
-{{- if .Values.route53.enabled }}
-{{- print "aws" -}}
-{{- end -}}
 {{- if .Values.rfc2136.enabled }}
 {{- print "rfc2136" -}}
 {{- end -}}
@@ -81,11 +78,7 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "k8gb.extdnsOwnerID" -}}
-{{- if .Values.route53.enabled -}}
-k8gb-{{ .Values.route53.hostedZoneID }}-{{ .Values.k8gb.clusterGeoTag }}
-{{- else -}}
 k8gb-{{ index (split ":" (index (split ";" (include "k8gb.dnsZonesString" .)) "_0")) "_1" }}-{{ .Values.k8gb.clusterGeoTag }}
-{{- end -}}
 {{- end -}}
 
 {{- define "k8gb.edgeDNSServers" -}}

--- a/chart/k8gb/templates/_validators.tpl
+++ b/chart/k8gb/templates/_validators.tpl
@@ -1,0 +1,43 @@
+# Validates that "duplicated" values are consistent across the chart
+
+# Validates that the geo tag in extdns.txtPrefix/extdns.txtOwnerId contains the same value as the geo tag in k8gb.clusterGeoTag
+{{- define "validateGeoTag" -}}
+{{- if .Values.extdns.enabled -}}
+{{- if not (contains .Values.k8gb.clusterGeoTag .Values.extdns.txtPrefix) -}}
+{{- fail (printf "Validation failed: extdns.txtPrefix (%s) does not contain the expected geo tag (%s)" .Values.extdns.txtPrefix .Values.k8gb.clusterGeoTag) -}}
+{{- end -}}
+{{- if not (contains .Values.k8gb.clusterGeoTag .Values.extdns.txtOwnerId) -}}
+{{- fail (printf "Validation failed: extdns.txtOwnerId (%s) does not contain the expected geo tag (%s)" .Values.extdns.txtOwnerId .Values.k8gb.clusterGeoTag) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+# Validates that the zones in k8gb.edgeDNSZone/k8gb.dnsZones match the zones in extdns.domainFilters
+{{- define "validateDnsZones" -}}
+{{- $k8gbZones := list -}}
+{{- range .Values.k8gb.dnsZones -}}
+  {{- $k8gbZones = append $k8gbZones .zone -}}
+{{- end -}}
+{{- if and (or (not .Values.k8gb.dnsZones) (eq (len .Values.k8gb.dnsZones) 0)) .Values.k8gb.dnsZone .Values.k8gb.edgeDNSZone }}
+  {{- $k8gbZones = append $k8gbZones .Values.k8gb.edgeDNSZone -}}
+{{- end }}
+
+{{- $extdnsZones := .Values.extdns.domainFilters -}}
+
+{{- if ne (len $k8gbZones) (len $extdnsZones) -}}
+  {{- fail (printf "Validation failed: Number of zones in k8gb.edgeDNSZone/k8gb.dnsZones (%d) does not match number of domains in extdns.domainFilters (%d)" (len $k8gbZones) (len $extdnsZones)) -}}
+{{- end -}}
+
+{{- range $k8gbZone := $k8gbZones -}}
+  {{- if not (has $k8gbZone $extdnsZones) -}}
+    {{- fail (printf "Validation failed: Zone '%s' from k8gb.edgeDNSZone/k8gb.dnsZones is not present in extdns.domainFilters" $k8gbZone) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- range $extdnsZone := $extdnsZones -}}
+  {{- if not (has $extdnsZone $k8gbZones) -}}
+    {{- fail (printf "Validation failed: Domain '%s' from extdns.domainFilters is not present in k8gb.edgeDNSZone/k8gb.dnsZones" $extdnsZone) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- end -}}

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -109,7 +109,7 @@ spec:
                   name: infoblox
                   key: INFOBLOX_WAPI_PASSWORD
             {{- end }}
-            {{- if or .Values.extdns.enabled .Values.route53.enabled .Values.ns1.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+            {{- if or .Values.extdns.enabled .Values.ns1.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
             - name: EXTDNS_ENABLED
               value: "true"
             {{- end }}

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{ include "validateGeoTag" . }}
+{{ include "validateDnsZones" . }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -106,7 +109,7 @@ spec:
                   name: infoblox
                   key: INFOBLOX_WAPI_PASSWORD
             {{- end }}
-            {{- if or .Values.route53.enabled .Values.ns1.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+            {{- if or .Values.extdns.enabled .Values.route53.enabled .Values.ns1.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
             - name: EXTDNS_ENABLED
               value: "true"
             {{- end }}

--- a/chart/k8gb/templates/external-dns/dns-endpoint-crd-manifest.yaml
+++ b/chart/k8gb/templates/external-dns/dns-endpoint-crd-manifest.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.extdns.enabled }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -91,3 +92,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.ns1.enabled .Values.route53.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+{{- if or .Values.ns1.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,9 +39,6 @@ spec:
         - --txt-owner-id={{ include "k8gb.extdnsOwnerID" . }}
         - --txt-prefix=k8gb-{{ .Values.k8gb.clusterGeoTag }}- # add custom prefix to TXT records, critical for Cloudflare NS record creation
         - --provider={{ include "k8gb.extdnsProvider" . }}
-        {{- if and .Values.route53.assumeRoleArn (not .Values.route53.secret) }}
-        - --aws-assume-role={{ .Values.route53.assumeRoleArn }}
-        {{- end }}
         {{ include "k8gb.extdnsProviderOpts" . }}
         resources:
           requests:
@@ -56,27 +53,6 @@ spec:
         env:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-      {{- if .Values.route53.secret }}
-        {{- if not .Values.externaldns.extraEnv }}
-        env:
-        {{- end }}
-          - name: AWS_SHARED_CREDENTIALS_FILE
-            value: /.aws/credentials
-        volumeMounts:
-          - name: aws-credentials
-            mountPath: /.aws
-            readOnly: true
-          {{- with .Values.externaldns.extraVolumeMounts }}
-          {{- toYaml . | nindent 10 }}
-          {{- end }}
-      volumes:
-        - name: aws-credentials
-          secret:
-            secretName: {{ .Values.route53.secret }}
-        {{- with .Values.externaldns.extraVolumes }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-      {{- end }}
       {{- if .Values.rfc2136.rfc2136auth.gssTsig.enabled }}
         volumeMounts:
           - mountPath: /etc/krb5.conf

--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.ns1.enabled .Values.route53.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+{{- if or .Values.ns1.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -30,8 +30,4 @@ kind: ServiceAccount
 metadata:
   name: k8gb-external-dns
   namespace: {{ .Release.Namespace }}
-{{- if and .Values.route53.enabled .Values.route53.irsaRole }}
-  annotations:
-    eks.amazonaws.com/role-arn: {{ .Values.route53.irsaRole }}
-{{- end }}
 {{- end }}

--- a/chart/k8gb/values-extdns.yaml
+++ b/chart/k8gb/values-extdns.yaml
@@ -1,0 +1,23 @@
+k8gb:
+  clusterGeoTag: "us"
+  extGslbClustersGeoTags: "eu"
+
+extdns:
+  enabled: true
+  txtPrefix: "k8gb-us-"
+  txtOwnerId: "k8gb-us"
+  provider:
+    name: aws
+  env:
+  - name: AWS_DEFAULT_REGION
+    value: "eu-central-1"
+  - name: AWS_SHARED_CREDENTIALS_FILE
+    value: .aws/credentials
+  extraVolumes:
+  - name: aws-credentials
+    secret:
+      secretName: credentials
+  extraVolumeMounts:
+  - name: aws-credentials
+    mountPath: /.aws
+    readOnly: true

--- a/chart/k8gb/values-extdns.yaml
+++ b/chart/k8gb/values-extdns.yaml
@@ -1,6 +1,10 @@
 k8gb:
   clusterGeoTag: "us"
   extGslbClustersGeoTags: "eu"
+  dnsZones:
+    - zone: "k8gb.io"
+      domain: "cloud.k8gb.io"
+      dnsZoneNegTTL: 30
 
 extdns:
   enabled: true
@@ -21,3 +25,5 @@ extdns:
   - name: aws-credentials
     mountPath: /.aws
     readOnly: true
+  domainFilters:
+  - k8gb.io

--- a/chart/k8gb/values-route53.yaml
+++ b/chart/k8gb/values-route53.yaml
@@ -1,0 +1,7 @@
+k8gb:
+  clusterGeoTag: "us"
+  extGslbClustersGeoTags: "eu"
+
+route53:
+  enabled: true
+  secret: credentials

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -15,6 +15,11 @@
                 "externaldns": {
                     "$ref": "#/definitions/Externaldns"
                 },
+                "extdns": {
+                    "type": "object",
+                    "description": "Values for the external-dns upstream chart. See https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns for all available options",
+                    "additionalProperties": true
+                },
                 "coredns": {
                     "$ref": "#/definitions/Coredns"
                 },

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -32,9 +32,9 @@ k8gb:
     # -- use this DNS server as a main resolver to enable cross k8gb DNS based communication
     - "1.1.1.1"
   # -- used for places where we need to distinguish between different Gslb instances
-  clusterGeoTag: "eu"
+  clusterGeoTag: "FIXME"
   # -- comma-separated list of external gslb geo tags to pair with
-  extGslbClustersGeoTags: "us"
+  extGslbClustersGeoTags: "FIXME,FIXME"
   # -- Reconcile time in seconds
   reconcileRequeueSeconds: 30
   # -- TTL of the NS and respective glue record used by external DNS
@@ -84,7 +84,7 @@ externaldns:
   # functionality. See links below
   # https://github.com/k8gb-io/external-dns
   # https://github.com/k8gb-io/external-dns/pkgs/container/external-dns
-  image: ghcr.io/k8gb-io/external-dns:v0.13.4-azure-ns-multiarch
+  image: registry.k8s.io/external-dns/external-dns:v0.15.1
   # -- external-dns sync interval
   interval: "20s"
   securityContext:
@@ -145,15 +145,43 @@ route53:
   # -- Enable Route53 provider
   enabled: false
   # -- Route53 ZoneID
-  hostedZoneID: ZXXXSSS
+  hostedZoneID: ZXXXSSS # -> available as part of extdns.txtOwnerId
   # -- specify IRSA Role in AWS ARN format or disable it by setting to `null`
-  irsaRole: arn:aws:iam::111111:role/external-dns
+  irsaRole: arn:aws:iam::111111:role/external-dns # -> available as extdns.serviceAccount.annotations: eks.amazonaws.com/role-arn = arn:aws:iam::111111:role/external-dns
   # -- specify IRSA Role in AWS ARN format for assume role permissions or disable it by setting to `null`
-  assumeRoleArn: null
+  assumeRoleArn: null # -> available as extdns.extraArgs.aws-assume-role
   # -- alternatively specify the secret name with static credentials for IAM user (make sure this user has limited privileges)
   # this can be useful when IRSA is not present or when using say Azure cluster and Route53
   # docs: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#create-iam-user-and-attach-the-policy
   secret: null
+
+extdns:
+  enabled: false
+  interval: 20s
+  labelFilter: "k8gb.absa.oss/dnstype=extdns"
+  logLevel: debug
+  managedRecordTypes:
+  - A
+  - CNAME
+  - NS
+  policy: sync
+  rbac:
+    create: true
+  sources:
+  - crd
+  domainFilters:
+  - "example.com"
+  txtPrefix: "k8gb-<GEOTAG>-"
+  txtOwnerId: "k8gb-<GEOTAG>"
+
+  # replaces route53.irsaRole
+  #serviceAccount:
+  #  annotations:
+  #    eks.amazonaws.com/role-arn: arn:aws:iam::111111:role/external-dns
+
+  #extraArgs:
+  # TODO: add other mandator extra args
+  #- --aws-assume-role=assumeRoleArn # replaces route53.assumeRoleArn
 
 ns1:
   # -- Enable NS1 provider

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -141,20 +141,6 @@ infoblox:
   # -- Size of connections pool
   httpPoolConnections: 10
 
-route53:
-  # -- Enable Route53 provider
-  enabled: false
-  # -- Route53 ZoneID
-  hostedZoneID: ZXXXSSS # -> available as part of extdns.txtOwnerId
-  # -- specify IRSA Role in AWS ARN format or disable it by setting to `null`
-  irsaRole: arn:aws:iam::111111:role/external-dns # -> available as extdns.serviceAccount.annotations: eks.amazonaws.com/role-arn = arn:aws:iam::111111:role/external-dns
-  # -- specify IRSA Role in AWS ARN format for assume role permissions or disable it by setting to `null`
-  assumeRoleArn: null # -> available as extdns.extraArgs.aws-assume-role
-  # -- alternatively specify the secret name with static credentials for IAM user (make sure this user has limited privileges)
-  # this can be useful when IRSA is not present or when using say Azure cluster and Route53
-  # docs: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/aws.md#create-iam-user-and-attach-the-policy
-  secret: null
-
 extdns:
   enabled: false
   interval: 20s
@@ -173,15 +159,6 @@ extdns:
   - "example.com"
   txtPrefix: "k8gb-<GEOTAG>-"
   txtOwnerId: "k8gb-<GEOTAG>"
-
-  # replaces route53.irsaRole
-  #serviceAccount:
-  #  annotations:
-  #    eks.amazonaws.com/role-arn: arn:aws:iam::111111:role/external-dns
-
-  #extraArgs:
-  # TODO: add other mandator extra args
-  #- --aws-assume-role=assumeRoleArn # replaces route53.assumeRoleArn
 
 ns1:
   # -- Enable NS1 provider

--- a/docs/examples/route53/k8gb/k8gb-cluster-us-east-1.yaml
+++ b/docs/examples/route53/k8gb/k8gb-cluster-us-east-1.yaml
@@ -5,10 +5,18 @@ k8gb:
   clusterGeoTag: "us-east-1" # used for places where we need to distinguish between differnet Gslb instances
   extGslbClustersGeoTags: "eu-west-1" # comma-separated list of external gslb geo tags to pair with
 
-route53:
+extdns:
   enabled: true
-  hostedZoneID: Z<zone-id>
-  irsaRole: arn:aws:iam::<account-id>:role/external-dns-k8gb-cluster-us-east-1 # ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+  txtPrefix: "k8gb-us-east-1-"
+  txtOwnerId: "k8gb-Z<zone-id>-us-east-1"
+  provider:
+    name: aws
+  env:
+  - name: AWS_DEFAULT_REGION
+    value: "us-east-1"
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/external-dns-k8gb-cluster-us-east-1
 
 coredns:
   serviceType: LoadBalancer


### PR DESCRIPTION
The latest version of the external-dns image requires setting the AWS_DEFAULT_REGION environment variable.
The introduction of this variable demands changes in our chart as well as changes to the user configuration. Therefore, it is a good opportunity to do breaking changes and introduce the upstream external-dns helm chart.
By using the upstream chart we can profit from all the features of the external dns community out-of-the-box. We no longer have to develop a wrapper on our side, which is currently the bottleneck to supporting further upstream DNS providers. These features include both authentication options and new upstream providers.

The change deprecates only the route53 integration, all other integrations are not affected.

## Review tips

Checkout the first commit of this PR, fb11af4, and compare the route53 integration using the old route53 integration, or the new extdns integration:
`helm package -u . > /dev/null && helm template k8gb "k8gb-v0.14.0.tgz" --include-crds -f values.yaml -f values-route53.yaml > route53.yaml`
`helm package -u . > /dev/null && helm template k8gb "k8gb-v0.14.0.tgz" --include-crds -f values.yaml -f values-extdns.yaml > extdns.yaml`

The second commit removes the route53 configuration from the chart.

## Required user changes

The following configuration changes should be included in the release notes:

#### Auth configuration
1.
```
route53:
  enabled: true
  secret: credentials
```
becomes
```
extdns:
  enabled: true
  provider:
    name: aws
  extraVolumes:
  - name: aws-credentials
    secret:
      secretName: credentials
  extraVolumeMounts:
  - name: aws-credentials
    mountPath: /.aws
    readOnly: true
```

2.
```
route53:
  enabled: true
  irsaRole: arn:aws:iam::111111:role/external-dns
```
becomes:
```
extdns:
  enabled: true
  provider:
    name: aws
  serviceAccount:
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::111111:role/external-dns
```

3.
```
route53:
  enabled: true
  assumeRoleArn: role
```
becomes:
```
extdns:
  enabled: true
  provider:
    name: aws
  extraArgs:
    aws-assume-role: role
```

#### General configuration
In addition, the AWS_DEFAULT_REGION must be specified using an environment variable, for example:
```
extdns:
  env:
  - name: AWS_DEFAULT_REGION
    value: "us-east-1"
```
And a couple of variables must be manually specified (there are helm validation function that make sure they are correct). Replace `<GEOTAG>` with the same value as `k8gb.clusterGeoTag`, and `domainFilters` with the same values as `k8gb.dnsZones.zone`/`k8gb.dnsZone`:
```
extdns:
  txtPrefix: "k8gb-<GEOTAG>"
  txtOwnerId: "k8gb-<GEOTAG>"
  domainFilters:
  - "<domain>"
```
Note: if you used to set `hostedZoneID`, then txtOwnerId will take the value `k8gb-<hostZoneID>-<GEOTAG>`.