### PR TITLE
Fix: Upgrade testing,  split stable and test versions

### DIFF
--- a/deploy/helm/next.yaml
+++ b/deploy/helm/next.yaml
@@ -1,0 +1,8 @@
+k8gb:
+  reconcileRequeueSeconds: 10
+  dnsZoneNegTTL: 10
+  log:
+    format: simple
+    level: debug
+rfc2136:
+  enabled: true

--- a/deploy/helm/stable.yaml
+++ b/deploy/helm/stable.yaml
@@ -1,0 +1,9 @@
+k8gb:
+  reconcileRequeueSeconds: 10
+  dnsZoneNegTTL: 10
+  log:
+    format: simple
+    level: debug
+rfc2136:
+  enabled: true
+


### PR DESCRIPTION
We currently have an issue where the upgrade testing installs the stable version, but we have changes in values.yaml. The stable version doesn't recognize some of the newly added Helm properties, so the installation fails like this:

```shell
helm -n k8gb upgrade -i k8gb k8gb/k8gb -f "" \
	--set k8gb.clusterGeoTag='us' --set k8gb.extGslbClustersGeoTags='eu' --set extdns.txtPrefix='k8gb-us-' --set extdns.txtOwnerId='k8gb-us' \
	--set k8gb.reconcileRequeueSeconds=10 \
	--set k8gb.dnsZoneNegTTL=10 \
	--set k8gb.imageTag=v0.14.0 \
	--set k8gb.log.format=simple \
	--set k8gb.log.level=debug \
	--set rfc2136.enabled=true \
	--set k8gb.edgeDNSServers[0]=172.18.0.1:1053 \
	--wait --timeout=10m0s
Release "k8gb" does not exist. Installing it now.
Error: values don't meet the specifications of the schema(s) in the following chart(s):
k8gb:
- (root): Additional property extdns is not allowed
```


This PR separates the stable and test properties into two different configurations and allows both Terratest and upgrade testing to pass.

kudos to @k0da 

