### PR TITLE
fix: restore extraServerBlocks as global setting

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -79,6 +79,7 @@ Note: k8gb is architected to run on top of any compliant Kubernetes cluster and 
 | extdns.sources[0] | string | `"crd"` |  |
 | extdns.txtOwnerId | string | `"k8gb-<GEOTAG>"` |  |
 | extdns.txtPrefix | string | `"k8gb-<GEOTAG>-"` |  |
+| extraServerBlocks | string | `""` | Extra CoreDNS server blocks to be added after all k8gb zones. Useful for adding glue records or additional DNS zones for cluster discovery. |
 | global.imagePullSecrets | list | `[]` | Reference to one or more secrets to be used when pulling images ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | infoblox.dnsView | string | `"default"` | DNS view to use for zone operations |
 | infoblox.enabled | bool | `false` | infoblox provider enabled |
@@ -92,7 +93,7 @@ Note: k8gb is architected to run on top of any compliant Kubernetes cluster and 
 | k8gb.clusterGeoTag | string | `"eu"` | Unique geotag for this K8GB instance. This tag identifies the cluster's location or role (e.g., "eu", "us-east", "dc1" or "primary"). This tag should be present in all clusters’ extGslbClustersGeoTags |
 | k8gb.deployCrds | bool | `true` | whether it should also deploy the gslb and dnsendpoints CRDs |
 | k8gb.deployRbac | bool | `true` | whether it should also deploy the service account, cluster role and cluster role binding |
-| k8gb.dnsZones | list | `[{"dnsZoneNegTTL":30,"extraPlugins":[],"extraServerBlocks":"","geoDataField":"","geoDataFilePath":"","loadBalancedZone":"cloud.example.com","parentZone":"example.com"}]` | array of dns zones controlled by gslb |
+| k8gb.dnsZones | list | `[{"dnsZoneNegTTL":30,"extraPlugins":[],"geoDataField":"","geoDataFilePath":"","loadBalancedZone":"cloud.example.com","parentZone":"example.com"}]` | array of dns zones controlled by gslb |
 | k8gb.edgeDNSServers[0] | string | `"1.1.1.1"` | use this DNS server as a main resolver to enable cross k8gb DNS based communication |
 | k8gb.exposeMetrics | bool | `false` | Exposing metrics |
 | k8gb.extGslbClustersGeoTags | string | `"eu,us"` | Comma-separated list of geotags for external K8GB clusters. These are arbitrary, user-defined identifiers (e.g., "eu,us" or "dc2,dc3") used for coordination between K8GB instances If the value remains empty, dynamic geotags extracted from the NS records on the edge DNS will be used. |

--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -36,7 +36,7 @@ data:
         }
     }
 {{- end }}
-    {{- with .extraServerBlocks -}}
+    {{- with .Values.extraServerBlocks -}}
     {{- tpl . $ | nindent 4 }}
     {{- end }}
 {{- end }}

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -34,6 +34,10 @@
                 },
                 "istio": {
                     "$ref": "#/definitions/Istio"
+                },
+                "extraServerBlocks": {
+                    "type": "string",
+                    "description": "Extra CoreDNS server blocks to be added after all k8gb zones"
                 }
             }
         },
@@ -542,9 +546,6 @@
                         "type": "string",
                         "minLength": 1
                     }
-                },
-                "extraServerBlocks": {
-                    "type": "string"
                 }
             },
             "required": [

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -22,7 +22,6 @@ k8gb:
       loadBalancedZone: "cloud.example.com" # -- zone controlled by gslb (same meaning as the old dnsZone)
       dnsZoneNegTTL: 30  # -- Negative TTL for SOA record# -- host/ip[:port] format is supported here where port defaults to 53
       extraPlugins: [] # -- Extra CoreDNS plugins to be enabled for this zone
-      extraServerBlocks: "" # -- Extra CoreDNS server blocks for this zone
       geoDataFilePath: "" # -- GeoData file path
       geoDataField: "" # -- GeoData field
   edgeDNSServers:
@@ -211,3 +210,16 @@ tracing:
 istio:
   # -- install istio RBAC
   enabled: true
+
+# -- Extra CoreDNS server blocks to be added after all k8gb zones.
+# Useful for adding glue records or additional DNS zones for cluster discovery.
+# Example:
+#   extraServerBlocks: |
+#     example.com:5353 {
+#       errors
+#       forward . /etc/resolv.conf
+#       k8s_crd {
+#         filter k8gb.absa.oss/dnstype=glue
+#       }
+#     }
+extraServerBlocks: ""


### PR DESCRIPTION
Fixes #2120

## Summary

The `extraServerBlocks` feature was broken after refactoring to support multiple DNS zones. This PR restores it to its original global design as intended in PR #1709.

## Problem

The feature was originally added in PR #1709 (commit 518a2ce1) as a **global setting** at `k8gb.coredns.extraServerBlocks` to enable adding glue records for cluster discovery. During the refactoring that changed from single `dnsZone` to `dnsZones[]` array, `extraServerBlocks` was mistakenly moved to per-zone in the schema but the template was never updated, causing it to break.

## Changes

This PR restores the original global behavior:

1. **Schema** (`values.schema.json`): 
   - Moved `extraServerBlocks` from `k8gbDnsZone` definition to root-level `All` definition
   - Added proper description

2. **Template** (`templates/coredns/cm.yaml`):
   - Fixed template to access `.Values.extraServerBlocks` instead of `.extraServerBlocks`

3. **Values** (`values.yaml`):
   - Removed `extraServerBlocks` from per-zone example
   - Added it at root level with comprehensive documentation and example
   - Documented the use case (glue records, cluster discovery)

4. **Documentation** (`README.md`):
   - Updated to reflect new root-level location
   - Removed from dnsZones array documentation

## Testing

```bash
# Schema validation now passes
helm template .

# Feature works correctly with custom server blocks
helm template . --set 'extraServerBlocks=example.com:5353 { errors; forward . /etc/resolv.conf }'
```

## Use Case

As documented in the original PR #1709, this feature allows k8gb to configure glue records for other clusters in CoreDNS, enabling cluster discovery without depending on infrastructure outside the cluster.

Example:
```yaml
extraServerBlocks: |
  example.com:5353 {
    errors
    forward . /etc/resolv.conf
    k8s_crd {
      filter k8gb.absa.oss/dnstype=glue
    }
  }
```

## Breaking Changes

None - the feature was previously broken. This restores it to working state with the original intended behavior.
