### PR TITLE
Temporary disable OCI publish to unblock release

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -33,14 +33,10 @@ jobs:
           destination-repo: k8gb-io/k8gb
           destination-branch: gh-pages
 
-      - name: Package Helm Chart
-        run: |
-          helm package chart/k8gb --version $(make version)
-
-      - name: Push to OCI Registry
-        run: |
-          echo ${{ secrets.CR_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
-          helm push k8gb-*.tgz oci://ghcr.io/k8gb-io/charts
+#      - name: Push to OCI Registry
+#        run: |
+#          echo ${{ secrets.CR_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+#          helm push k8gb-*.tgz oci://ghcr.io/k8gb-io/charts
 
       - name: Create k3s cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79


### PR DESCRIPTION
..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
