### PR TITLE
Move Azure DNS configuration to external-dns's upstream chart

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -52,17 +52,6 @@ For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| azuredns.authSecretName | string | `"external-dns-secret-azure"` | External-dns secret name which contains Azure credentials. See https://github.com/k8gb-io/external-dns/blob/master/docs/tutorials/azure.md#configuration-file for expected format |
-| azuredns.createAuthSecret.aadClientId | string | `"myAadClientId"` | Azure client ID that is associated with the Service Principal. |
-| azuredns.createAuthSecret.aadClientSecret | string | `"myAadClientSecret"` | Azure client secret that is associated with the Service Principal. |
-| azuredns.createAuthSecret.enabled | bool | `true` | Create an authentication secret for Azure DNS based on the values below alternatively, you can create the secret manually and pass its name in the `azuredns.authSecretName` value |
-| azuredns.createAuthSecret.resourceGroup | string | `"myDnsResourceGroup"` | Azure Resource Group which holds the Azure DNS Zone (which is defined as 'k8gb.edgeDNSZone') |
-| azuredns.createAuthSecret.subscriptionId | string | `"mySubscriptionId"` | subscription id which holds the Azure DNS zone |
-| azuredns.createAuthSecret.tenantId | string | `"myTenantId"` | Azure tenant ID which holds the managed identity |
-| azuredns.createAuthSecret.useManagedIdentityExtension | bool | `false` | Use either AKS Kubelet Identity or AAD Pod Identities |
-| azuredns.createAuthSecret.useWorkloadIdentityExtension | bool | `false` | Use AKS workload identity extension |
-| azuredns.createAuthSecret.userAssignedIdentityID | string | `"myUserAssignedIdentityID"` | Client id from the Managed identitty when using the AAD Pod Identities |
-| azuredns.enabled | bool | `false` |  |
 | coredns.corefile | object | `{"enabled":true,"reload":{"enabled":true,"interval":"30s","jitter":"15s"}}` | CoreDNS configmap |
 | coredns.corefile.reload | object | `{"enabled":true,"interval":"30s","jitter":"15s"}` | Reload CoreDNS configmap when it changes https://coredns.io/plugins/reload/ |
 | coredns.deployment.skipConfig | bool | `true` | Skip CoreDNS creation and uses the one shipped by k8gb instead |

--- a/chart/k8gb/templates/_helpers.tpl
+++ b/chart/k8gb/templates/_helpers.tpl
@@ -66,9 +66,6 @@ Create the name of the service account to use
 {{- if .Values.rfc2136.enabled }}
 {{- print "rfc2136" -}}
 {{- end -}}
-{{- if .Values.azuredns.enabled }}
-{{- print "azure-dns" -}}
-{{- end -}}
 {{- end -}}
 
 {{- define "k8gb.extdnsOwnerID" -}}
@@ -94,9 +91,6 @@ k8gb-{{ index (split ":" (index (split ";" (include "k8gb.dnsZonesString" .)) "_
 {{- end }}
 
 {{- define "k8gb.extdnsProviderOpts" -}}
-{{- if .Values.azuredns.enabled -}}
-        - --azure-resource-group={{ .Values.azuredns.resourceGroup }}
-{{- end }}
 {{- if and (eq .Values.rfc2136.enabled true) (eq .Values.rfc2136.rfc2136auth.insecure.enabled true) -}}
         - --rfc2136-insecure
 {{- end -}}
@@ -139,25 +133,4 @@ k8gb-{{ index (split ":" (index (split ";" (include "k8gb.dnsZonesString" .)) "_
 {{- end -}}
 {{- define "k8gb.metrics_port" -}}
 {{ print (split ":" .Values.k8gb.metricsAddress)._1 }}
-{{- end -}}
-
-{{- define "external-dns.azure-credentials" -}}
-{{- if and (eq .Values.azuredns.enabled true) (eq .Values.azuredns.createAuthSecret.enabled true) -}}
-{
-  "tenantId": "{{ .Values.azuredns.createAuthSecret.tenantId }}",
-  "subscriptionId": "{{ .Values.azuredns.createAuthSecret.subscriptionId }}",
-  "resourceGroup": "{{ .Values.azuredns.createAuthSecret.resourceGroup }}",
-  {{- if .Values.azuredns.createAuthSecret.aadClientId }}
-  "aadClientId": "{{ .Values.azuredns.createAuthSecret.aadClientId }}",
-  {{- end }}
-  {{- if .Values.azuredns.createAuthSecret.aadClientSecret }}
-  "aadClientSecret": "{{ .Values.azuredns.createAuthSecret.aadClientSecret }}",
-  {{- end }}
-  "useManagedIdentityExtension": {{ .Values.azuredns.createAuthSecret.useManagedIdentityExtension | default false }},
-  {{- if .Values.azuredns.createAuthSecret.userAssignedIdentityID }}
-  "userAssignedIdentityID": "{{ .Values.azuredns.createAuthSecret.userAssignedIdentityID }}",
-  {{- end }}
-  "useWorkloadIdentityExtension": {{ .Values.azuredns.createAuthSecret.useWorkloadIdentityExtension | default false }}
-}
-{{- end -}}
 {{- end -}}

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
                   name: infoblox
                   key: INFOBLOX_WAPI_PASSWORD
             {{- end }}
-            {{- if or .Values.extdns.enabled .Values.rfc2136.enabled .Values.azuredns.enabled }}
+            {{- if or .Values.extdns.enabled .Values.rfc2136.enabled }}
             - name: EXTDNS_ENABLED
               value: "true"
             {{- end }}

--- a/chart/k8gb/templates/external-dns/external-dns-azure-auth.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns-azure-auth.yaml
@@ -1,9 +1,0 @@
-{{- if and .Values.azuredns.enabled .Values.azuredns.createAuthSecret.enabled }}
-apiVersion: v1
-kind: Secret
-type: Opaque
-metadata:
-  name: {{ .Values.azuredns.authSecretName | default "external-dns-secret-azure" }}
-data:
-  azure.json: {{ include "external-dns.azure-credentials" . | b64enc }}
-{{- end }}

--- a/chart/k8gb/templates/external-dns/external-dns.yaml
+++ b/chart/k8gb/templates/external-dns/external-dns.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rfc2136.enabled .Values.azuredns.enabled }}
+{{- if .Values.rfc2136.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -70,15 +70,5 @@ spec:
         {{- with .Values.externaldns.extraVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- end }}
-      {{- if .Values.azuredns.enabled }}
-        volumeMounts:
-          - name: azure-config-file
-            mountPath: /etc/kubernetes/
-            readOnly: true
-      volumes:
-        - name: azure-config-file
-          secret:
-            secretName: {{ .Values.azuredns.authSecretName | default "external-dns-secret-azure" }}
       {{- end }}
 {{- end }}

--- a/chart/k8gb/templates/external-dns/rbac.yaml
+++ b/chart/k8gb/templates/external-dns/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.rfc2136.enabled .Values.azuredns.enabled }}
+{{- if .Values.rfc2136.enabled }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -29,9 +29,6 @@
                 "rfc2136": {
                     "$ref": "#/definitions/Rfc2136"
                 },
-                "azuredns": {
-                    "$ref": "#/definitions/AzureDNS"
-                },
                 "openshift": {
                     "$ref": "#/definitions/Openshift"
                 },
@@ -713,61 +710,6 @@
                 }
             },
             "title": "Rfc2136authGssTsigCreds"
-        },
-        "AzureDNS": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "enabled": {
-                    "type": "boolean"
-                },
-                "authSecretName": {
-                    "type": "string",
-                    "default": "external-dns-secret-azure"
-                },
-                "createAuthSecret": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
-                        },
-                        "tenantId": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "subscriptionId": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "resourceGroup": {
-                            "type": "string",
-                            "minLength": 1
-                        },
-                        "aadClientId": {
-                            "type": "string"
-                        },
-                        "aadClientSecret": {
-                            "type": "string"
-                        },
-                        "useManagedIdentityExtension": {
-                            "type": "boolean",
-                            "default": false
-                        },
-                        "userAssignedIdentityID": {
-                            "type": "string"
-                        },
-                        "useWorkloadIdentityExtension": {
-                            "type": "boolean",
-                            "default": false
-                        }
-                    }
-                }
-            },
-            "required": [
-                "enabled"
-            ],
-            "title": "azuredns"
         },
         "Tracing": {
             "type": "object",

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -226,32 +226,6 @@ rfc2136:
         - kerberos-password: ad-user-pass
         - kerberos-realm: ad-domain-realm
 
-azuredns:
-  enabled: false
-  # -- External-dns secret name which contains Azure credentials.
-  # See https://github.com/k8gb-io/external-dns/blob/master/docs/tutorials/azure.md#configuration-file for expected format
-  authSecretName: external-dns-secret-azure
-  createAuthSecret:
-    # -- Create an authentication secret for Azure DNS based on the values below
-    # alternatively, you can create the secret manually and pass its name in the `azuredns.authSecretName` value
-    enabled: true
-    # -- Azure tenant ID which holds the managed identity
-    tenantId: myTenantId
-    # -- subscription id which holds the Azure DNS zone
-    subscriptionId: mySubscriptionId
-    # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'k8gb.edgeDNSZone')
-    resourceGroup: myDnsResourceGroup
-    # -- Azure client ID that is associated with the Service Principal.
-    aadClientId: myAadClientId
-    # -- Azure client secret that is associated with the Service Principal.
-    aadClientSecret: myAadClientSecret
-    # -- Use either AKS Kubelet Identity or AAD Pod Identities
-    useManagedIdentityExtension: false
-    # -- Client id from the Managed identitty when using the AAD Pod Identities
-    userAssignedIdentityID: myUserAssignedIdentityID
-    # -- Use AKS workload identity extension
-    useWorkloadIdentityExtension: false
-
 openshift:
   # -- Install OpenShift specific RBAC
   enabled: false

--- a/docs/deploy_azuredns.md
+++ b/docs/deploy_azuredns.md
@@ -2,10 +2,6 @@
 
 This document outlines how to configure k8gb to use the Azure Public DNS provider. Azure Private DNS is not supported as it does not support NS records at this time. For private DNS scenarios in Azure, please refer to the [Windows DNS](deploy_windowsdns.md) documentation and consider implementing it using VM-based DNS services such as Windows DNS or BIND.
 
-### external-dns credentials for Azure DNS
-
-In this example, we will use a registered app in Microsoft Entra ID and it's corresponding Client ID / Client Secret to authenticate with the Azure DNS zone. All of the [supported authentication fields supported by external-dns](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md#configuration-file) are supported by k8gb and can be used in the `azuredns` section of the `k8gb` Helm chart values.yaml file.
-
 ## Sample solution
 
 In this sample solution we will deploy two private AKS clusters in different regions. A workload will be deployed to both clusters and exposed to the internet with the help of k8gb and Azure Public DNS.
@@ -52,6 +48,10 @@ This action will install K8gb in both clusters using the provided [sample](https
 ```sh
 make deploy-k8gb
 ```
+
+### Deploy the credentials for Azure DNS
+
+In this example, we can use a registered app in Microsoft Entra ID and it's corresponding Client ID / Client Secret to authenticate with the Azure DNS zone. Deploy on both clusters a secret called `external-dns-secret-azure` following [External DNS's documentation](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md#configuration-file).
 
 ### Install demo app
 

--- a/docs/examples/azure/k8gb/aks1-helm-values.yaml
+++ b/docs/examples/azure/k8gb/aks1-helm-values.yaml
@@ -5,7 +5,7 @@ k8gb:
       parentZone: "k8gb-kubeconeu2023.com" # -- main zone which would contain gslb zone to delegate
       dnsZoneNegTTL: 300 # -- Negative TTL for SOA record
   # -- host/ip[:port] format is supported here where port defaults to 53
-  parentZoneDNSServers:
+  edgeDNSServers:
     # -- use these DNS server as a main resolver to enable cross k8gb DNS based communication
     - "1.1.1.1"
     - "8.8.8.8"
@@ -16,19 +16,23 @@ k8gb:
   # -- Reconcile time in seconds
   reconcileRequeueSeconds: 10
 
-externaldns:
-  interval: "10s"
-
-azuredns:
-  # -- Enable Azure DNS provider
+extdns:
   enabled: true
-  # -- Azure tenant ID which holds the managed identity
-  createAuthSecret:
-    enabled: true
-    tenantId: myTenantID
-    # -- subscription id which holds the Azure DNS zone
-    subscriptionId: mySubscriptionID
-    # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'edgeDNSZone')
-    resourceGroup: k8gb-kubeconeu2023
-    aadClientId: myAADClientID
-    aadClientSecret: myAADClientSecret
+  fullnameOverride: "k8gb-external-dns"
+  provider:
+    name: azure-dns
+  txtPrefix: "k8gb-uksouth-"
+  txtOwnerId: "k8gb-demo.k8gb-kubeconeu2023.com-uksouth"
+  domainFilters:
+    - k8gb-kubeconeu2023.com
+  extraVolumes:
+    - name: azure-config-file
+      secret:
+        secretName: external-dns-secret-azure
+  extraVolumeMounts:
+    - name: azure-config-file
+      mountPath: /etc/kubernetes/
+      readOnly: true
+  extraArgs:
+    azure-resource-group: k8gb-kubeconeu2023
+  interval: "10s"

--- a/docs/examples/azure/k8gb/aks2-helm-values.yaml
+++ b/docs/examples/azure/k8gb/aks2-helm-values.yaml
@@ -4,7 +4,7 @@ k8gb:
       parentZone: "k8gb-kubeconeu2023.com" # -- main zone which would contain gslb zone to delegate
       dnsZoneNegTTL: 300 # -- Negative TTL for SOA record
   # -- host/ip[:port] format is supported here where port defaults to 53
-  parentZoneDNSServers:
+  edgeDNSServers:
     # -- use these DNS server as a main resolver to enable cross k8gb DNS based communication
     - "1.1.1.1"
     - "8.8.8.8"
@@ -15,18 +15,23 @@ k8gb:
   # -- Reconcile time in seconds
   reconcileRequeueSeconds: 10
 
-externaldns:
-  interval: "10s"
-
-azuredns:
-  # -- Enable Azure DNS provider
+extdns:
   enabled: true
-  createAuthSecret:
-    enabled: true
-    tenantId: myTenantID
-    # -- subscription id which holds the Azure DNS zone
-    subscriptionId: mySubscriptionID
-    # -- Azure Resource Group which holds the Azure DNS Zone (which is defined as 'edgeDNSZone')
-    resourceGroup: k8gb-kubeconeu2023
-    aadClientId: myAADClientID
-    aadClientSecret: myAADClientSecret
+  fullnameOverride: "k8gb-external-dns"
+  provider:
+    name: azure-dns
+  txtPrefix: "k8gb-francecentral-"
+  txtOwnerId: "k8gb-demo.k8gb-kubeconeu2023.com-francecentral"
+  domainFilters:
+    - k8gb-kubeconeu2023.com
+  extraVolumes:
+    - name: azure-config-file
+      secret:
+        secretName: external-dns-secret-azure
+  extraVolumeMounts:
+    - name: azure-config-file
+      mountPath: /etc/kubernetes/
+      readOnly: true
+  extraArgs:
+    azure-resource-group: k8gb-kubeconeu2023
+  interval: "10s"


### PR DESCRIPTION
Similarly to what we did with AWS Route53 (#1856), NS1 (#2042) and Cloudflare (#2045), we are migrating the configuration of Azure DNS to the upstream helm chart of external dns.

The Azure configuration is removed from the k8gb helm chart, and the examples are adapted with the equivalent configuration using the upstream helm chart of external dns.

From now on, any Azure DNS configuration options can now be used without any changes to k8gb's helm chart as long as they are supported by external dns (https://kubernetes-sigs.github.io/external-dns/latest/docs/tutorials/azure/)

---

To check it for yourself, run the following commands on master and on this branch (the configuration is equivalent, only some labels differ):
```
cd chart/k8gb/
helm template . -f ../../docs/examples/azure/k8gb/aks1-helm-values.yaml --include-crds > manifests.yaml
```

---

Note that this PR removes the option of creating credentials directly from the Helm chart. This was not secure for production setups since credentials would be leaked in git. Instead, in the tutorial, we provide a link to external dns's documentation on the topic: https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md#configuration-file