### PR TITLE
Add helm support for geo data fields in coredns cm

### DIFF
--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -27,6 +27,12 @@ data:
             filter k8gb.absa.oss/dnstype=local
             negttl {{ .dnsZoneNegTTL | default 30 }}
             loadbalance weight
+            {{- if and .geoDataFilePath (ne .geoDataFilePath "") }}
+            geoDataFilePath {{ .geoDataFilePath }}
+            {{- end }}
+            {{- if and .geoDataField (ne .geoDataField "") }}
+            geoDataField {{ .geoDataField }}
+            {{- end }}
         }
     }
 {{- end }}

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -23,6 +23,8 @@ k8gb:
       dnsZoneNegTTL: 30  # -- Negative TTL for SOA record# -- host/ip[:port] format is supported here where port defaults to 53
       extraPlugins: [] # -- Extra CoreDNS plugins to be enabled for this zone
       extraServerBlocks: "" # -- Extra CoreDNS server blocks for this zone
+      geoDataFilePath: "" # -- GeoData file path
+      geoDataField: "" # -- GeoData field
   edgeDNSServers:
     # -- use this DNS server as a main resolver to enable cross k8gb DNS based communication
     - "1.1.1.1"


### PR DESCRIPTION
Add support in helm chart to configure `geoDataFilePath` & `geoDataField` in the k8gb coredns plugin arguments. 

Fixes #2015