### PR TITLE
General docu improvements

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,4 +1,138 @@
 .md-search {
   max-width: 280px;
-  margin-right: 16px;
+  margin-right: 0 !important;
+}
+
+.md-header__inner.md-grid {
+  max-width: 61rem !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  padding-left: 0 !important;
+  padding-right: 1rem !important;
+  display: flex !important;
+  align-items: center !important;
+  gap: 16px !important;
+}
+
+@media screen and (min-width: 76.25em) {
+  .md-header__inner.md-grid {
+    max-width: 76.25rem !important;
+    padding-left: 7.6rem !important;
+    padding-right: 13.1rem !important;
+  }
+}
+
+@media screen and (min-width: 60em) {
+  .md-header__inner.md-grid {
+    padding-right: 13.1rem !important;
+  }
+}
+
+.md-header__button.md-logo {
+  display: flex !important;
+  flex-shrink: 0 !important;
+  margin: 0 !important;
+  padding: 0.4rem !important;
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+.md-header__button.md-logo .md-logo img,
+.md-header__button.md-logo .md-logo svg {
+  display: block !important;
+  height: 1.2rem !important;
+  width: auto !important;
+}
+
+.md-header__title {
+  display: flex !important;
+  flex: 0 1 auto !important;  
+  opacity: 1 !important;
+  visibility: visible !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  min-width: 0 !important;
+  max-width: 400px !important;  
+}
+
+.md-header__ellipsis {
+  display: flex !important;
+  min-width: 0 !important;
+}
+
+.md-header__topic {
+  display: block !important;
+  opacity: 1 !important;
+  position: static !important;
+  transform: none !important;
+  transition: none !important;
+}
+
+.md-header__topic .md-ellipsis {
+  display: block !important;
+  font-size: 0.8rem !important;
+  white-space: nowrap !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+}
+
+.md-header__option {
+  flex: 0 0 auto !important;
+  margin-left: auto !important;
+  margin-right: 0 !important;
+}
+
+.md-header__source {
+  flex: 0 0 auto !important;
+  margin: 0 !important;
+}
+
+.md-source__repository {
+  max-width: none !important;
+}
+
+.md-footer {
+  background-color: var(--md-primary-fg-color) !important;
+}
+
+.md-footer-meta {
+  background-color: var(--md-primary-fg-color) !important;
+}
+
+.md-footer-copyright {
+  font-size: 0.7rem !important;
+  color: hsla(0, 0%, 100%, 0.87) !important;
+  margin: 0.8rem 0 !important;
+  padding-left: 0 !important;
+}
+
+.md-footer-copyright a {
+  color: hsla(0, 0%, 100%, 0.87) !important;
+  text-decoration: underline;
+}
+
+.md-footer-copyright a:hover {
+  color: white !important;
+}
+
+.md-footer-meta__inner.md-grid {
+  max-width: 61rem !important;
+  margin-left: auto !important;
+  margin-right: auto !important;
+  padding-left: 1rem !important;
+  padding-right: 1rem !important;
+}
+
+@media screen and (min-width: 76.25em) {
+  .md-footer-meta__inner.md-grid {
+    max-width: 76.25rem !important;
+    padding-left: 8.0rem !important;
+    padding-right: 13.1rem !important;
+  }
+}
+
+@media screen and (min-width: 60em) {
+  .md-footer-meta__inner.md-grid {
+    padding-right: 13.1rem !important;
+  }
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,3 +99,7 @@ plugins:
         on_page_markdown: "docs.link_fixer:fix_links"
 extra_css:
   - stylesheets/extra.css
+extra:
+  palette:
+    scheme: default
+copyright: © 2025 The Linux Foundation. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/legal/trademark-usage">Trademark Usage</a> page.

--- a/overrides/partials/footer.html
+++ b/overrides/partials/footer.html
@@ -1,0 +1,11 @@
+<footer class="md-footer">
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-meta__inner md-grid">
+      <div class="md-footer-copyright">
+        {% if config.copyright %}
+          {{ config.copyright }}
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</footer>

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -1,0 +1,48 @@
+<header class="md-header" data-md-component="header">
+  <nav class="md-header__inner md-grid" aria-label="{{ lang.t('header') }}">
+    
+    <a href="{{ config.site_url | d(nav.homepage.url, true) | url }}" title="{{ config.site_name | e }}" class="md-header__button md-logo" aria-label="{{ config.site_name }}" data-md-component="logo">
+      {% include "partials/logo.html" %}
+    </a>
+    
+    <div class="md-header__title" data-md-component="header-title">
+      <div class="md-header__ellipsis">
+        <div class="md-header__topic">
+          <span class="md-ellipsis">
+            {{ config.site_name }}
+          </span>
+        </div>
+      </div>
+    </div>
+
+    {% if config.theme.palette %}
+      {% if not config.theme.palette is mapping %}
+        <form class="md-header__option" data-md-component="palette">
+          {% for option in config.theme.palette %}
+            {% set scheme = option.scheme | d("default", true) %}
+            <input class="md-option" data-md-color-media="{{ option.media }}" data-md-color-scheme="{{ scheme | replace(' ', '-') }}" data-md-color-primary="{{ option.primary | replace(' ', '-') }}" data-md-color-accent="{{ option.accent | replace(' ', '-') }}" {% if option.toggle %} aria-label="{{ option.toggle.name }}" {% else %} aria-hidden="true" {% endif %} type="radio" name="__palette" id="__palette_{{ loop.index }}">
+            {% if option.toggle %}
+              <label class="md-header__button md-icon" title="{{ option.toggle.name }}" for="__palette_{{ loop.index0 or loop.length }}" hidden>
+                {% include ".icons/" ~ option.toggle.icon ~ ".svg" %}
+              </label>
+            {% endif %}
+          {% endfor %}
+        </form>
+      {% endif %}
+    {% endif %}
+
+    {% if "material/search" in config.plugins %}
+      <label class="md-header__button md-icon" for="__search">
+        {% include ".icons/material/magnify.svg" %}
+      </label>
+      {% include "partials/search.html" %}
+    {% endif %}
+
+    {% if config.repo_url %}
+      <div class="md-header__source">
+        {% include "partials/source.html" %}
+      </div>
+    {% endif %}
+
+  </nav>
+</header>

--- a/overrides/partials/source.html
+++ b/overrides/partials/source.html
@@ -1,19 +1,18 @@
-<div style="display: flex; align-items: center; gap: 0;">
-  <!-- Original Material repo link with left margin to center it -->
+<div style="display: flex; align-items: center; gap: 16px;">
+  <!-- Original Material repo link -->
   {% if config.repo_url %}
-    <a href="{{ config.repo_url }}" title="{{ config.repo_name }}" class="md-source" data-md-component="source" style="min-width: 200px; margin-right: 80px;">
+    <a href="{{ config.repo_url }}" title="{{ config.repo_name }}" class="md-source" data-md-component="source">
       <div class="md-source__icon md-icon">
         {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %}
         {% include ".icons/" ~ icon ~ ".svg" %}
       </div>
-      <div class="md-source__repository" style="max-width: none; width: auto;">
+      <div class="md-source__repository">
         {{ config.repo_name }}
       </div>
     </a>
   {% endif %}
-
-  <!-- Your custom star button -->
-  <a href="https://github.com/k8gb-io/k8gb" target="_blank" rel="noopener" style="display: inline-flex; align-items: center; gap: 8px; padding: 8px 16px; background: #24292e; border-radius: 6px; color: white; text-decoration: none; font-size: 0.7rem; font-weight: 500; white-space: nowrap; flex-shrink: 0;">
+  <!-- custom star button matching search bar style -->
+  <a href="https://github.com/k8gb-io/k8gb" target="_blank" rel="noopener" style="display: inline-flex; align-items: center; gap: 4px; padding: 0.5rem 1rem; background: rgba(0, 0, 0, 0.26); border-radius: 0.1rem; color: white; text-decoration: none; font-size: 0.8rem; font-weight: 400; white-space: nowrap; min-height: 1.8rem;">
     <svg viewBox="0 0 16 16" width="16" height="16" fill="currentColor">
       <path d="M8 .25a.75.75 0 01.673.418l1.882 3.815 4.21.612a.75.75 0 01.416 1.279l-3.046 2.97.719 4.192a.75.75 0 01-1.088.791L8 12.347l-3.766 1.98a.75.75 0 01-1.088-.79l.72-4.194L.818 6.374a.75.75 0 01.416-1.28l4.21-.611L7.327.668A.75.75 0 018 .25z"/>
     </svg>


### PR DESCRIPTION
- properly align header
- add trademark in footer (CLO monitor score)
- fix styling on "star project" button to match header

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
