### PR TITLE
Fix missing DNS endpoint CRD causing Infoblox integration failures

### DIFF
--- a/chart/k8gb/crd/dns-endpoint-crd-manifest.yaml
+++ b/chart/k8gb/crd/dns-endpoint-crd-manifest.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-sigs/external-dns/pull/2007"
+  creationTimestamp: null
+  name: dnsendpoints.externaldns.k8s.io
+spec:
+  group: externaldns.k8s.io
+  names:
+    kind: DNSEndpoint
+    listKind: DNSEndpointList
+    plural: dnsendpoints
+    singular: dnsendpoint
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DNSEndpointSpec defines the desired state of DNSEndpoint
+            properties:
+              endpoints:
+                items:
+                  description: Endpoint is a high-level way of a connection between a service and an IP
+                  properties:
+                    dnsName:
+                      description: The hostname of the DNS record
+                      type: string
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels stores labels defined for the Endpoint
+                      type: object
+                    providerSpecific:
+                      description: ProviderSpecific stores provider specific config
+                      items:
+                        description: ProviderSpecificProperty holds the name and value of a configuration which is specific to individual DNS providers
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    recordTTL:
+                      description: TTL for the record
+                      format: int64
+                      type: integer
+                    recordType:
+                      description: RecordType type of record, e.g. CNAME, A, SRV, TXT etc
+                      type: string
+                    setIdentifier:
+                      description: Identifier to distinguish multiple records with the same name and type (e.g. Route53 records with routing policies other than 'simple')
+                      type: string
+                    targets:
+                      description: The targets the DNS record points to
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            description: DNSEndpointStatus defines the observed state of DNSEndpoint
+            properties:
+              observedGeneration:
+                description: The generation observed by the external-dns controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/k8gb/templates/crds-template.yaml
+++ b/chart/k8gb/templates/crds-template.yaml
@@ -1,9 +1,10 @@
 {{- if .Values.k8gb.deployCrds }}
 
 {{- $files := .Files }}
-{{- range tuple "crd/k8gb.absa.oss_gslbs.yaml" "crd/dns-endpoint-crd-manifest.yaml" }}
-{{ $files.Get . }}
+{{ $files.Get "crd/k8gb.absa.oss_gslbs.yaml" }}
 
+{{- if not .Values.extdns.enabled }}
+{{ $files.Get "crd/dns-endpoint-crd-manifest.yaml" }}
 {{- end }}
 
 {{- end }}


### PR DESCRIPTION
## Problem
The k8gb Helm chart’s CRD template (`crds-template.yaml`) references `dns-endpoint-crd-manifest.yaml`, which does not exist in the repository.  
This prevents the **DNSEndpoint CRD** from being installed, leading to runtime errors when k8gb attempts to create DNS endpoint resources.  
The failure is most visible in **Infoblox integrations**, where DNS records cannot be managed without this CRD.  

## Root Cause
The CRD template currently includes:  

```yaml
{{- range tuple "crd/k8gb.absa.oss_gslbs.yaml" "crd/dns-endpoint-crd-manifest.yaml" }}
{{ $files.Get . }}
{{- end }}
```

However, the file dns-endpoint-crd-manifest.yaml is missing.

Impact on Infoblox Integration

- k8gb’s native Infoblox provider (infoblox.enabled: true) depends on DNS endpoint resources
- external-dns with Infoblox also requires the DNSEndpoint CRD


**Solution**

Added the missing dns-endpoint-crd-manifest.yaml file containing the DNSEndpoint CRD definition (sourced from the external-dns project).

This ensures k8gb’s DNS management works correctly with Infoblox and other enterprise DNS providers.

**Note**

While the project team plans to standardize DNS management via external-dns, Infoblox lacks official external-dns support.
This fix ensures Infoblox users can successfully integrate k8gb without encountering missing resource errors.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
