### PR TITLE
Move Cloudflare configuration to external-dns

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -63,9 +63,6 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 | azuredns.createAuthSecret.useWorkloadIdentityExtension | bool | `false` | Use AKS workload identity extension |
 | azuredns.createAuthSecret.userAssignedIdentityID | string | `"myUserAssignedIdentityID"` | Client id from the Managed identitty when using the AAD Pod Identities |
 | azuredns.enabled | bool | `false` |  |
-| cloudflare.dnsRecordsPerPage | int | `5000` | Configure how many DNS records to fetch per request see https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#throttling |
-| cloudflare.enabled | bool | `false` | Enable Cloudflare provider |
-| cloudflare.zoneID | string | `"replaceme"` | Cloudflare Zone ID follow https://developers.cloudflare.com/fundamentals/setup/find-account-and-zone-ids/ to find your zoneID value |
 | coredns.corefile | object | `{"enabled":true,"reload":{"enabled":true,"interval":"30s","jitter":"15s"}}` | CoreDNS configmap |
 | coredns.corefile.reload | object | `{"enabled":true,"interval":"30s","jitter":"15s"}` | Reload CoreDNS configmap when it changes https://coredns.io/plugins/reload/ |
 | coredns.deployment.skipConfig | bool | `true` | Skip CoreDNS creation and uses the one shipped by k8gb instead |

--- a/chart/k8gb/templates/_helpers.tpl
+++ b/chart/k8gb/templates/_helpers.tpl
@@ -69,9 +69,6 @@ Create the name of the service account to use
 {{- if .Values.azuredns.enabled }}
 {{- print "azure-dns" -}}
 {{- end -}}
-{{- if .Values.cloudflare.enabled }}
-{{- print "cloudflare" -}}
-{{- end -}}
 {{- end -}}
 
 {{- define "k8gb.extdnsOwnerID" -}}
@@ -138,17 +135,6 @@ k8gb-{{ index (split ":" (index (split ";" (include "k8gb.dnsZonesString" .)) "_
             secretKeyRef:
               name: rfc2136
               key: secret
-{{- end -}}
-{{- if .Values.cloudflare.enabled -}}
-        - --zone-id-filter={{ .Values.cloudflare.zoneID }}
-        - --cloudflare-dns-records-per-page={{
-          .Values.cloudflare.dnsRecordsPerPage | default 5000 }}
-        env:
-        - name: CF_API_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: cloudflare
-              key: token
 {{- end -}}
 {{- end -}}
 {{- define "k8gb.metrics_port" -}}

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
                   name: infoblox
                   key: INFOBLOX_WAPI_PASSWORD
             {{- end }}
-            {{- if or .Values.extdns.enabled .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+            {{- if or .Values.extdns.enabled .Values.rfc2136.enabled .Values.azuredns.enabled }}
             - name: EXTDNS_ENABLED
               value: "true"
             {{- end }}

--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+{{- if or .Values.rfc2136.enabled .Values.azuredns.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rfc2136.enabled .Values.azuredns.enabled .Values.cloudflare.enabled }}
+{{- if or .Values.rfc2136.enabled .Values.azuredns.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -32,9 +32,6 @@
                 "azuredns": {
                     "$ref": "#/definitions/AzureDNS"
                 },
-                "cloudflare": {
-                    "$ref": "#/definitions/Cloudflare"
-                },
                 "openshift": {
                     "$ref": "#/definitions/Openshift"
                 },
@@ -771,26 +768,6 @@
                 "enabled"
             ],
             "title": "azuredns"
-        },
-        "Cloudflare": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "dnsRecordsPerPage": {
-                    "type": "integer"
-                },
-                "zoneID": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "enabled",
-                "zoneID"
-            ],
-            "title": "Cloudflare"
         },
         "Tracing": {
             "type": "object",

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -252,17 +252,6 @@ azuredns:
     # -- Use AKS workload identity extension
     useWorkloadIdentityExtension: false
 
-cloudflare:
-  # -- Enable Cloudflare provider
-  enabled: false
-  # -- Cloudflare Zone ID
-  # follow https://developers.cloudflare.com/fundamentals/setup/find-account-and-zone-ids/
-  # to find your zoneID value
-  zoneID: replaceme
-  # -- Configure how many DNS records to fetch per request
-  # see https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#throttling
-  dnsRecordsPerPage: 5000
-
 openshift:
   # -- Install OpenShift specific RBAC
   enabled: false

--- a/docs/deploy_cloudflare.md
+++ b/docs/deploy_cloudflare.md
@@ -37,22 +37,21 @@ k8gb:
 
 ### Cloudflare-specific configuration
 
-Let's look closer at the Cloudflare section of the configuration examples.
-
+The example linked above shows how to configure a `zone-id-filter` and the number of `cloudflare-dns-records-per-page`.
 ```yaml
-cloudflare:
-  # -- Enable Cloudflare provider
-  enabled: true
-  # -- Cloudflare Zone ID
-  zoneID: cdebf92e613133e4bb176a14a9c5b730
-  # -- Configure how many DNS records to fetch per request
-  # see https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#throttling
-  dnsRecordsPerPage: 5000
+extdns:
+  ...
+  extraArgs
+    # -- Cloudflare Zone ID
+    zone-id-filter: "cdebf92e613133e4bb176a14a9c5b730"
+    # -- Configure how many DNS records to fetch per request
+    # see https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#throttling
+    cloudflare-dns-records-per-page: "5000"
 ```
 
-Follow
-https://developers.cloudflare.com/fundamentals/setup/find-account-and-zone-ids/
-to find your `zoneID`
+For additional configuration options please refer to [External DNS's documentation](https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/cloudflare/)
+
+To find your `zoneID` follow: https://developers.cloudflare.com/fundamentals/setup/find-account-and-zone-ids/
 
 ### Install the k8gb helm chart in each cluster
 
@@ -88,8 +87,7 @@ spec:
   resourceRef:
     apiVersion: networking.k8s.io/v1
     kind: Ingress
-    matchLabels:
-      app: test-gslb-failover
+    name: test-gslb-failover
   strategy:
     dnsTtlSeconds: 60 # Minimum for non-Enterprise Cloudflare https://developers.cloudflare.com/dns/manage-dns-records/reference/ttl/
     primaryGeoTag: eu

--- a/docs/deploy_ns1.md
+++ b/docs/deploy_ns1.md
@@ -10,7 +10,7 @@ The EKS setup is identical to [Route53 tutorial](deploy_route53.md)
 
 Terraform code for cluster reference setup can be found [here](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/route53)
 
-For additional configuration options please check [External DNS's documentation](https://kubernetes-sigs.github.io/external-dns/v0.14.0/tutorials/ns1/)
+For additional configuration options please check [External DNS's documentation](https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/ns1/)
 
 ## Deploy k8gb
 

--- a/docs/examples/cloudflare/k8gb-cluster-cloudflare-eu.yaml
+++ b/docs/examples/cloudflare/k8gb-cluster-cloudflare-eu.yaml
@@ -7,11 +7,24 @@ k8gb:
   # -- comma-separated list of external gslb geo tags to pair with
   extGslbClustersGeoTags: "us"
 
-cloudflare:
-  # -- Enable Cloudflare provider
+extdns:
   enabled: true
-  # -- Cloudflare Zone ID
-  zoneID: cdebf92e613133e4bb176a14a9c5b730
-  # -- Configure how many DNS records to fetch per request
-  # see https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#throttling
-  dnsRecordsPerPage: 5000
+  fullnameOverride: "k8gb-external-dns"
+  provider:
+    name: cloudflare
+  txtPrefix: k8gb-eu-
+  txtOwnerId: k8gb-cloudflare-test.k8gb.io-eu
+  domainFilters:
+    - k8gb.io
+  env:
+    - name: CF_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: cloudflare
+          key: token
+  extraArgs:
+    # -- Configure how many DNS records to fetch per request
+    # see https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#throttling
+    cloudflare-dns-records-per-page: "5000"
+    # -- Cloudflare Zone ID
+    zone-id-filter: "cdebf92e613133e4bb176a14a9c5b730"

--- a/docs/examples/cloudflare/k8gb-cluster-cloudflare-us.yaml
+++ b/docs/examples/cloudflare/k8gb-cluster-cloudflare-us.yaml
@@ -7,11 +7,23 @@ k8gb:
   # -- comma-separated list of external gslb geo tags to pair with
   extGslbClustersGeoTags: "eu"
 
-cloudflare:
-  # -- Enable Cloudflare provider
+extdns:
   enabled: true
-  # -- Cloudflare Zone ID
-  zoneID: cdebf92e613133e4bb176a14a9c5b730
-  # -- Configure how many DNS records to fetch per request
-  # see https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#throttling
-  dnsRecordsPerPage: 5000
+  provider:
+    name: cloudflare
+  txtPrefix: k8gb-us-
+  txtOwnerId: k8gb-cloudflare-test.k8gb.io-us
+  domainFilters:
+    - k8gb.io
+  env:
+    - name: CF_API_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: cloudflare
+          key: token
+  extraArgs:
+    # -- Configure how many DNS records to fetch per request
+    # see https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md#throttling
+    cloudflare-dns-records-per-page: "5000"
+    # -- Cloudflare Zone ID
+    zone-id-filter: "cdebf92e613133e4bb176a14a9c5b730"

--- a/docs/examples/cloudflare/test-gslb-failover.yaml
+++ b/docs/examples/cloudflare/test-gslb-failover.yaml
@@ -4,8 +4,6 @@ kind: Ingress
 metadata:
   name: test-gslb-failover
   namespace: test-gslb
-  labels:
-    app: test-gslb-failover
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
Similarly to what we did with AWS Route53 (#1856) and NS1 (#2042), we are migrating the configuration of DNS providers to the upstream helm chart of external dns. This PR does this migration for Cloudflare.

The cloudfloare configuration is removed from the k8gb helm chart, and the examples are adapted with the equivalent configuration using the upstream external dns helm chart.

As linked in the docs update, any cloudflare options can now be used without any changes to k8gb's helm chart as long as they are supported by external dns (https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/cloudflare/)

---

To check it for yourself, run the following commands on master and on this branch (the configuration is equivalent, only some labels differ):
```
cd chart/k8gb/
helm template . -f ../../docs/examples/cloudflare/k8gb-cluster-cloudflare-eu.yaml --include-crds > manifests.yaml
```