### PR TITLE
Remove unused route53 helm key

### DIFF
--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -26,9 +26,6 @@
                 "infoblox": {
                     "$ref": "#/definitions/Infoblox"
                 },
-                "route53": {
-                    "$ref": "#/definitions/Route53"
-                },
                 "ns1": {
                     "$ref": "#/definitions/Ns1"
                 },
@@ -654,59 +651,6 @@
                 }
             },
             "title": "Rfc2136authGssTsigCreds"
-        },
-        "Route53": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "hostedZoneID": {
-                    "type": "string",
-                    "minLength": 2
-                },
-                "irsaRole": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "pattern": "^arn:aws:iam:.+$",
-                            "minLength": 20
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "secret": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "assumeRoleArn": {
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "pattern": "^arn:aws:iam:.+$",
-                            "minLength": 20
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                }
-            },
-            "required": [
-                "hostedZoneID",
-                "irsaRole"
-            ],
-            "title": "Route53"
         },
         "AzureDNS": {
             "type": "object",

--- a/docs/examples/route53/k8gb/k8gb-cluster-eu-west-1.yaml
+++ b/docs/examples/route53/k8gb/k8gb-cluster-eu-west-1.yaml
@@ -6,10 +6,18 @@ k8gb:
   clusterGeoTag: "eu-west-1" # used for places where we need to distinguish between differnet Gslb instances
   extGslbClustersGeoTags: "us-east-1" # comma-separated list of external gslb geo tags to pair with
 
-route53:
+extdns:
   enabled: true
-  hostedZoneID: Z<zone-id>
-  irsaRole: arn:aws:iam::<account-id>:role/external-dns-k8gb-cluster-eu-west-1 # ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+  provider:
+    name: aws
+  serviceAccount:
+    name: k8gb-external-dns
+    annotations:
+      eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/external-dns-k8gb-cluster-eu-west-1 # ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+  txtPrefix: k8gb-eu-west-1
+  txtOwnerId: k8gb-<zone-id>-eu-west-1
+  domainFilters:
+    - k8gb.io
 
 coredns:
   serviceType: LoadBalancer


### PR DESCRIPTION
With the migration of route53 to external dns in v0.15.0, the `route53` key in the helm chart is no longer used. Therefore, this PR removes it.

In addition, I noticed there was a documentation example of route53 configuration that was forgotten. It is now updated to reflect the new configuration.