### PR TITLE
Add VERSION fallback in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ NO_VALUE ?= no_value
 ###############################
 PWD ?=  $(shell pwd)
 ifndef VERSION
-VERSION := $(shell git fetch --force --tags &> /dev/null ; git describe --tags --abbrev=0)
+VERSION := $(shell git fetch --force --tags &> /dev/null; git describe --tags --abbrev=0 2>/dev/null || echo 'v0.0.0')
 endif
 COMMIT_HASH ?= $(shell git rev-parse --short HEAD)
 SEMVER ?= $(VERSION)-$(COMMIT_HASH)


### PR DESCRIPTION
When using a fork of k8gb there are no tags, resulting in the image reference breaking. This adds a fallback to a made-up version


<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
