### PR TITLE
Deprecate configuration of GSLB resources via annotations

### DIFF
--- a/adr/0000-template.md
+++ b/adr/0000-template.md
@@ -1,0 +1,40 @@
+# ADR-0000: [Title]
+
+## Status
+
+[Proposed/Accepted/Deprecated/Superseded]
+
+## Date
+
+[YYYY-MM-DD]
+
+## Context
+
+[Describe the situation that led to this decision. What problem are we trying to solve? What constraints exist?]
+
+## Decision
+
+[Describe the decision that was made. Be specific and clear about what was chosen.]
+
+## Consequences
+
+### Positive
+
+- [List positive consequences]
+
+### Negative
+
+- [List negative consequences or trade-offs]
+
+### Neutral
+
+- [List neutral consequences or notes]
+
+## Alternatives
+
+[Describe other options that were considered and why they were rejected]
+
+## References
+
+- [Link to relevant documentation, discussions, or code]
+- [Link to related issues or pull requests]

--- a/adr/0001-deprecate-configuration-of-gslb-resources-via-annotations.md
+++ b/adr/0001-deprecate-configuration-of-gslb-resources-via-annotations.md
@@ -1,0 +1,32 @@
+# ADR-0001: Deprecate configuration of GSLB resources via annotations
+
+## Status
+
+Accepted
+
+## Date
+
+2025-08-29
+
+## Context
+
+When k8gb only supported ingress integration using Ingress resources, there were two ways the strategy for an application could be configured: creating a GSLB resouce or annotating an Ingress resource
+
+With the introduction of new ingress integrations, it triggered the question whether both configuration methods should be supported, or only one of them
+
+## Decision
+
+We will only support configuration using a GSLB resource. Ingress annotations will be deprecated and removed in k8gb v0.17
+
+## Consequences
+
+### Positive
+
+- Smaller code base, easier to maintain
+- Removed source of bugs since it was not clear which configuration method is the source of truth:
+  - If GSLB is the source of truth and someone tweaks an Ingress annotation, should that change be pushed back into the GSLB or should the annotation be overwritten?
+  - Conversely, if a GSLB was created from annotations, what takes precedence later — editing the GSLB or editing the annotations?
+
+### Negative
+
+- Configuring k8gb using annotations is very user friendly

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,69 @@
+# Architectural Decision Records (ADRs)
+
+This directory contains Architectural Decision Records (ADRs) for the k8gb project. ADRs are documents that capture important architectural decisions made during the project's development, along with their context, consequences, and rationale.
+
+## ADR Index
+
+- [ADR-0000: Template](0000-template.md) - Template for new ADRs
+- [ADR-0001: Deprecate Configuration of GSLB resources via annotations](0001-deprecate-configuration-of-gslb-resources-via-annotations.md) - GSLB configuration
+
+## What are ADRs?
+
+Architectural Decision Records are short text documents that capture a single architecture decision. They help teams:
+
+- Understand why certain decisions were made
+- Avoid repeating discussions about already-solved problems
+- Provide context for future architectural changes
+- Onboard new team members to the project's architecture
+
+## ADR Format
+
+Each ADR follows this structure:
+
+- **ADR-0001**: Sequential number for the decision
+- **Title**: Short, descriptive title
+- **Status**: Current status (Proposed, Accepted, Deprecated, Superseded)
+- **Date**: When the decision was made
+- **Context**: The situation that led to the decision
+- **Decision**: What was decided
+- **Consequences**: What happens as a result, both positive and negative
+- **Alternatives**: Other options that were considered
+- **References**: Links to relevant documentation, discussions, or code
+
+## Creating a New ADR
+
+1. Copy the template from `0000-template.md`
+2. Rename it to the next sequential number (e.g., `0001-example-decision.md`)
+3. Fill in all sections
+4. Submit a pull request for review
+
+## ADR Status Values
+
+- **Proposed**: Decision is under discussion and review
+- **Accepted**: Decision has been made and implemented
+- **Deprecated**: Decision is no longer relevant
+- **Superseded**: Replaced by a newer ADR
+
+## When to Create an ADR
+
+Create an ADR when making decisions about:
+
+- Architecture patterns and designs
+- Technology choices
+- API design decisions
+- Data model changes
+- Integration approaches
+- Performance optimizations
+- Security implementations
+
+## Examples
+
+- ADR-0001: Use Go modules for dependency management
+- ADR-0002: Implement controller-runtime pattern for Kubernetes operators
+- ADR-0003: Choose CoreDNS as the DNS provider interface
+
+## References
+
+- [ADR GitHub Repository](https://github.com/joelparkerhenderson/architecture_decision_record)
+- [ADR Tools](https://adr.github.io/)
+- [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)

--- a/controllers/handlers.go
+++ b/controllers/handlers.go
@@ -89,6 +89,11 @@ func (g *IngressHandler) isK8gbAnnotated(obj client.Object) bool {
 }
 
 func (g *IngressHandler) createGslbFromIngress(ing client.Object, scheme *runtime.Scheme) *k8gbv1beta1.Gslb {
+	log.Warn().
+		Str("ingress", ing.GetName()).
+		Msg("Configuration GSLB resources via Ingress annotations is deprecated. " +
+			"This feature will be removed in k8gb v0.17. Please explicitly define a GSLB resource instead")
+
 	strategy := ing.GetAnnotations()[strategyAnnotation]
 	objectKey := client.ObjectKey{Namespace: ing.GetNamespace(), Name: ing.GetName()}
 	log.Info().


### PR DESCRIPTION
The introduction of an ingress integration with Service resources triggered the discussion about GSLB configuration (https://github.com/k8gb-io/k8gb/pull/2029#discussion_r2288799279). After discussion between the maintainers, we decided to deprecate this feature and remove it in k8gb v0.17.0

I also introduced an Architectural Decision Record folder to track such decisions. I believe our future selves will appreciate it one day.