### PR TITLE
Add mkdocs-simple-hooks plugin to fix README links in documentation

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Install MkDocs
         run: |
-          pip3 install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin
+          pip3 install mkdocs mkdocs-material mkdocs-git-revision-date-localized-plugin mkdocs-simple-hooks
 
       - name: Setup git config
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ tofu.tfstate.*
 
 mkdocs-env/
 site/
+docs/__pycache__/

--- a/docs/link_fixer.py
+++ b/docs/link_fixer.py
@@ -1,0 +1,13 @@
+"""
+Simple hook function to fix docs/ links in README for MkDocs compatibility
+"""
+import re
+
+def fix_links(markdown, page, config, files):
+    """
+    Fix docs/ links in markdown content for MkDocs compatibility
+    """
+    if page.file.src_path == 'index.md':
+        # Replace (docs/filename.md) with (filename.md) for the index page
+        markdown = re.sub(r'\(docs/([a-zA-Z0-9_.-]+\.md)\)', r'(\1)', markdown)
+    return markdown

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,3 +93,6 @@ plugins:
   - search
   - git-revision-date-localized:
       enable_creation_date: true
+  - mkdocs-simple-hooks:
+      hooks:
+        on_page_markdown: "docs.link_fixer:fix_links"


### PR DESCRIPTION
- Configure link transformation for docs/ paths in MkDocs
- Add hook to convert docs/filename.md to filename.md in index page
- Update CI to install mkdocs-simple-hooks plugin
- Add `docs/__pycache__/` to .gitignore

This allows the same README.md to work correctly in both GitHub and MkDocs documentation sites.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
