### PR TITLE
Fix go-releaser installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -397,7 +397,7 @@ ensure-cluster-size:
 
 .PHONY: goreleaser
 goreleaser:
-	command -v goreleaser &> /dev/null || go install github.com/goreleaser/goreleaser@v2.12.7
+	go install github.com/goreleaser/goreleaser/v2@v2.12.7
 
 .PHONY: release-images
 release-images: goreleaser


### PR DESCRIPTION
In #2101 goreleaser was upgraded to version 2. However, the Readme didn't force an upgrade for users that already had goreleaser v1 installed, leading to errors building the image:
```
➜  make release-images
command -v goreleaser &> /dev/null || go install github.com/goreleaser/goreleaser@v2.12.7
goreleaser release --snapshot --clean --skip=validate,publish,sbom,sign
   ⨯ command failed            error=unknown flag: --clean
make: *** [release-images] Error 1
```

So, I decided to try to install it everytime. The `go install` commands returns quickly if `goreleaser` is already installed.

The `go install` command needed a small update though. From:
```
➜ go install github.com/goreleaser/goreleaser@v2.12.7
go: github.com/goreleaser/goreleaser@v2.12.7: github.com/goreleaser/goreleaser@v2.12.7: invalid version: go.mod has post-v2 module path "github.com/goreleaser/goreleaser/v2" at revision v2.12.7
```
To:
```
➜ go install github.com/goreleaser/goreleaser/v2@v2.12.7
```