### PR TITLE
Add support for k8gb tolerations

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -138,6 +138,7 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | k8gb.securityContext.runAsNonRoot | bool | `true` | For more options consult https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#securitycontext-v1-core |
 | k8gb.securityContext.runAsUser | int | `1000` |  |
 | k8gb.serviceMonitor | object | `{"enabled":false}` | enable ServiceMonitor |
+| k8gb.tolerations | array | `[]` | Tolerations to apply to the k8gb operator deployment |
 | k8gb.validatingAdmissionPolicy | object | `{"enabled":false}` | enable validating admission policies |
 | ns1.enabled | bool | `false` | Enable NS1 provider |
 | ns1.ignoreSSL | bool | `false` | optional custom NS1 API endpoint for on-prem setups endpoint: https://api.nsone.net/v1/ |

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: k8gb
+      {{- if .Values.k8gb.tolerations }}
+      tolerations: {{ toYaml .Values.k8gb.tolerations | nindent 8 }}
+      {{- end }}
       containers:
         - name: k8gb
           ports:

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -411,6 +411,53 @@
                 },
                 "resources": {
                     "$ref": "#/definitions/Resources"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "type": "string",
+                                "enum": ["Exists", "Equal"]
+                            },
+                            "value": {
+                                "type": "string"
+                            },
+                            "effect": {
+                                "type": "string",
+                                "enum": ["NoSchedule", "PreferNoSchedule", "NoExecute"]
+                            },
+                            "tolerationSeconds": {
+                                "type": "integer"
+                            }
+                        },
+                        "anyOf": [
+                            {
+                            "properties": {
+                                "operator": {"const": "Exists"}
+                                },
+                            "not": {
+                                "required": ["value"]
+                                }
+                            },
+                            {
+                            "properties": {
+                                "operator": {"const": "Equal"}
+                                },
+                            "required": ["value"]
+                            },
+                            {
+                            "not": {
+                                "required": ["operator"]
+                                }
+                            }
+                        ],
+                        "additionalProperties": false
+                    }
                 }
             },
             "required": [

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -71,6 +71,15 @@ k8gb:
       memory: "128Mi"
       cpu: "500m"
 
+  # -- Tolerations to apply to the k8gb operator deployment
+  # for example:
+  #   tolerations:
+  #   - key: foo.bar.com/role
+  #     operator: Equal
+  #     value: master
+  #     effect: NoSchedule
+  tolerations: []
+
 externaldns:
   # -- `.spec.template.spec.dnsPolicy` for ExternalDNS deployment
   dnsPolicy: "ClusterFirst"
@@ -173,7 +182,7 @@ infoblox:
   # -- Size of connections pool
   httpPoolConnections: 10
   # -- DNS view to use for zone operations
-  dnsView: "default"  
+  dnsView: "default"
 
 extdns:
   enabled: false


### PR DESCRIPTION
..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
