### PR TITLE
Update chart README template for helm-docs

### DIFF
--- a/chart/k8gb/_helm-docs-template.gotmpl
+++ b/chart/k8gb/_helm-docs-template.gotmpl
@@ -23,14 +23,15 @@
 
 {{ template "chart.requirementsSection" . }}
 
-For Kubernetes `< 1.19` use this chart and k8gb in version `0.8.8` or lower.
+#### Tested Environment Configurations:
 
-#### Compatibility matrix:
+| Type                             | Implementation                                                |
+|----------------------------------|---------------------------------------------------------------|
+| Kubernetes Version               | >= 1.21                                                       |
+| Environment                      | Any conformant Kubernetes cluster on-prem or in cloud         |
+| Ingress Controller               | NGINX, Istio, AWS Load Balancer Controller                    |
+| EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS, GCP Cloud DNS   |
 
-| k8gb                           |      <= 0.8.x      | >= 0.9.0           |
-| ------------------------------ | :----------------: | :----------------: |
-| Kubernetes <= 1.18             | :white_check_mark: |        :x:         |
-| Kubernetes >= 1.19 and <= 1.21 | :white_check_mark: | :white_check_mark: |
-| Kubernetes >= 1.22             |        :x:         | :white_check_mark: |
+Note: k8gb is architected to run on top of any compliant Kubernetes cluster and Ingress controller. The table above lists solutions where we have tested and verified k8gb installation.
 
 {{ template "chart.valuesSection" . }}


### PR DESCRIPTION
Fixes the discrepancy issues spotted in https://github.com/k8gb-io/k8gb/pull/2081#pullrequestreview-3367773253

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
