### PR TITLE
Fix status field requirements

### DIFF
--- a/api/v1beta1/gslb_types.go
+++ b/api/v1beta1/gslb_types.go
@@ -98,9 +98,9 @@ type GslbStatus struct {
 	// Comma-separated list of hosts
 	Hosts string `json:"hosts,omitempty"`
 	// LoadBalancer configuration
-	LoadBalancer LoadBalancer `json:"loadBalancer"`
+	LoadBalancer LoadBalancer `json:"loadBalancer,omitempty"`
 	// Servers configuration
-	Servers []*Server `json:"servers"`
+	Servers []*Server `json:"servers,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/chart/k8gb/crd/k8gb.absa.oss_gslbs.yaml
+++ b/chart/k8gb/crd/k8gb.absa.oss_gslbs.yaml
@@ -456,8 +456,6 @@ spec:
             required:
             - geoTag
             - healthyRecords
-            - loadBalancer
-            - servers
             - serviceHealth
             type: object
         type: object


### PR DESCRIPTION
When migrating from 0.12 I've found that updates to any gslb object was failing due to validation errors.

This happens when resourceRef is not set yet, object is saved with .spec.resourceRef but status.loadbalancer nor status.servers is not yet set or calculated.

Lets relax a requirement to allow smoother transition to updated status structure

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
