### PR TITLE
Use add selector labels to pod

### DIFF
--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       labels:
         name: k8gb
+        {{- include "chart.selectorLabels" . | nindent 8 }}
         {{- with .Values.k8gb.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
k8gb-metrics service uses selector:
```
k8gb-metrics           <none>                            216d
```
Adding pod selector will fix it.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
