### PR TITLE
add coredns plugin and server bocks per zone

### DIFF
--- a/chart/k8gb/templates/_helpers.tpl
+++ b/chart/k8gb/templates/_helpers.tpl
@@ -99,15 +99,6 @@ k8gb-{{ index (split ":" (index (split ";" (include "k8gb.dnsZonesString" .)) "_
 {{- join ";" $entries }}
 {{- end }}
 
-
-{{- define "k8gb.coredns.extraPlugins" -}}
-{{- if .Values.k8gb.coredns.extra_plugins }}
-{{- range .Values.k8gb.coredns.extra_plugins }}
-        {{ . }}
-{{- end }}
-{{- end }}
-{{- end }}
-
 {{- define "k8gb.extdnsProviderOpts" -}}
 {{- if .Values.ns1.enabled -}}
 {{- if .Values.ns1.endpoint -}}

--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -8,17 +8,12 @@ metadata:
 {{ include "chart.labels" . | indent 4  }}
 data:
   Corefile: |-
-{{- $dnsZonesRaw := include "k8gb.dnsZonesString" . }}
-{{- $dnsZones := split ";" $dnsZonesRaw }}
-{{- range $dnsZones }}
-    {{- $parts := split ":" . }}
-    {{- $loadBalancedZone := index $parts "_1" }}
-    {{- $dnsZoneNegTTL := index $parts "_2" }}
-    {{ $loadBalancedZone }}:5353 {
+{{- range .Values.k8gb.dnsZones }}
+    {{ .loadBalancedZone }}:5353 {
         errors
         health
-{{- if $.Values.k8gb.coredns.extra_plugins }}
-{{- range $.Values.k8gb.coredns.extra_plugins }}
+{{- if .extraPlugins }}
+{{- range .extraPlugins }}
         {{ . }}
 {{- end }}
 {{- end }}
@@ -27,12 +22,12 @@ data:
         forward . /etc/resolv.conf
         k8s_crd {
             filter k8gb.absa.oss/dnstype=local
-            negttl {{ $dnsZoneNegTTL | default 30 }}
+            negttl {{ .dnsZoneNegTTL | default 30 }}
             loadbalance weight
         }
     }
 {{- end }}
-    {{- with .Values.k8gb.coredns.extraServerBlocks -}}
+    {{- with .extraServerBlocks -}}
     {{- tpl . $ | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -364,22 +364,6 @@
             },
             "title": "Log"
         },
-        "k8gbCoreDNS": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "extra_plugins": {
-                    "type": [
-                        "array",
-                        "null"
-                    ]
-                },
-                "extraServerBlocks": {
-                    "type": "string"
-                }
-            },
-            "title": "k8gbCoredns"
-        },
         "k8gbSecurityContext": {
             "type": "object",
             "additionalProperties": false,
@@ -433,6 +417,19 @@
                     "type": "integer",
                     "minimum": 0,
                     "default": 300
+                },
+                "extraPlugins": {
+                    "type": [
+                        "array",
+                        "null"
+                    ],
+                    "items": {
+                        "type": "string",
+                        "minLength": 1
+                    }
+                },
+                "extraServerBlocks": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -303,9 +303,6 @@
                 "log": {
                     "$ref": "#/definitions/k8gbLog"
                 },
-                "coredns": {
-                    "$ref": "#/definitions/k8gbCoreDNS"
-                },
                 "splitBrainCheck": {
                     "type": "boolean"
                 },
@@ -363,22 +360,6 @@
                 }
             },
             "title": "Log"
-        },
-        "k8gbCoreDNS": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "serviceType": {
-                    "type": "string",
-                    "enum": [
-                        "ClusterIP",
-                        "NodePort",
-                        "LoadBalancer",
-                        "ExternalName"
-                    ]
-                }
-            },
-            "title": "k8gbCoreDNS"
         },
         "k8gbSecurityContext": {
             "type": "object",

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -364,6 +364,22 @@
             },
             "title": "Log"
         },
+        "k8gbCoreDNS": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "serviceType": {
+                    "type": "string",
+                    "enum": [
+                        "ClusterIP",
+                        "NodePort",
+                        "LoadBalancer",
+                        "ExternalName"
+                    ]
+                }
+            },
+            "title": "k8gbCoreDNS"
+        },
         "k8gbSecurityContext": {
             "type": "object",
             "additionalProperties": false,

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -21,6 +21,8 @@ k8gb:
     - parentZone: "example.com" # -- parent zone which would contain gslb zone to delegate (same meaning as the old edgeDNSZone)
       loadBalancedZone: "cloud.example.com" # -- zone controlled by gslb (same meaning as the old dnsZone)
       dnsZoneNegTTL: 30  # -- Negative TTL for SOA record# -- host/ip[:port] format is supported here where port defaults to 53
+      extraPlugins: [] # -- Extra CoreDNS plugins to be enabled for this zone
+      extraServerBlocks: "" # -- Extra CoreDNS server blocks for this zone
   edgeDNSServers:
     # -- use this DNS server as a main resolver to enable cross k8gb DNS based communication
     - "1.1.1.1"
@@ -33,11 +35,7 @@ k8gb:
   reconcileRequeueSeconds: 30
   # -- TTL of the NS and respective glue record used by external DNS
   nsRecordTTL: 30
-  coredns:
-    # -- Extra CoreDNS server blocks
-    extraServerBlocks: ""
-    # -- Extra CoreDNS plugins to be enabled
-    extra_plugins: []
+
   log:
     # -- log format (simple,json)
     format: simple # log format (simple,json)


### PR DESCRIPTION
- Allow extraPlugins and extraServerBlocks to be defined per each zone instead for all zone entries in the Corefile. 
- Some refactoring to simplify stuff
- Removed the `k8gb.coredns.extraServerBlocks` and `extra_plugins` values from the values.yaml file
- Adjusted values.schema.json

Is related to my work to allow NS entries for coredns-crd-plugin, here the [issue](https://github.com/k8gb-io/coredns-crd-plugin/issues/74).