### PR TITLE
RELEASE: v0.16.0

### DIFF
--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -3,8 +3,8 @@ name: k8gb
 description: A Helm chart for Kubernetes Global Balancer
 icon: https://www.k8gb.io/images/k8gb-icon-color.svg
 type: application
-version: v0.15.0
-appVersion: v0.15.0
+version: v0.16.0
+appVersion: v0.16.0
 kubeVersion: ">= 1.21.0-0"
 
 dependencies:

--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -1,6 +1,6 @@
 # k8gb
 
-![Version: v0.15.0](https://img.shields.io/badge/Version-v0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
+![Version: v0.16.0](https://img.shields.io/badge/Version-v0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.16.0](https://img.shields.io/badge/AppVersion-v0.16.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes Global Balancer
 
@@ -38,15 +38,16 @@ Kubernetes: `>= 1.21.0-0`
 | https://coredns.github.io/helm | coredns | 1.44.3 |
 | https://kubernetes-sigs.github.io/external-dns | extdns(external-dns) | 1.19.0 |
 
-For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
+#### Tested Environment Configurations:
 
-#### Compatibility matrix:
+| Type                             | Implementation                                                |
+|----------------------------------|---------------------------------------------------------------|
+| Kubernetes Version               | >= 1.21                                                       |
+| Environment                      | Any conformant Kubernetes cluster on-prem or in cloud         |
+| Ingress Controller               | NGINX, Istio, AWS Load Balancer Controller                    |
+| EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS                  |
 
-| k8gb                           |      <= 0.8.x      | >= 0.9.0           |
-| ------------------------------ | :----------------: | :----------------: |
-| Kubernetes <= 1.18             | :white_check_mark: |        :x:         |
-| Kubernetes >= 1.19 and <= 1.21 | :white_check_mark: | :white_check_mark: |
-| Kubernetes >= 1.22             |        :x:         | :white_check_mark: |
+Note: k8gb is architected to run on top of any compliant Kubernetes cluster and Ingress controller. The table above lists solutions where we have tested and verified k8gb installation.
 
 ## Values
 


### PR DESCRIPTION
Cut quarterly release

Fixes https://github.com/k8gb-io/k8gb/issues/1992 

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
