### PR TITLE
FIX: Processing rest of targets when querying GlueA or NS fails

### DIFF
--- a/controllers/providers/k8gbendpoint/applicationDNSEndpoint.go
+++ b/controllers/providers/k8gbendpoint/applicationDNSEndpoint.go
@@ -198,8 +198,8 @@ func (d *ApplicationDNSEndpoint) GetExternalTargets(host string) (targets Target
 				Str("fqdn", cluster+".").
 				Str("nameservers", d.config.EdgeDNSServers.String()).
 				Err(err).
-				Msg("can't resolve FQDN using nameservers")
-			return targets
+				Msg("can't lookup GlueA record")
+			continue
 		}
 		d.logger.Info().
 			Str("nameserver", cluster).
@@ -222,7 +222,7 @@ func (d *ApplicationDNSEndpoint) GetExternalTargets(host string) (targets Target
 				Str("nameservers", nameServersToUse.String()).
 				Err(err).
 				Msg("can't resolve FQDN using nameservers")
-			return targets
+			continue
 		}
 		clusterTargets := d.queryService.ExtractARecords(a)
 		if len(clusterTargets) > 0 {


### PR DESCRIPTION
If a Glue A record was not found, or the FQDN could not be resolved using the nameserver, the target restoration process was terminated and a warning was issued. However, this does not mean that the Glue A record or FQDN for another tag does not exist or cannot be returned. This was blocking in cases where multiple external clusters existed in a FAILOVER strategy (it would not switch, even though there might still be someone to switch to).






