### PR TITLE
Added helm OCI registry support

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -48,7 +48,9 @@ jobs:
           git fetch origin gh-pages:gh-pages
           if git checkout gh-pages; then
             echo "Backing up existing files..."
-            # Only preserve CNAME for domain configuration
+            test -d charts && cp -r charts /tmp/preserved/
+            test -f artifacthub-repo.yml && cp artifacthub-repo.yml /tmp/preserved/
+            test -f index.yaml && cp index.yaml /tmp/preserved/
             test -f CNAME && cp CNAME /tmp/preserved/
           fi
           git checkout master
@@ -70,6 +72,9 @@ jobs:
           cp -r /tmp/mkdocs-site/* .
 
           # Restore preserved files
+          test -d /tmp/preserved/charts && cp -r /tmp/preserved/charts .
+          test -f /tmp/preserved/artifacthub-repo.yml && cp /tmp/preserved/artifacthub-repo.yml .
+          test -f /tmp/preserved/index.yaml && cp /tmp/preserved/index.yaml .
           test -f /tmp/preserved/CNAME && cp /tmp/preserved/CNAME .
 
           # Commit and push if there are changes

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -48,9 +48,7 @@ jobs:
           git fetch origin gh-pages:gh-pages
           if git checkout gh-pages; then
             echo "Backing up existing files..."
-            test -d charts && cp -r charts /tmp/preserved/
-            test -f artifacthub-repo.yml && cp artifacthub-repo.yml /tmp/preserved/
-            test -f index.yaml && cp index.yaml /tmp/preserved/
+            # Only preserve CNAME for domain configuration
             test -f CNAME && cp CNAME /tmp/preserved/
           fi
           git checkout master
@@ -72,9 +70,6 @@ jobs:
           cp -r /tmp/mkdocs-site/* .
 
           # Restore preserved files
-          test -d /tmp/preserved/charts && cp -r /tmp/preserved/charts .
-          test -f /tmp/preserved/artifacthub-repo.yml && cp /tmp/preserved/artifacthub-repo.yml .
-          test -f /tmp/preserved/index.yaml && cp /tmp/preserved/index.yaml .
           test -f /tmp/preserved/CNAME && cp /tmp/preserved/CNAME .
 
           # Commit and push if there are changes

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -19,17 +19,22 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - uses: dave-mcconnell/helm-gh-pages-microservices@8478af5f0fd712cc0fb59f2c99e0688f3f591287
-        with:
-          access-token: ${{ secrets.CR_TOKEN }}
-          source-charts-folder: 'chart'
-          destination-repo: k8gb-io/k8gb
-          destination-branch: gh-pages
+      # TODO: Remove after OCI migration is complete
+      # - uses: dave-mcconnell/helm-gh-pages-microservices@8478af5f0fd712cc0fb59f2c99e0688f3f591287
+      #   with:
+      #     access-token: ${{ secrets.CR_TOKEN }}
+      #     source-charts-folder: 'chart'
+      #     destination-repo: k8gb-io/k8gb
+      #     destination-branch: gh-pages
       - name: Create k3s cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
+      - name: Push to OCI Registry
+        run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          helm push k8gb-*.tgz oci://ghcr.io/k8gb-io/charts
       - name: Smoke test helm installation
         run: |
           helm repo add k8gb https://k8gb.io/

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -19,22 +19,23 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      # TODO: Remove after OCI migration is complete
-      # - uses: dave-mcconnell/helm-gh-pages-microservices@8478af5f0fd712cc0fb59f2c99e0688f3f591287
-      #   with:
-      #     access-token: ${{ secrets.CR_TOKEN }}
-      #     source-charts-folder: 'chart'
-      #     destination-repo: k8gb-io/k8gb
-      #     destination-branch: gh-pages
+      - uses: dave-mcconnell/helm-gh-pages-microservices@8478af5f0fd712cc0fb59f2c99e0688f3f591287
+        with:
+          access-token: ${{ secrets.CR_TOKEN }}
+          source-charts-folder: 'chart'
+          destination-repo: k8gb-io/k8gb
+          destination-branch: gh-pages
+
+      - name: Push to OCI Registry
+        run: |
+          echo ${{ secrets.CR_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          helm push k8gb-*.tgz oci://ghcr.io/k8gb-io/charts
+
       - name: Create k3s cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
-      - name: Push to OCI Registry
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
-          helm push k8gb-*.tgz oci://ghcr.io/k8gb-io/charts
       - name: Smoke test helm installation
         run: |
           helm repo add k8gb https://k8gb.io/


### PR DESCRIPTION
Previously, we had issue of blast radius while setting up gh-pages.. basically docs updates could break chart serving.
Therefore in #1979 #1985 chart preservation was done in `.github/workflows/gh-pages.yaml` temporarily

But as mentioned by @ytsarev in #1973 as a good possible solution. I have done following this to implement this solution.

- Add OCI registry publishing (`oci://ghcr.io/k8gb-io/charts/k8gb`)
- chart preservation logic from gh-pages workflow also exist.

**Testing:**
- [x] Verify OCI registry publishing works on release v0.15.0
- [x] Test installation methods work

**Steps done:**
- `helm dependency update chart/k8gb` and `helm package chart/k8gb` -> successfully created k8gb-v0.15.0.tgz
- `echo $GITHUB_TOKEN | helm registry login ghcr.io -u itsfarhan --password-stdin` and `helm push k8gb-*.tgz oci://ghcr.io/itsfarhan/charts` ->  Chart successfully pushed to ghcr.io/itsfarhan/charts/k8gb:v0.15.0
- `helm install k8gb oci://ghcr.io/itsfarhan/charts/k8gb --version v0.15.0 -n k8gb --create-namespace` -> Chart pulled and installed successfully.
- Tested on different branch and docs only deployed without chart files. (no preservation needed)

<img width="2043" height="587" alt="Screenshot from 2025-08-09 00-36-27" src="https://github.com/user-attachments/assets/42d5f90e-e0a9-43a5-8164-4ba104c3d052" />
<img width="2059" height="375" alt="Screenshot from 2025-08-09 00-02-15" src="https://github.com/user-attachments/assets/5229abb4-4014-4605-98d2-91ca60414cea" />

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
