### PR TITLE
add option to disable coredns configmap provided by k8gb

### DIFF
--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.coredns.deployment.enabled }}
+{{- if and .Values.coredns.deployment.enabled .Values.coredns.corefile.enabled}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -108,6 +108,11 @@
                 },
                 "resources": {
                     "$ref": "#/definitions/Resources"
+                },
+                "corefile": {
+                    "enabled": {
+                        "type": "boolean"
+                    }
                 }
             },
             "title": "Coredns"

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -144,6 +144,10 @@ coredns:
       cpu: 100m
       memory: 128Mi
 
+  # -- CoreDNS configmap
+  corefile:
+    enabled: true
+
 infoblox:
   # -- infoblox provider enabled
   enabled: false


### PR DESCRIPTION
Instead of adding to much configuration to the values.yaml file, the user should just overwrite the existing configmap. This will reduce complexity of the values.yaml file in the future and allows the user to have the maximum flexibility.