### PR TITLE
Don't write uselsess namespace into resourceRef

### DIFF
--- a/chainsaw/step-templates/assert-dependent-gslb.yaml
+++ b/chainsaw/step-templates/assert-dependent-gslb.yaml
@@ -26,7 +26,6 @@ spec:
               apiVersion: networking.k8s.io/v1
               kind: Ingress
               name: ($test.metadata.name)
-              namespace: ($namespace)
         timeout: 15s
 
 

--- a/chainsaw/tests/failover-playground-resourceref/testdata/gslb.yaml
+++ b/chainsaw/tests/failover-playground-resourceref/testdata/gslb.yaml
@@ -9,7 +9,6 @@ spec:
     apiVersion: networking.k8s.io/v1
     kind: Ingress
     name: failover-playground-resourceref
-    namespace: failover-playground-resourceref
   strategy:
     type: failover
     primaryGeoTag: "eu"

--- a/controllers/handlers.go
+++ b/controllers/handlers.go
@@ -188,7 +188,6 @@ func (g *IngressHandler) getGslb(obj client.Object) (*k8gbv1beta1.Gslb, bool, er
 		ResourceRef: k8gbv1beta1.ResourceRef{
 			ObjectReference: corev1.ObjectReference{
 				Name:       obj.GetName(),
-				Namespace:  obj.GetNamespace(),
 				Kind:       "Ingress",
 				APIVersion: "networking.k8s.io/v1",
 			},


### PR DESCRIPTION
While processing resourceRef corev1.ObjectReference Namespace field is not evalued/used. Instead we rely on GLSB's object namespace

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
