### PR TITLE
Allow multiline extraplugin

### DIFF
--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -14,7 +14,7 @@ data:
         health
 {{- if .extraPlugins }}
 {{- range .extraPlugins }}
-        {{ . }}
+{{ . | nindent 8 }}
 {{- end }}
 {{- end }}
         ready


### PR DESCRIPTION
- By using `nindent` we can add the indentation for each line. This provides easier templating with multiline plugins.

Example of multiline plugin:
```
   dnsZones:
      - parentZone: example.com
        loadBalancedZone: hello.exmaple.com
        extraPlugins:
          - |
            template IN SOA hello.exmaple.com {
                match "hello.exmaple.com"
                answer "hello.exmaple.com. 3600 IN SOA hello.exmaple.com. hostmaster.hello.exmaple.com. 2025070801 7200 3600 1209600 3600"
            }
```
