### PR TITLE
Allow duplicit values in EXT_GSLB_CLUSTER_GEOTAGS

### DIFF
--- a/controllers/resolver/config_delegationZones.go
+++ b/controllers/resolver/config_delegationZones.go
@@ -56,6 +56,10 @@ func parseDelegationZones(config *Config) ([]*DelegationZoneInfo, error) {
 	extClusterNSNames := func(zone, edge string) map[string]string {
 		m := map[string]string{}
 		for _, tag := range config.ExtClustersGeoTagsRaw {
+			if tag == config.ClusterGeoTag {
+				// skip the cluster GeoTag, see: https://github.com/k8gb-io/k8gb/issues/720
+				continue
+			}
 			m[tag] = getNsName(tag, zone, edge)
 		}
 		return m


### PR DESCRIPTION
closes #720

Maintaining extClusterGeoTags is error-prone, because someone might copy-paste the ext-cluster GeoTags between cluster configurations and accidentally leave a duplicate GeoTag that matches the clusterGeoTag.

This PR basically allows me to have a configuration like this:

```shell
cluster 1:
CLUSTER_GEO_TAG: eu
EXT_GSLB_CLUSTERS_GEO_TAGS: eu, us, cz, af, ap

cluster 2:
CLUSTER_GEO_TAG: us
EXT_GSLB_CLUSTERS_GEO_TAGS: eu, us, cz, af, ap

cluster 3:
CLUSTER_GEO_TAG: cz
EXT_GSLB_CLUSTERS_GEO_TAGS: eu, us, cz, af, ap
```

previously:

```shell
# cluster 1:
CLUSTER_GEO_TAG: eu
EXT_GSLB_CLUSTERS_GEO_TAGS: us, cz, af, ap

# cluster 2:
CLUSTER_GEO_TAG: us
EXT_GSLB_CLUSTERS_GEO_TAGS: eu, cz, af, ap

# cluster 3:
CLUSTER_GEO_TAG: cz
EXT_GSLB_CLUSTERS_GEO_TAGS: eu, us, af, ap
..
```
