### PR TITLE
Reload coredns if configuration changes

### DIFF
--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -12,6 +12,9 @@ data:
     {{ .loadBalancedZone }}:5353 {
         errors
         health
+        {{- if $.Values.coredns.corefile.reload.enabled }}
+        reload {{ $.Values.coredns.corefile.reload.interval }} {{ $.Values.coredns.corefile.reload.jitter }}
+        {{- end }}
 {{- if .extraPlugins }}
 {{- range .extraPlugins }}
 {{ . | nindent 8 }}

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -107,9 +107,7 @@
                     "$ref": "#/definitions/Resources"
                 },
                 "corefile": {
-                    "enabled": {
-                        "type": "boolean"
-                    }
+                    "$ref": "#/definitions/CorednsCorefile"
                 }
             },
             "title": "Coredns"
@@ -159,6 +157,38 @@
                 "name"
             ],
             "title": "ServiceAccount"
+        },
+        "CorednsCorefile": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "reload": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "jitter": {
+                            "type": "string",
+                            "minLength": 1
+                        }
+                    },
+                    "required": [
+                        "enabled",
+                        "interval",
+                        "jitter"
+                    ]
+                }
+            },
+            "title": "Corefile"
         },
         "Externaldns": {
             "type": "object",

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -147,6 +147,12 @@ coredns:
   # -- CoreDNS configmap
   corefile:
     enabled: true
+    # -- Reload CoreDNS configmap when it changes
+    # https://coredns.io/plugins/reload/
+    reload:
+      enabled: true
+      interval: 30s
+      jitter: 15s
 
 infoblox:
   # -- infoblox provider enabled


### PR DESCRIPTION
Until now, coreDNS pods needed a restart to pick up configuration updates (e.g. adding or removing DNS zones).

By enabling the reload plugin, the configuration of the Corefile is automatically picked up upon changes. It is a hot reload, the pods do not restart. Also, any Corefile changes are picked up, not only the ones in the zone where the plugin is configured.

The reload interval and jitter are made configurable and set to the default values documented in https://coredns.io/plugins/reload/

# Testing
* Query coredns for a record in a zone not yet configured (e.g. podinfo.aws.k8gb.website), which fails
* Add the zone "aws.k8gb.website" to the core file.
* Wait for the reload
* Query coredns for the same record, which now resolves correctly.

The reload is also visible in the logs:
```
[INFO] Reloading
[INFO] plugin/k8s_crd: Filter: [k8gb.absa.oss/dnstype=local]
[INFO] plugin/k8s_crd: negTTL: 30
[INFO] plugin/k8s_crd: loadbalance: [weight]
[INFO] plugin/k8s_crd: Running 'inCluster' kube controller
[INFO] plugin/k8s_crd: Filter: [k8gb.absa.oss/dnstype=local]
[INFO] plugin/k8s_crd: negTTL: 30
[INFO] plugin/k8s_crd: loadbalance: [weight]
[INFO] plugin/k8s_crd: Running 'inCluster' kube controller
[INFO] plugin/reload: Running configuration SHA512 = a08ef6c491feee319ca8e583a1abb865c1efe853d160051bba7ade67805ac519761242fa2e2798378b322f48692bac6a619bc8a6efb90e8ae7b934f27709549e
[INFO] Reloading complete
```