### PR TITLE
Update CONTRIBUTING.md fix cosign 404

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,7 +377,7 @@ compliant with the [in-toto Attestation Framework](https://in-toto.io/Statement/
 
 For signing the artifacts we use [`cosign`](https://github.com/sigstore/cosign) tool with:
 - **Private key**: Stored as repository secret (`COSIGN_PRIVATE_KEY`)
-- **Public key**: Available in [`cosign.pub`](./cosign.pub) file
+- **Public key**: Available in [`cosign.pub`](https://github.com/k8gb-io/k8gb/blob/master/cosign.pub) file
 - **Passphrase**: Stored as repository secret (`COSIGN_PASSWORD`)
 
 To regenerate signing keys:


### PR DESCRIPTION
mkdocs serve                          
INFO    -  Building documentation...
INFO    -  Cleaning site directory
WARNING -  Doc file 'CONTRIBUTING.md' contains a link './cosign.pub', but the target 'cosign.pub' is not found among documentation files.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
