### PR TITLE
Initialize Prometheus metrics with zero values at startup

### DIFF
--- a/controllers/providers/metrics/prometheus.go
+++ b/controllers/providers/metrics/prometheus.go
@@ -224,6 +224,65 @@ func (m *PrometheusMetrics) Unregister() {
 	}
 }
 
+// InitializeZeroValues initializes all counter and gauge metrics with zero values.
+// This ensures that all metrics are visible in Prometheus dashboards even before
+// they are first updated by the application code. Uses a special "init" label value
+// to create initial time series that make the metrics discoverable.
+func (m *PrometheusMetrics) InitializeZeroValues() {
+	// Use special labels to initialize metrics so they appear in Prometheus
+	// These serve as placeholder time series to make metrics discoverable
+	// Real GSLB resources will create their own time series with actual labels
+	initLabels := prometheus.Labels{
+		"namespace": m.config.K8gbNamespace,
+		"name":      "init",
+	}
+
+	// Initialize counter metrics
+	m.metrics.K8gbGslbErrorsTotal.With(initLabels).Add(0)
+	m.metrics.K8gbGslbReconciliationLoopsTotal.With(initLabels).Add(0)
+	m.metrics.K8gbInfobloxZoneUpdatesTotal.With(initLabels).Add(0)
+	m.metrics.K8gbInfobloxZoneUpdateErrorsTotal.With(initLabels).Add(0)
+	m.metrics.K8gbInfobloxHeartbeatsTotal.With(initLabels).Add(0)
+	m.metrics.K8gbInfobloxHeartbeatErrorsTotal.With(initLabels).Add(0)
+
+	// Initialize gauge metrics
+	m.metrics.K8gbGslbHealthyRecords.With(initLabels).Set(0)
+
+	// Initialize gauge metrics with status labels
+	statusLabels := prometheus.Labels{
+		"namespace": m.config.K8gbNamespace,
+		"name":      "init",
+		"status":    "Healthy",
+	}
+	m.metrics.K8gbGslbServiceStatusNum.With(statusLabels).Set(0)
+	m.metrics.K8gbGslbStatusCountForFailover.With(statusLabels).Set(0)
+	m.metrics.K8gbGslbStatusCountForRoundrobin.With(statusLabels).Set(0)
+	m.metrics.K8gbGslbStatusCountForGeoip.With(statusLabels).Set(0)
+
+	statusLabels["status"] = "Unhealthy"
+	m.metrics.K8gbGslbServiceStatusNum.With(statusLabels).Set(0)
+	m.metrics.K8gbGslbStatusCountForFailover.With(statusLabels).Set(0)
+	m.metrics.K8gbGslbStatusCountForRoundrobin.With(statusLabels).Set(0)
+	m.metrics.K8gbGslbStatusCountForGeoip.With(statusLabels).Set(0)
+
+	statusLabels["status"] = "NotFound"
+	m.metrics.K8gbGslbServiceStatusNum.With(statusLabels).Set(0)
+	m.metrics.K8gbGslbStatusCountForFailover.With(statusLabels).Set(0)
+	m.metrics.K8gbGslbStatusCountForRoundrobin.With(statusLabels).Set(0)
+	m.metrics.K8gbGslbStatusCountForGeoip.With(statusLabels).Set(0)
+
+	// Initialize endpoint status metric
+	endpointLabels := prometheus.Labels{
+		"namespace": m.config.K8gbNamespace,
+		"name":      "init",
+		"dns_name":  "init.example.com",
+	}
+	m.metrics.K8gbEndpointStatusNum.With(endpointLabels).Set(0)
+
+	// Note: K8gbInfobloxRequestDuration is a histogram and doesn't need initialization
+	// Note: K8gbRuntimeInfo is set separately via SetRuntimeInfo()
+}
+
 // init instantiates particular metrics
 func (m *PrometheusMetrics) init() {
 

--- a/controllers/providers/metrics/prometheus_test.go
+++ b/controllers/providers/metrics/prometheus_test.go
@@ -376,6 +376,49 @@ func TestRuntimeStatus(t *testing.T) {
 	}
 }
 
+func TestInitializeZeroValues(t *testing.T) {
+	// arrange
+	m := newPrometheusMetrics(defaultConfig)
+	initLabels := prometheus.Labels{"namespace": namespace, "name": "init"}
+
+	// act
+	m.InitializeZeroValues()
+
+	// assert - verify counter metrics are initialized with 0
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbErrorsTotal).AsCounterVec().With(initLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbReconciliationLoopsTotal).AsCounterVec().With(initLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbInfobloxZoneUpdatesTotal).AsCounterVec().With(initLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbInfobloxZoneUpdateErrorsTotal).AsCounterVec().With(initLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbInfobloxHeartbeatsTotal).AsCounterVec().With(initLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbInfobloxHeartbeatErrorsTotal).AsCounterVec().With(initLabels)))
+
+	// assert - verify gauge metrics are initialized with 0
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbHealthyRecords).AsGaugeVec().With(initLabels)))
+
+	// assert - verify gauge metrics with status labels are initialized with 0
+	statusLabels := prometheus.Labels{"namespace": namespace, "name": "init", "status": "Healthy"}
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbServiceStatusNum).AsGaugeVec().With(statusLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbStatusCountForFailover).AsGaugeVec().With(statusLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbStatusCountForRoundrobin).AsGaugeVec().With(statusLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbStatusCountForGeoIP).AsGaugeVec().With(statusLabels)))
+
+	statusLabels["status"] = "Unhealthy"
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbServiceStatusNum).AsGaugeVec().With(statusLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbStatusCountForFailover).AsGaugeVec().With(statusLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbStatusCountForRoundrobin).AsGaugeVec().With(statusLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbStatusCountForGeoIP).AsGaugeVec().With(statusLabels)))
+
+	statusLabels["status"] = "NotFound"
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbServiceStatusNum).AsGaugeVec().With(statusLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbStatusCountForFailover).AsGaugeVec().With(statusLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbStatusCountForRoundrobin).AsGaugeVec().With(statusLabels)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbGslbStatusCountForGeoIP).AsGaugeVec().With(statusLabels)))
+
+	// assert - verify endpoint status metric is initialized with 0
+	endpointLabels := prometheus.Labels{"namespace": namespace, "name": "init", "dns_name": "init.example.com"}
+	assert.Equal(t, 0.0, testutil.ToFloat64(m.Get(K8gbEndpointStatusNum).AsGaugeVec().With(endpointLabels)))
+}
+
 func TestMain(m *testing.M) {
 	defaultGslb.Name = gslbName
 	defaultGslb.Namespace = namespace

--- a/main.go
+++ b/main.go
@@ -135,6 +135,8 @@ func run() error {
 		log.Err(err).Msg("Unable to register metrics")
 		return err
 	}
+	// Initialize all metrics with zero values so they appear in Prometheus dashboards
+	metrics.Metrics().InitializeZeroValues()
 
 	log.Info().Msg("Resolving DNS provider")
 	f, err = dns.NewDNSProviderFactory(context.TODO(), mgr.GetClient(), *config)


### PR DESCRIPTION
This change addresses issue #715 by ensuring all Prometheus metrics are initialized with zero values when the operator starts. This makes metrics discoverable in monitoring dashboards (like Grafana) even before they are first incremented or updated by application code.

Key changes:
- Added InitializeZeroValues() method to PrometheusMetrics that initializes all counter and gauge metrics with zero values using placeholder labels (namespace=k8gb, name=init)
- Call InitializeZeroValues() in main.go after metrics registration
- Added comprehensive unit tests to verify all metrics are properly initialized

This ensures metrics like k8gb_gslb_errors_total,
k8gb_gslb_reconciliation_loops_total, and others appear in the Prometheus /metrics endpoint from startup, allowing dashboard configuration without requiring GSLB resources to exist first.

Fixes #715