### PR TITLE
Fix: Remove EDGE_DNSZONE and DNS_ZONE envvars

### DIFF
--- a/controllers/depresolver/depresolver.go
+++ b/controllers/depresolver/depresolver.go
@@ -134,10 +134,6 @@ type Config struct {
 	fallbackEdgeDNSServerName string `env:"EDGE_DNS_SERVER"`
 	// to avoid breaking changes is used as fallback server port for EdgeDNSServers
 	fallbackEdgeDNSServerPort int `env:"EDGE_DNS_SERVER_PORT, default=53"`
-	// edgeDNSZone main zone which would contain gslb zone to delegate; e.g. example.com
-	edgeDNSZone string `env:"EDGE_DNS_ZONE"`
-	// dnsZone controlled by gslb; e.g. cloud.example.com
-	dnsZone string `env:"DNS_ZONE"`
 	// DelegationZones
 	DelegationZones DelegationZones
 	// DelegationZones pairs of dnsZone ad edgeDNSZone, eg: DNS_ZONES=example.com:cloud.example.com;example.io:cloud.example.io


### PR DESCRIPTION
# Motivation
https://github.com/k8gb-io/k8gb/pull/1856#pullrequestreview-2718753423 - Under certain circumstances, the DNS_ZONE and EDGEDNS_ZONE were still being validated during the startup, which are now deprecated because we use a single ENVVAR that holds all the values.

This PR removes the unused ENVVARS, including the validation and tests.