### PR TITLE
fix(docs): added more rollback procedures

### DIFF
--- a/docs/rollback_procedures.md
+++ b/docs/rollback_procedures.md
@@ -46,7 +46,7 @@ kubectl get pods -n k8gb
 kubectl get gslb -A
 ```
 
-You may also come across issues with CRD conflicts during rollback. If so, follow these steps:
+You may also run into CRD ownership conflicts when downgrading/rolling back, because the CRD already exists but Helm can’t “adopt” it. Since CRDs are cluster-scoped, Helm relies on specific annotations/labels to recognize them as part of the release.
 
 ```bash
 kubectl annotate crd dnsendpoints.externaldns.k8s.io meta.helm.sh/release-name=k8gb --overwrite
@@ -58,8 +58,9 @@ kubectl label crd dnsendpoints.externaldns.k8s.io app.kubernetes.io/managed-by=H
 helm upgrade k8gb k8gb/k8gb --version v0.14.0 -n k8gb -f new-values.yaml
 ```
 This method manually sets the necessary Helm annotations and labels on the CRDs to allow Helm to manage them during the rollback.
-
-You can also fix this by using the `--force` flag with Helm upgrade:
+> NOTE: by rollback, we mean downgrading to the previous version, not specific `helm rollback` functionality 
+If the chart version changes the CRD schema (or conversion webhook behavior), downgrading can still fail even after adoption, because existing CR instances may not validate against the older schema. In that case you may need to align CRD versions more explicitly (or avoid downgrading CRDs altogether).
+You can use --force, but treat it as a last resort because it may replace resources to apply changes.:
 ```bash
 helm upgrade k8gb k8gb/k8gb --version v0.14.0 -n k8gb -f new-values.yaml --force
 ```


### PR DESCRIPTION
Adding more rollback issues in the doc.

Reference to #1908 and #2090 

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
