### PR TITLE
Fix mkdocs preservation logic issue, add workflow_dispatch

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -8,6 +8,8 @@ on:
       - '**.md'
       - 'docs/**'
       - 'mkdocs.yml'
+      - '.github/workflows/gh-pages.yaml'
+  workflow_dispatch:
 permissions:
   contents: read
 
@@ -58,13 +60,16 @@ jobs:
 
       - name: Deploy to gh-pages
         run: |
+          # Copy built site to temp location
+          cp -r site /tmp/mkdocs-site
+
           git checkout gh-pages
 
           # Clean everything except git files and preserved files
           find . -maxdepth 1 -not -name '.git*' -not -name '.' -not -name '..' -exec rm -rf {} +
 
           # Deploy new site
-          cp -r site/* .
+          cp -r /tmp/mkdocs-site/* .
 
           # Restore preserved files
           test -d /tmp/preserved/charts && cp -r /tmp/preserved/charts .


### PR DESCRIPTION
Fix the issue and add workflow_dispatch for testing and manual deployment trigger.

https://github.com/k8gb-io/k8gb/actions/runs/16393539502/job/46322631731 

Trigger gh-deploy when workflow configuration changes

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
