### PR TITLE
Move NS1 configuration to external-dns

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ k8gb is tested with the following environment options.
 |----------------------------------|------------------------------------------------------------------------------|
 | Kubernetes Version               | >= `1.21`                                                                    |
 | Environment                      | Any conformant Kubernetes cluster on-prem or in cloud                        |
-| Ingress Controller               | NGINX, AWS Load Balancer Controller [*](#clarify)                            |
+| Ingress Controller               | NGINX, Istio, AWS Load Balancer Controller [*](#clarify)                     |
 | EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS                                 |
 
 <a name="clarify"></a>

--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -140,8 +140,6 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | k8gb.serviceMonitor | object | `{"enabled":false}` | enable ServiceMonitor |
 | k8gb.tolerations | list | `[]` | Tolerations to apply to the k8gb operator deployment for example:   tolerations:   - key: foo.bar.com/role     operator: Equal     value: master     effect: NoSchedule |
 | k8gb.validatingAdmissionPolicy | object | `{"enabled":false}` | enable validating admission policies |
-| ns1.enabled | bool | `false` | Enable NS1 provider |
-| ns1.ignoreSSL | bool | `false` | optional custom NS1 API endpoint for on-prem setups endpoint: https://api.nsone.net/v1/ |
 | openshift.enabled | bool | `false` | Install OpenShift specific RBAC |
 | rfc2136.enabled | bool | `false` |  |
 | rfc2136.rfc2136Opts[0].host | string | `"host.k3d.internal"` |  |

--- a/chart/k8gb/templates/_helpers.tpl
+++ b/chart/k8gb/templates/_helpers.tpl
@@ -63,9 +63,6 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "k8gb.extdnsProvider" -}}
-{{- if .Values.ns1.enabled -}}
-{{- print "ns1" -}}
-{{- end -}}
 {{- if .Values.rfc2136.enabled }}
 {{- print "rfc2136" -}}
 {{- end -}}
@@ -100,20 +97,6 @@ k8gb-{{ index (split ":" (index (split ";" (include "k8gb.dnsZonesString" .)) "_
 {{- end }}
 
 {{- define "k8gb.extdnsProviderOpts" -}}
-{{- if .Values.ns1.enabled -}}
-{{- if .Values.ns1.endpoint -}}
-        - --ns1-endpoint={{ .Values.ns1.endpoint }}
-{{- end -}}
-{{- if .Values.ns1.ignoreSSL -}}
-        - --ns1-ignoressl
-{{- end -}}
-        env:
-        - name: NS1_APIKEY
-          valueFrom:
-            secretKeyRef:
-              name: ns1
-              key: apiKey
-{{- end }}
 {{- if .Values.azuredns.enabled -}}
         - --azure-resource-group={{ .Values.azuredns.resourceGroup }}
 {{- end }}

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
                   name: infoblox
                   key: INFOBLOX_WAPI_PASSWORD
             {{- end }}
-            {{- if or .Values.extdns.enabled .Values.ns1.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+            {{- if or .Values.extdns.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
             - name: EXTDNS_ENABLED
               value: "true"
             {{- end }}

--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.ns1.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+{{- if or .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.ns1.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+{{- if or .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -26,9 +26,6 @@
                 "infoblox": {
                     "$ref": "#/definitions/Infoblox"
                 },
-                "ns1": {
-                    "$ref": "#/definitions/Ns1"
-                },
                 "rfc2136": {
                     "$ref": "#/definitions/Rfc2136"
                 },
@@ -437,22 +434,22 @@
                         },
                         "anyOf": [
                             {
-                            "properties": {
-                                "operator": {"const": "Exists"}
+                                "properties": {
+                                    "operator": {"const": "Exists"}
                                 },
-                            "not": {
-                                "required": ["value"]
+                                "not": {
+                                    "required": ["value"]
                                 }
                             },
                             {
-                            "properties": {
-                                "operator": {"const": "Equal"}
+                                "properties": {
+                                    "operator": {"const": "Equal"}
                                 },
-                            "required": ["value"]
+                                "required": ["value"]
                             },
                             {
-                            "not": {
-                                "required": ["operator"]
+                                "not": {
+                                    "required": ["operator"]
                                 }
                             }
                         ],
@@ -563,19 +560,6 @@
                 "loadBalancedZone",
                 "parentZone"
             ]
-        },
-        "Ns1": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "ignoreSSL": {
-                    "type": "boolean"
-                }
-            },
-            "title": "Ns1"
         },
         "Openshift": {
             "type": "object",

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -205,13 +205,6 @@ extdns:
   txtPrefix: "k8gb-<GEOTAG>-"
   txtOwnerId: "k8gb-<GEOTAG>"
 
-ns1:
-  # -- Enable NS1 provider
-  enabled: false
-  # -- optional custom NS1 API endpoint for on-prem setups
-  # endpoint: https://api.nsone.net/v1/
-  ignoreSSL: false
-
 rfc2136:
   enabled: false
   rfc2136Opts:

--- a/docs/deploy_ns1.md
+++ b/docs/deploy_ns1.md
@@ -10,6 +10,8 @@ The EKS setup is identical to [Route53 tutorial](deploy_route53.md)
 
 Terraform code for cluster reference setup can be found [here](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/route53)
 
+For additional configuration options please check [External DNS's documentation](https://kubernetes-sigs.github.io/external-dns/v0.14.0/tutorials/ns1/)
+
 ## Deploy k8gb
 
 Use `helm` to deploy stable release from Helm repo

--- a/docs/examples/ns1/k8gb-cluster-ns1-eu-west-1.yaml
+++ b/docs/examples/ns1/k8gb-cluster-ns1-eu-west-1.yaml
@@ -2,12 +2,26 @@ k8gb:
   dnsZones:
     - loadBalancedZone: "test.k8gb.io" # -- dnsZone controlled by gslb
       parentZone: "k8gb.io" # -- main zone which would contain gslb zone to delegate
-  edgeDNSServer: "169.254.169.253" # external DNS server to be used for resolution
+  edgeDNSServers:
+    - "169.254.169.253" # external DNS server to be used for resolution
   clusterGeoTag: "eu-west-1" # used for places where we need to distinguish between differnet Gslb instances
   extGslbClustersGeoTags: "us-east-1" # comma-separated list of external gslb geo tags to pair with
 
-ns1:
+extdns:
   enabled: true
+  fullnameOverride: "k8gb-external-dns"
+  provider:
+    name: ns1
+  txtPrefix: "k8gb-eu-west-1-"
+  txtOwnerId: "k8gb-test.k8gb.io-eu-west-1"
+  domainFilters:
+    - k8gb.io
+  env:
+    - name: NS1_APIKEY
+      valueFrom:
+        secretKeyRef:
+          name: ns1
+          key: apiKey
 
 coredns:
   serviceType: LoadBalancer

--- a/docs/examples/ns1/k8gb-cluster-ns1-us-east-1.yaml
+++ b/docs/examples/ns1/k8gb-cluster-ns1-us-east-1.yaml
@@ -2,13 +2,27 @@ k8gb:
   dnsZones:
     - loadBalancedZone: "test.k8gb.io" # -- dnsZone controlled by gslb
       parentZone: "k8gb.io" # -- main zone which would contain gslb zone to delegate
-  edgeDNSServer: "169.254.169.253" # external DNS server to be used for resolution
+  edgeDNSServers:
+    - "169.254.169.253" # external DNS server to be used for resolution
   clusterGeoTag: "us-east-1" # used for places where we need to distinguish between differnet Gslb instances
   extGslbClustersGeoTags: "eu-west-1" # comma-separated list of external gslb geo tags to pair with
 
-ns1:
+extdns:
   enabled: true
-  ignoreSSL: false
+  fullnameOverride: "k8gb-external-dns"
+  provider:
+    name: ns1
+  txtPrefix: "k8gb-us-east-1-"
+  txtOwnerId: "k8gb-test.k8gb.io-us-east-1"
+  domainFilters:
+    - k8gb.io
+  env:
+    - name: NS1_APIKEY
+      valueFrom:
+        secretKeyRef:
+          name: ns1
+          key: apiKey
+
 coredns:
   serviceType: LoadBalancer
   service:


### PR DESCRIPTION
Similarly to what we did with AWS Route53 (#1856), we are migrating the configuration of other DNS providers to the upstream helm chart of external dns. This PR does this migration for NS1.

The ns1 configuration is removed from the k8gb helm chart, and the examples are adapted with the equivalent configuration using the upstream external dns helm chart.

k8gb's helm chart also allowed to ignoreSSL, which can be achieved with the following configuration:
```
  extraArgs:
    ns1-ignoressl:
```

For additional options, please refer to: https://kubernetes-sigs.github.io/external-dns/v0.14.0/tutorials/ns1/

---

To check it for yourself, run the following commands on master and on this branch (the configuration is equivalent, only some labels differ):
```
cd chart/k8gb/
helm template . -f ../../docs/examples/ns1/k8gb-cluster-ns1-eu-west-1.yaml --include-crds > after.yaml
```
