### PR TITLE
feat: OCI Registry support fix

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag to publish (e.g., v0.16.0)"
+        description: 'Release tag to publish (e.g., v0.16.0)'
         required: true
         type: string
 permissions:
@@ -17,8 +17,7 @@ jobs:
   publish:
     runs-on: ubuntu-24.04
     env:
-      OCI_REPO: oci://ghcr.io/itsfarhan/charts
-
+      OCI_REPO: oci://ghcr.io/k8gb-io/charts
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -32,8 +31,8 @@ jobs:
       - uses: dave-mcconnell/helm-gh-pages-microservices@8478af5f0fd712cc0fb59f2c99e0688f3f591287
         with:
           access-token: ${{ secrets.CR_TOKEN }}
-          source-charts-folder: "chart"
-          destination-repo: itsfarhan/k8gb
+          source-charts-folder: 'chart'
+          destination-repo: k8gb-io/k8gb
           destination-branch: gh-pages
 
       - name: Push to OCI Registry
@@ -42,7 +41,7 @@ jobs:
           git fetch origin gh-pages
           git checkout origin/gh-pages -- charts/
           ls -la charts/
-          OCI_REPO="${OCI_REPO:-oci://ghcr.io/itsfarhan/charts}"
+          OCI_REPO="${OCI_REPO:-oci://ghcr.io/k8gb-io/charts}"
           for chart in charts/k8gb-*.tgz; do
             if [ -f "$chart" ]; then
               helm push "$chart" "$OCI_REPO"


### PR DESCRIPTION
Previously, while release of v0.16.0 there was a hiccup in deploying OCI registry support. This PR make sure helm charts are retrieved and pushed to OCI registry. I have also added screenshots of testing.

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
