### PR TITLE
Add(docs): more issues documented in rollback procedures

### DIFF
--- a/docs/rollback_procedures.md
+++ b/docs/rollback_procedures.md
@@ -45,3 +45,41 @@ helm list -n k8gb
 kubectl get pods -n k8gb
 kubectl get gslb -A
 ```
+
+You may also come across issues with CRD conflicts during rollback. If so, follow these steps:
+
+1. **Delete existing CRDs:**
+
+```bash
+kubectl delete crd gslbs.k8gb.io
+kubectl delete crd healthchecks.k8gb.io
+```
+2. **Reinstall previous version:**
+
+```bash
+helm upgrade k8gb k8gb/k8gb --version v0.14.0 -n k8gb -f new-values.yaml
+```
+3. **Verify installation:**
+
+```bash
+helm list -n k8gb
+kubectl get pods -n k8gb
+kubectl get gslb -A
+```
+
+### Alternative: Manual CRD Annotation and Labeling
+```bash
+kubectl annotate crd dnsendpoints.externaldns.k8s.io meta.helm.sh/release-name=k8gb --overwrite
+
+kubectl annotate crd dnsendpoints.externaldns.k8s.io meta.helm.sh/release-namespace=k8gb --overwrite
+
+kubectl label crd dnsendpoints.externaldns.k8s.io app.kubernetes.io/managed-by=Helm --overwrite
+
+helm upgrade k8gb k8gb/k8gb --version v0.14.0 -n k8gb -f new-values.yaml
+```
+This method manually sets the necessary Helm annotations and labels on the CRDs to allow Helm to manage them during the rollback.
+
+You can also fix this by using the `--force` flag with Helm upgrade:
+```bash
+helm upgrade k8gb k8gb/k8gb --version v0.14.0 -n k8gb -f new-values.yaml --force
+```


### PR DESCRIPTION
..
Documented more issues like CRD conflicts fix.

This is part of #1908 and continuation of #2090.  

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
