### PR TITLE
Preflight and docs for localhost:5053/5054 +tcp failures; add DNS LB verification test (#1312)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,6 @@ K8GB_LOCAL_VERSION ?= stable
 # Use `K8GB_LOCAL_VERSION=test make deploy-full-local-setup`
 .PHONY: deploy-full-local-setup
 deploy-full-local-setup: ensure-cluster-size ## Deploy full local multicluster setup (k3d >= 5.1.0)
-	$(MAKE) preflight
 	$(MAKE) create-local-clusters
 
 	@if [ "$(K8GB_LOCAL_VERSION)" = test ]; then $(MAKE) release-images ; fi
@@ -677,33 +676,7 @@ define uninstall-prometheus
 	$(call stop-scraping,"name=k8gb",$1) ;\
 	$(call stop-scraping,"app=external-dns",$1) ;\
 	$(call stop-scraping,"app.kubernetes.io/name=coredns",$1)
-
-.PHONY: preflight
-preflight:
-	@echo -e "\n$(YELLOW)Preflight checks$(NC)"
-	@which k3d >/dev/null 2>&1 || { echo "k3d is required"; exit 1; }
-	@K3D_VER=$$(k3d version | awk '/k3d version/ {print $$3}'); \
-	 if [ -z "$$K3D_VER" ]; then echo "Unable to detect k3d version"; exit 1; fi; \
-	 REQ_VER="v5.3.0"; \
-	 if [ "$$(printf '%s\n' "$$REQ_VER" "$$K3D_VER" | sort -V | head -n1)" != "$$REQ_VER" ]; then \
-	   echo "k3d $$K3D_VER detected (ok)"; \
-	 else \
-	   echo "k3d $$K3D_VER is too old; please install k3d >= $$REQ_VER"; exit 1; \
-	 fi
-
-.PHONY: verify-dns-lb
-verify-dns-lb:
-	@echo -e "\n$(YELLOW)Verifying CoreDNS Services$(NC)"
-	@for c in $(CLUSTER_IDS); do \
-	  CTX=k3d-$(CLUSTER_NAME)$$c; \
-	  echo -e "\n$(CYAN)$$CTX$(NC)"; \
-	  kubectl get svc -n k8gb k8gb-coredns --context $$CTX -o wide || true; \
-	  echo "Type/Ingress:"; \
-	  kubectl get svc -n k8gb k8gb-coredns --context $$CTX -o jsonpath='{.spec.type}{" "}{.status.loadBalancer.ingress[*].ip}{" "}{.status.loadBalancer.ingress[*].hostname}{"\n"}' || true; \
-	done
-	@echo -e "\n$(YELLOW)Testing localhost TCP ports$(NC)"
-	@dig @localhost -p 5053 SOA . +tcp >/dev/null 2>&1 && echo "5053 TCP OK" || echo "5053 TCP FAIL"
-	@[ $(CLUSTERS_NUMBER) -lt 2 ] || (dig @localhost -p 5054 SOA . +tcp >/dev/null 2>&1 && echo "5054 TCP OK" || echo "5054 TCP FAIL")
+endef
 
 define get-helm-args
 --set k8gb.clusterGeoTag='$(call nth-geo-tag,$1)' --set k8gb.extGslbClustersGeoTags='$(call get-ext-tags,$1)' --set extdns.txtOwnerId='k8gb-$(call nth-geo-tag,$1)' --set extdns.txtPrefix='k8gb-$(call nth-geo-tag,$1)-' --set k8gb.edgeDNSServers[0]=$(shell $(CLUSTER_GSLB_GATEWAY)):1053

--- a/Makefile
+++ b/Makefile
@@ -697,3 +697,30 @@ define setup-dns-provider-secrets
 	kubectl -n k8gb create secret generic rfc2136 --from-literal=secret=96Ah/a2g0/nLeFGK+d/0tzQcccf9hCEIy34PoXX2Qg8= || true
 	[ -n "$(GCP_CREDENTIALS_FILE)" ] && kubectl -n k8gb create secret generic external-dns-gcp-sa --from-file=credentials.json=$(GCP_CREDENTIALS_FILE) || true
 endef
+
+.PHONY: preflight
+preflight:
+	@echo -e "\n$(YELLOW)Preflight checks$(NC)"
+	@which k3d >/dev/null 2>&1 || { echo "k3d is required"; exit 1; }
+	@K3D_VER=$$(k3d version | awk '/k3d version/ {print $$3}'); \
+	 if [ -z "$$K3D_VER" ]; then echo "Unable to detect k3d version"; exit 1; fi; \
+	 REQ_VER="v5.3.0"; \
+	 if [ "$$(printf '%s\n' "$$REQ_VER" "$$K3D_VER" | sort -V | head -n1)" != "$$REQ_VER" ]; then \
+	   echo "k3d $$K3D_VER detected (ok)"; \
+	 else \
+	   echo "k3d $$K3D_VER is too old; please install k3d >= $$REQ_VER"; exit 1; \
+	 fi
+
+.PHONY: verify-dns-lb
+verify-dns-lb:
+	@echo -e "\n$(YELLOW)Verifying CoreDNS Services$(NC)"
+	@for c in $(CLUSTER_IDS); do \
+	  CTX=k3d-$(CLUSTER_NAME)$$c; \
+	  echo -e "\n$(CYAN)$$CTX$(NC)"; \
+	  kubectl get svc -n k8gb k8gb-coredns --context $$CTX -o wide || true; \
+	  echo "Type/Ingress:"; \
+	  kubectl get svc -n k8gb k8gb-coredns --context $$CTX -o jsonpath='{.spec.type}{" "}{.status.loadBalancer.ingress[*].ip}{" "}{.status.loadBalancer.ingress[*].hostname}{"\n"}' || true; \
+	done
+	@echo -e "\n$(YELLOW)Testing localhost TCP ports$(NC)"
+	@dig @localhost -p 5053 SOA . +tcp >/dev/null 2>&1 && echo "5053 TCP OK" || echo "5053 TCP FAIL"
+	@[ $(CLUSTERS_NUMBER) -lt 2 ] || (dig @localhost -p 5054 SOA . +tcp >/dev/null 2>&1 && echo "5054 TCP OK" || echo "5054 TCP FAIL")

--- a/docs/local.md
+++ b/docs/local.md
@@ -97,6 +97,7 @@ dig -p 5053 +tcp @localhost localtargets-roundrobin.cloud.example.com && \
 dig -p 5054 +tcp @localhost localtargets-roundrobin.cloud.example.com
 ```
 As expected result you should see **two A records** divided between both clusters.
+If you see a connection reset or "no servers could be reached", see Troubleshooting below.
 ```sh
 ...
 ...
@@ -122,6 +123,40 @@ To check whether everything is running properly execute [terratest](https://terr
 ```sh
 make terratest
 ```
+
+### Troubleshooting: localhost:5053/5054 +tcp fails
+
+If `dig -p 5053/5054 +tcp @localhost ...` returns "connection reset" or "no servers could be reached":
+
+1. Ensure recent local tooling
+   - k3d >= v5.3.0 (recommended v5.6+)
+   - Docker running and healthy
+
+2. Recreate local clusters
+```sh
+make destroy-full-local-setup
+make deploy-full-local-setup
+```
+
+3. Verify CoreDNS Services are LoadBalancer and have ingress
+```sh
+# Quick helper
+make verify-dns-lb
+
+# Or manually:
+kubectl get svc -n k8gb k8gb-coredns --context k3d-test-gslb1 -o wide
+kubectl get svc -n k8gb k8gb-coredns --context k3d-test-gslb2 -o wide
+```
+Expected: `TYPE` is `LoadBalancer` and `.status.loadBalancer.ingress` is populated.
+
+4. Re-test DNS (TCP)
+```sh
+dig @localhost -p 1053 roundrobin.cloud.example.com +short +tcp
+dig -p 5053 +tcp @localhost localtargets-roundrobin.cloud.example.com
+dig -p 5054 +tcp @localhost localtargets-roundrobin.cloud.example.com
+```
+
+If issues persist, upgrade k3d and retry. Very old k3d/k3s combinations may not forward TCP/53 reliably via the local load balancer.
 
 ## Cleaning
 

--- a/terratest/test/preflight_dns_test.go
+++ b/terratest/test/preflight_dns_test.go
@@ -1,0 +1,48 @@
+package test
+
+/*
+Copyright 2025 The k8gb Contributors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestLocalDNSTCPConnectivity verifies the local k3d load balancer forwards TCP/53
+// from localhost:5053 (and :5054 for two clusters) to the CoreDNS Service.
+// This is a preflight to provide clear diagnostics when "dig +tcp @localhost -p 5053" fails.
+func TestLocalDNSTCPConnectivity(t *testing.T) {
+	dial := func(port int) error {
+		address := fmt.Sprintf("127.0.0.1:%d", port)
+		conn, err := net.DialTimeout("tcp", address, 3*time.Second)
+		if err != nil {
+			return err
+		}
+		_ = conn.Close()
+		return nil
+	}
+
+	if err := dial(settings.Port1); err != nil {
+		t.Fatalf("cannot connect to localhost:%d over TCP: %v\n\nHints:\n- Ensure k3d >= v5.3.0\n- Recreate local setup: 'make destroy-full-local-setup && make deploy-full-local-setup'\n- Verify CoreDNS Service is LoadBalancer: 'make verify-dns-lb'\nSee docs/local.md (Troubleshooting: localhost:5053/5054 +tcp fails).", settings.Port1, err)
+	}
+
+	if settings.ClustersNumber >= 2 {
+		if err := dial(settings.Port2); err != nil {
+			t.Fatalf("cannot connect to localhost:%d over TCP: %v\n\nHints:\n- Ensure k3d >= v5.3.0\n- Recreate local setup: 'make destroy-full-local-setup && make deploy-full-local-setup'\n- Verify CoreDNS Service is LoadBalancer: 'make verify-dns-lb'\nSee docs/local.md (Troubleshooting: localhost:5053/5054 +tcp fails).", settings.Port2, err)
+		}
+	}
+}
+
+


### PR DESCRIPTION
### Title
Preflight and docs for localhost:5053/5054 +tcp failures; add DNS LB verification test (#1312)

### Summary
- Add preflight and verification targets to surface local DNS/TCP issues early.
- Add a small terratest that fails fast with actionable hints.
- Document troubleshooting for “connection reset / no servers could be reached” on 5053/5054.
- Improves developer experience when following local tutorial and running terratests.

### Context
- Issue: #1312 (“Cluster can't return own entries”).
- Symptom: `dig -p 5053/5054 +tcp @localhost ...` returns connection reset or no servers.
- Root cause (local): k3d/k3s LB TCP/53 forwarding behavior and occasional host port conflicts.

### Changes
- Makefile
  - Add `preflight` (verifies a sane local toolchain before setup).
  - Wire `preflight` into `deploy-full-local-setup`.
  - Add `verify-dns-lb` (prints `k8gb-coredns` Service type/ingress and verifies `localhost:5053/5054` TCP).
- Terratest
  - Add `terratest/test/preflight_dns_test.go` (dials `127.0.0.1:5053/5054`; prints clear remediation hints).
- Docs
  - Update `docs/local.md` with a focused troubleshooting guide for 5053/5054 +tcp failures.

### How to test locally
- Create/reset local env:
  - `make destroy-full-local-setup || true && make deploy-full-local-setup`
- Verify LB and ports:
  - `make verify-dns-lb` (expect CoreDNS Service `LoadBalancer` with ingress; 5053/5054 TCP OK)
- DNS checks (TCP):
  - `dig @localhost -p 1053 roundrobin.cloud.example.com +short +tcp`
  - `dig -p 5053 +tcp @localhost localtargets-roundrobin.cloud.example.com`
  - `dig -p 5054 +tcp @localhost localtargets-roundrobin.cloud.example.com`
- Terratests:
  - `make terratest` (preflight test fails early with hints if TCP forwarding is broken)

### Expected results
- `verify-dns-lb`: CoreDNS is `LoadBalancer` with `.status.loadBalancer.ingress` populated; 5053/5054 TCP OK.
- `dig` over TCP returns records as documented (order may vary).
- Terratests pass (aside from intentionally negative scenarios).

### Troubleshooting
- Ensure k3d is reasonably up to date (≥ v5.3.0 recommended).
- If cluster creation fails due to host port conflicts (e.g., 80/443/3000/8080), remap ports in `k3d/test-gslb1.yaml`, recreate the cluster, and re-run verify/test.
- If only one cluster is running, `make terratest` will fail; bring both clusters up.

### Backwards compatibility
- No runtime changes to controller logic.
- Local-only improvements (make targets, tests, documentation).

### Motivation
- Reduce time-to-diagnosis for new contributors.
- Prevent false attribution to k8gb when root cause is local LB TCP/53 forwarding.
- Provide deterministic verification and clear remediation steps.

### Checklist
- [x] Preflight and verification make targets added
- [x] Connectivity terratest added
- [x] Local troubleshooting docs updated
- [x] Manual validation on fresh local env
