### PR TITLE
feat: add configurable Infoblox DNS View support via Helm

### DIFF
--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -99,6 +99,11 @@ spec:
                 configMapKeyRef:
                   name: infoblox
                   key: INFOBLOX_HTTP_POOL_CONNECTIONS
+            - name: INFOBLOX_DNS_VIEW
+              valueFrom:
+                configMapKeyRef:
+                  name: infoblox
+                  key: INFOBLOX_DNS_VIEW                  
             - name: INFOBLOX_WAPI_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/chart/k8gb/templates/infoblox-cm.yaml
+++ b/chart/k8gb/templates/infoblox-cm.yaml
@@ -6,6 +6,7 @@ data:
   INFOBLOX_WAPI_PORT: {{ quote .Values.infoblox.wapiPort }}
   INFOBLOX_HTTP_REQUEST_TIMEOUT: {{ quote .Values.infoblox.httpRequestTimeout }}
   INFOBLOX_HTTP_POOL_CONNECTIONS: {{ quote .Values.infoblox.httpPoolConnections }}
+  INFOBLOX_DNS_VIEW: {{ quote .Values.infoblox.dnsView }}
 kind: ConfigMap
 metadata:
   name: infoblox

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -292,6 +292,10 @@
                 "httpPoolConnections": {
                     "type": "integer",
                     "minimum": 0
+                },
+                "dnsView": {
+                  "type": "string",
+                  "description": "DNS view to use for zone operations"
                 }
             },
             "required": [

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -163,6 +163,8 @@ infoblox:
   httpRequestTimeout: 20
   # -- Size of connections pool
   httpPoolConnections: 10
+  # -- DNS view to use for zone operations
+  dnsView: "default"  
 
 extdns:
   enabled: false

--- a/controllers/providers/dns/infoblox.go
+++ b/controllers/providers/dns/infoblox.go
@@ -131,7 +131,8 @@ func (p *InfobloxProvider) createZoneDelegated(o ibcl.IBObjectManager, fqdn stri
 	start := time.Now()
 	ns := ibcl.NullableNameServers{NameServers: d, IsNull: false}
 	//nolint: gosec
-	res, err = o.CreateZoneDelegated(fqdn, ns, "created by k8gb", false, false, "", uint32(p.config.NSRecordTTL), true, ibcl.EA{}, "default", "FORWARD")
+	res, err = o.CreateZoneDelegated(fqdn, ns, "created by k8gb", false, false,
+		"", uint32(p.config.NSRecordTTL), true, ibcl.EA{}, p.config.Infoblox.DNSView, "FORWARD")
 	m.InfobloxObserveRequestDuration(start, metrics.CreateZoneDelegated, err == nil)
 	return
 }

--- a/controllers/resolver/config.go
+++ b/controllers/resolver/config.go
@@ -91,4 +91,6 @@ type Infoblox struct {
 	HTTPRequestTimeout int `env:"INFOBLOX_HTTP_REQUEST_TIMEOUT" optional:"" default:"20" help:"request timeout seconds"`
 	// HTTPPoolConnections seconds
 	HTTPPoolConnections int `env:"INFOBLOX_HTTP_POOL_CONNECTIONS" optional:"" default:"10" help:"pool connection seconds"`
+	// DNSView specifies the DNS view to use for zone operations
+	DNSView string `env:"INFOBLOX_DNS_VIEW" optional:"" default:"default" help:"DNS view to use for zone operations"`
 }


### PR DESCRIPTION
What
Added support for configuring Infoblox DNS View via Helm values.

Why
In Infoblox-managed DNS environments, DNS Views are configurable, with "default" being the standard view name. By making the DNS View configurable in k8gb, we enable greater deployment flexibility to accommodate different Infoblox setups.

Changes
Added infoblox.dnsView to Helm values.yaml (default: "default")
Passed K8GB_DNS_VIEW as an environment variable to the controller
Used K8GB_DNS_VIEW inside the controller to configure the Infoblox provider
Updated docs/configuration.md to reflect the new setting

Notes
Default behavior remains unchanged (uses "default" view)
Tested locally against Infoblox Grid Manager

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
