### PR TITLE
Fix Prometheus and Grafana exposure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,8 +146,8 @@ If you need to check and query the k8gb metrics locally, you can install a Prome
 
 The deployed Prometheus scrapes metrics from the dedicated k8gb operator endpoint and makes them accessible via Prometheus web UI:
 
-- http://127.0.0.1:9080
-- http://127.0.0.1:9081
+- http://127.0.0.1:9090
+- http://127.0.0.1:9091
 
 All the metric data is ephemeral and will be lost with pod restarts.
 To uninstall Prometheus, run `make uninstall-prometheus`

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This setup is adapted for local scenarios and works without external DNS provide
 
 Consult with [local playground](docs/local.md) documentation to learn all the details of experimenting with local setup.
 
-Optionally, you can run `make deploy-prometheus` and check the metrics on the test clusters (http://localhost:9080, http://localhost:9081).
+Optionally, you can run `make deploy-prometheus` and check the metrics on the test clusters (http://localhost:9090, http://localhost:9091).
 
 ## Motivation and Architecture
 

--- a/deploy/grafana/values.yaml
+++ b/deploy/grafana/values.yaml
@@ -1,10 +1,9 @@
 adminUser: admin
 adminPassword: admin # don't use in production (1st login to web ui will ask for the password change)
 service:
-  nodePort: 30030 # allowed port range between 30000 and 32768
   targetPort: 3000
   port: 3000
-  type: NodePort
+  type: LoadBalancer
 sidecar:
   dashboards:
     enabled: true
@@ -14,18 +13,20 @@ datasources:
     datasources:
     - name: Prometheus
       type: prometheus
-      url: http://k3d-test-gslb1-agent-0:30090
+      url: http://prometheus-server:9090
       access: proxy
       isDefault: true
     - name: Prometheus-cluster1
       type: prometheus
-      url: http://localhost:9080
-      access: direct
+      # For Docker/K8s-in-Docker (k3d/kind), use host.docker.internal to reach the host's exposed port
+      url: http://172.17.0.1:9090
+      access: proxy
       isDefault: false
     - name: Prometheus-cluster2
       type: prometheus
-      url: http://localhost:9081
-      access: direct
+      # For Docker/K8s-in-Docker (k3d/kind), use host.docker.internal to reach the host's exposed port
+      url: http://172.17.0.1:9091
+      access: proxy
       isDefault: false
 dashboardProviders:
   dashboardproviders.yaml:

--- a/deploy/prometheus/values.yaml
+++ b/deploy/prometheus/values.yaml
@@ -3,9 +3,8 @@ server:
   persistentVolume:
     enabled: false # emptyDir, all data is lost when pod restarts
   service:
-    nodePort: 30090 # allowed port range between 30000 and 32768
     servicePort: 9090
-    type: NodePort
+    type: LoadBalancer
 
 alertmanager:
   enabled: false
@@ -14,7 +13,7 @@ alertmanager:
 #    servicePort: 9091
 #    type: NodePort
 
-pushgateway:
+prometheus-pushgateway:
   enabled: false
 #  service:
 #    nodePort: 30092 # allowed port range between 30000 and 32768

--- a/k3d/generate-yaml.sh
+++ b/k3d/generate-yaml.sh
@@ -13,7 +13,7 @@ for c in $(seq $UPTO); do
     export CLUSTER_INDEX=$(( 1 + $c ))
     export PORT_HTTP=$(( 80 + $c ))
     export PORT_HTTPS=$(( 443 + $c ))
-    export PORT_PROM=$(( 9080 + $c ))
+    export PORT_PROM=$(( 9090 + $c ))
     export PORT_DNS=$(( 5053 + $c ))
     cat ${DIR}/gslb.yaml.tmpl | envsubst > ${DIR}/test-gslb${CLUSTER_INDEX}.yaml
 done

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -17,12 +17,12 @@ ports:
   - port: 443:443
     nodeFilters:
       - agent:0:direct
-  - port: 3000:30030
+  - port: 3000:3000
     nodeFilters:
-      - agent:0:direct
-  - port: 9080:30090
+      - loadbalancer
+  - port: 9090:9090
     nodeFilters:
-      - agent:0:direct
+      - loadbalancer
   - port: 5053:53/tcp
     nodeFilters:
       - loadbalancer

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -17,9 +17,9 @@ ports:
   - port: 444:443
     nodeFilters:
       - agent:0:direct
-  - port: 9081:30090
+  - port: 9091:9090
     nodeFilters:
-      - agent:0:direct
+      - loadbalancer
   - port: 5054:53/tcp
     nodeFilters:
       - loadbalancer

--- a/k3d/test-gslb3.yaml
+++ b/k3d/test-gslb3.yaml
@@ -17,9 +17,9 @@ ports:
   - port: 445:443
     nodeFilters:
       - agent:0:direct
-  - port: 9082:30090
+  - port: 9092:9090
     nodeFilters:
-      - agent:0:direct
+      - loadbalancer
   - port: 5055:53/tcp
     nodeFilters:
       - loadbalancer


### PR DESCRIPTION
In the local setup, Prometheus and Grafana were exposed as nodePort services. In my machine it was not always possible to reach the servers, so I now expose them as loadbalancer services, similar to how coreDNS is exposed.

---

In addition, the connection between `grafana` and the `prometheus` servers (one in each cluster) was fixed. This connection was previously done via direct browser access. However, this feature is now deprecated:
```
Browser access mode in the Prometheus data source is no longer available. Switch to server access mode.
```
So we need to connect using `proxy` access (from the container). We can use the address `172.17.0.1` to have access to the host network.