### PR TITLE
dnsEndpoint generation

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -154,7 +154,7 @@ infoblox:
   dnsView: "default"
 
 extdns:
-  enabled: false
+  enabled: true
   interval: 20s
   labelFilter: "k8gb.absa.oss/dnstype=extdns"
   logLevel: debug
@@ -169,8 +169,8 @@ extdns:
   - crd
   domainFilters:
   - "example.com"
-  txtPrefix: "k8gb-<GEOTAG>-"
-  txtOwnerId: "k8gb-<GEOTAG>"
+  txtPrefix: "k8gb-eu-"
+  txtOwnerId: "k8gb-eu"
 
 openshift:
   # -- Install OpenShift specific RBAC


### PR DESCRIPTION
```
➜  ~/code/k8gb-admin/chart/k8gb git:(PS1c0m/dnsEndpoint) helm template . --include-crds | grep -A 10 "CustomResourceDefinition"
walk.go:75: found symbolic link in path: /Users/andreaguas/code/k8gb-admin/chart/k8gb/LICENSE resolves to /Users/andreaguas/code/k8gb-admin/LICENSE. Contents of linked file included and used
kind: CustomResourceDefinition
metadata:
  annotations:
    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/external-dns/pull/2007
  name: dnsendpoints.externaldns.k8s.io
spec:
  group: externaldns.k8s.io
  names:
    kind: DNSEndpoint
    listKind: DNSEndpointList
    plural: dnsendpoints
--
kind: CustomResourceDefinition
metadata:
  annotations:
    controller-gen.kubebuilder.io/version: v0.18.0
  name: gslbs.k8gb.absa.oss
spec:
  group: k8gb.absa.oss
  names:
    kind: Gslb
    listKind: GslbList
    plural: gslbs
```