### PR TITLE
Fix mkdocs GitHub Pages deployment with reliable chart preservation

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -35,30 +35,48 @@ jobs:
         run: |
           pip3 install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin
           
-      - name: Build and Deploy
+      - name: Setup git config
         run: |
-          # Backup chart repo files
-          git checkout gh-pages
-          mkdir -p /tmp/chart-backup
-          cp -r . /tmp/chart-backup/ 2>/dev/null || true
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Backup preserved files
+        run: |
+          mkdir -p /tmp/preserved
+          git fetch origin gh-pages:gh-pages
+          if git checkout gh-pages; then
+            echo "Backing up existing files..."
+            test -d charts && cp -r charts /tmp/preserved/
+            test -f artifacthub-repo.yml && cp artifacthub-repo.yml /tmp/preserved/
+            test -f index.yaml && cp index.yaml /tmp/preserved/
+            test -f CNAME && cp CNAME /tmp/preserved/
+          fi
           git checkout master
-          
-          # Build MkDocs site
-          mkdocs build
-          
-          # Deploy with chart files preserved
+
+      - name: Build documentation
+        run: mkdocs build --clean
+
+      - name: Deploy to gh-pages
+        run: |
           git checkout gh-pages
-          rm -rf docs/ *.html *.js *.css search/ sitemap.xml* 2>/dev/null || true
+          
+          # Clean MkDocs artifacts only
+          rm -rf docs/ *.html *.js *.css search/ sitemap.xml
+          
+          # Deploy new site
           cp -r site/* .
           
-          # Restore only chart repo and essential files (Jekyll replaced by MkDocs)
-          cp -r /tmp/chart-backup/charts/ . 2>/dev/null || true
-          cp -r /tmp/chart-backup/artifacthub-repo.yml . 2>/dev/null || true
-          cp -r /tmp/chart-backup/index.yaml . 2>/dev/null || true
-          cp -r /tmp/chart-backup/CNAME . 2>/dev/null || true
+          # Restore preserved files
+          test -d /tmp/preserved/charts && cp -r /tmp/preserved/charts .
+          test -f /tmp/preserved/artifacthub-repo.yml && cp /tmp/preserved/artifacthub-repo.yml .
+          test -f /tmp/preserved/index.yaml && cp /tmp/preserved/index.yaml .
+          test -f /tmp/preserved/CNAME && cp /tmp/preserved/CNAME .
           
+          # Commit and push if there are changes
           git add .
-          git commit -m "Documentation sync from master" || exit 0
-          git push origin gh-pages
+          if ! git diff --cached --quiet; then
+            git commit -m "Deploy documentation from ${{ github.sha }}"
+            git push origin gh-pages
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -25,16 +25,16 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
-          
+
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
         with:
           python-version: '3.x'
-          
+
       - name: Install MkDocs
         run: |
           pip3 install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin
-          
+
       - name: Setup git config
         run: |
           git config --local user.email "action@github.com"
@@ -59,19 +59,19 @@ jobs:
       - name: Deploy to gh-pages
         run: |
           git checkout gh-pages
-          
-          # Clean MkDocs artifacts only
-          rm -rf docs/ *.html *.js *.css search/ sitemap.xml
-          
+
+          # Clean everything except git files and preserved files
+          find . -maxdepth 1 -not -name '.git*' -not -name '.' -not -name '..' -exec rm -rf {} +
+
           # Deploy new site
           cp -r site/* .
-          
+
           # Restore preserved files
           test -d /tmp/preserved/charts && cp -r /tmp/preserved/charts .
           test -f /tmp/preserved/artifacthub-repo.yml && cp /tmp/preserved/artifacthub-repo.yml .
           test -f /tmp/preserved/index.yaml && cp /tmp/preserved/index.yaml .
           test -f /tmp/preserved/CNAME && cp /tmp/preserved/CNAME .
-          
+
           # Commit and push if there are changes
           git add .
           if ! git diff --cached --quiet; then


### PR DESCRIPTION
 - Follow up to #1979
 - Add git configuration to prevent commit author errors
 - Replace unreliable || true patterns with proper conditionals
 - Clean all existing gh-pages content (Jekyll artifacts) before deploy
 - Preserve Helm chart files (charts/, index.yaml, artifacthub-repo.yml, CNAME)
 - Split deployment into logical steps for better maintainability


<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
