### PR TITLE
Fix extdns/k8gb DNS zone validation (helm)

### DIFF
--- a/chart/k8gb/templates/_validators.tpl
+++ b/chart/k8gb/templates/_validators.tpl
@@ -24,19 +24,15 @@
 
 {{- $extdnsZones := .Values.extdns.domainFilters -}}
 
-{{- if ne (len $parentZones) (len $extdnsZones) -}}
-  {{- fail (printf "Validation failed: Number of zones in k8gb.dnsZones (%d) does not match number of domains in extdns.domainFilters (%d)" (len $parentZones) (len $extdnsZones)) -}}
-{{- end -}}
-
 {{- range $parentZone := $parentZones -}}
   {{- if not (has $parentZone $extdnsZones) -}}
-    {{- fail (printf "Validation failed: Zone '%s' from k8gb.dnsZones is not present in extdns.domainFilters" $parentZone) -}}
+    {{- fail (printf "Validation failed: Parent zone '%s' from k8gb.dnsZones is not present in extdns.domainFilters" $parentZone) -}}
   {{- end -}}
 {{- end -}}
 
 {{- range $extdnsZone := $extdnsZones -}}
   {{- if not (has $extdnsZone $parentZones) -}}
-    {{- fail (printf "Validation failed: Domain '%s' from extdns.domainFilters is not present in k8gb.dnsZones" $extdnsZone) -}}
+    {{- fail (printf "Validation failed: Domain '%s' from extdns.domainFilters is not present in k8gb.dnsZones.parentZone" $extdnsZone) -}}
   {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
We have a validation function that verifies if the DNS zones configured in k8gb and external DNS match, to prevent misconfigurations.

One of the conditions was checking if the number of zones is the same in both configurations, however there are valid configurations where this is not the case. Take the example:
```
k8gb:
  dnsZones:
  - parentZone: example.com
    loadBalancedZone: cloud.example.com
  - parentZone: example.com
    loadBalancedZone: demo.example.com
```
In this case, the parentZones are the same, so we only need one entry in the external-dns configuration.

There is a workaround though. One can duplicate the entry in the external dns configuration without any side effects:
```
extdns:
  domainFilters:
  - example.com
  - example.com
```

To clean up the validation and avoid this redundancy the PR removes the faulty equality condition. It is enough to verify if each k8gb's parentZone is present in the external-dns's domainFilters, and vice-versa.