### PR TITLE
Fix OCI helm publish, enable workflow_dispatch for manual trigger

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -4,6 +4,12 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish (e.g., v0.16.0)'
+        required: true
+        type: string
 permissions:
   contents: read
 
@@ -19,12 +25,17 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
       - uses: dave-mcconnell/helm-gh-pages-microservices@8478af5f0fd712cc0fb59f2c99e0688f3f591287
         with:
           access-token: ${{ secrets.CR_TOKEN }}
           source-charts-folder: 'chart'
           destination-repo: k8gb-io/k8gb
           destination-branch: gh-pages
+
+      - name: Package Helm Chart
+        run: |
+          helm package chart/k8gb --version $(make version)
 
       - name: Push to OCI Registry
         run: |


### PR DESCRIPTION
..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
