### PR TITLE
fix values.schema.json for Dynamic GeoTags

### DIFF
--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -290,7 +290,7 @@
                 },
                 "extGslbClustersGeoTags": {
                     "type": "string",
-                    "minLength": 1
+                    "minLength": 0
                 },
                 "reconcileRequeueSeconds": {
                     "type": "integer",
@@ -335,7 +335,6 @@
             },
             "required": [
                 "clusterGeoTag",
-                "extGslbClustersGeoTags",
                 "edgeDNSServers",
                 "dnsZones"
             ],


### PR DESCRIPTION
Dynamic GeoTags allows extGslbClustersGeoTags to be empty, However, when extGslbClustersGeoTags is empty, the validation of helm values.schema.json fails

```
[~]$ helm -n k8gb template k8gb .
walk.go:74: found symbolic link in path: /Users/gaozh/project/k8gb/chart/k8gb/LICENSE resolves to /Users/gaozh/project/k8gb/LICENSE
Error: values don't meet the specifications of the schema(s) in the following chart(s):
k8gb:
- k8gb.extGslbClustersGeoTags: String length must be greater than or equal to 1
```


<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
