### PR TITLE
Remove GSLB-derived annotations from generated Ingress and add management label

### DIFF
--- a/controllers/gslb_controller_reconciliation.go
+++ b/controllers/gslb_controller_reconciliation.go
@@ -106,13 +106,13 @@ func (r *GslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	// == Ingress ==========
 	if reflect.DeepEqual(gslb.Spec.ResourceRef, k8gbv1beta1.ResourceRef{}) {
-		ingress, err := r.gslbIngress(gslb)
+		ingress, err := r.createIngressFromGslb(gslb)
 		if err != nil {
 			m.IncrementError(gslb)
 			return result.RequeueError(err)
 		}
 
-		err = r.saveIngress(gslb, ingress)
+		err = r.saveDependentIngress(gslb, ingress)
 		if err != nil {
 			m.IncrementError(gslb)
 			return result.RequeueError(err)

--- a/controllers/utils/annotations.go
+++ b/controllers/utils/annotations.go
@@ -1,5 +1,7 @@
 package utils
 
+import netv1 "k8s.io/api/networking/v1"
+
 /*
 Copyright 2022 The k8gb Contributors.
 
@@ -35,6 +37,13 @@ func MergeAnnotations(target map[string]string, source map[string]string, contro
 	}
 
 	return target
+}
+
+func SetCommonGslbLabels(ingress *netv1.Ingress) {
+	if ingress.Labels == nil {
+		ingress.Labels = make(map[string]string)
+	}
+	ingress.Labels["app.k8gb.io/managed-by"] = "gslb"
 }
 
 // EqualPredefinedAnnotations checks if there has been a change in controlledAnnotations, it ignores the rest

--- a/terratest/examples/broken-ingress-annotation.yaml
+++ b/terratest/examples/broken-ingress-annotation.yaml
@@ -3,7 +3,6 @@ kind: Ingress
 metadata:
   annotations:
     k8gb.io/strategy: failover
-    k8gb.io/primary-geotag: eu
   name: broken-test-gslb-annotation-failover
 spec:
   ingressClassName: nginx

--- a/terratest/test/k8gb_annotation_test.go
+++ b/terratest/test/k8gb_annotation_test.go
@@ -59,7 +59,7 @@ func TestAnnotations(t *testing.T) {
 			host:            "test-ingress-annotation-failover.cloud.example.com",
 			path:            "../examples/ingress-annotation.yaml",
 			patch:           map[string]string{"k8gb.io/primary-geotag": "us"},
-			expectedIngress: map[string]string{"k8gb.io/primary-geotag": "eu", "k8gb.io/strategy": "failover"},
+			expectedIngress: map[string]string{"k8gb.io/primary-geotag": "us", "k8gb.io/strategy": "failover"},
 			expectedGslb:    map[string]string{},
 		},
 		{
@@ -67,7 +67,7 @@ func TestAnnotations(t *testing.T) {
 			host:            "test-gslb-annotation.cloud.example.com",
 			path:            "../examples/gslb-annotation.yaml",
 			patch:           map[string]string{"example.io/protocol": "tcp"},
-			expectedIngress: map[string]string{"k8gb.io/primary-geotag": "eu", "k8gb.io/strategy": "failover", "example.io/protocol": "tcp"},
+			expectedIngress: map[string]string{"example.io/protocol": "tcp"},
 			expectedGslb:    map[string]string{"example.io/origin": "gslb"},
 		},
 	}


### PR DESCRIPTION
When we apply GSLB, an Ingress is created automatically. This new Ingress had annotations generated from the GSLB values (strategy, dnsTTLSeconds, primary region). However, since GSLB is used as the single source of truth, these annotations have no place there. Additionally, I'm adding the label `app.k8gb.io/managed-by: gslb` to this generated Ingress to make it easy to select these Ingresses.

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: dependent-ingress
  annotations:
   # they will not be maintained in dependent ingresses
    k8gb.io/strategy: failover
    k8gb.io/primary-geotag: "eu"
    k8gb.io/dns-ttl-seconds: "5"
  ownerReferences:
  - gslb reference ...
```

Second case - when we create a GSLB from an Ingress, the annotations of course remain in the Ingress. The test coverage is in the `TestAnnotations` Terratest.
