### PR TITLE
Switch from Endpoints to EndpointSlice API (deprecation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ k8gb is tested with the following environment options.
 
 | Type                             | Implementation                                                               |
 |----------------------------------|------------------------------------------------------------------------------|
-| Kubernetes Version               | >= `1.19`                                                                    |
+| Kubernetes Version               | >= `1.21`                                                                    |
 | Environment                      | Any conformant Kubernetes cluster on-prem or in cloud                        |
 | Ingress Controller               | NGINX, AWS Load Balancer Controller [*](#clarify)                            |
 | EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS                                 |

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://www.k8gb.io/assets/images/icon-192x192.png
 type: application
 version: v0.15.0-rc2
 appVersion: v0.15.0-rc2
-kubeVersion: ">= 1.19.0-0"
+kubeVersion: ">= 1.21.0-0"
 
 dependencies:
   - name: coredns

--- a/chart/k8gb/templates/role.yaml
+++ b/chart/k8gb/templates/role.yaml
@@ -17,12 +17,19 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
   - services
   verbs:
   - 'get'
   - 'list'
   - 'watch'
+- apiGroups:
+    - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - 'get'
+    - 'list'
+    - 'watch'
 - apiGroups:
   - k8gb.absa.oss
   resources:


### PR DESCRIPTION
fix https://github.com/k8gb-io/k8gb/issues/1921

endpointslices now have the `.metadata.generation` so also removing that exception for endpoints in the `EventFilter`. This is actually a breaking change for older k8s versions that didn't have the EndpointSlice api present (before 1.21), so we may want to have some similar compatibility matrix as we had for the ingress v1 vs v2, or just bump the minimum k8s requirement in the [readme](https://github.com/k8gb-io/k8gb/blob/master/README.md?plain=1#L124) & [here](https://github.com/k8gb-io/k8gb/blob/master/chart/k8gb/Chart.yaml#L8)

