### PR TITLE
add LB Service to ResourceRef docs

### DIFF
--- a/docs/ingress_annotations.md
+++ b/docs/ingress_annotations.md
@@ -1,9 +1,0 @@
-# Ingress Annotations
-
-Instead of direct Gslb resource creation there is ability to enable global load balancing
-by setting annotations on the standard Ingress objects.
-
-| Annotation             | Description      | Type                           |
-| ---------------------- | ---------------- | ------------------------------ |
-| k8gb.io/strategy       | Glsb strategy    | "`roundRobin`" \| "`failover`" |
-| k8gb.io/primary-geotag | Arbitrary geotag | string (e.g. "`eu`")           |

--- a/docs/resource_ref.md
+++ b/docs/resource_ref.md
@@ -3,9 +3,11 @@ Starting from v0.15.0, k8gb introduces a much simpler way to link a GSLB resourc
 This makes your Ingress the single source of truth for application routing.
 
 K8GB supports the following ingress resources: 
-- [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
-- [Istio Virtual Service](https://istio.io/latest/docs/reference/config/networking/virtual-service/)
-- Gateway API's [HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/) and [GRPCRoute](https://gateway-api.sigs.k8s.io/api-types/grpcroute/) - to be released in v0.17.0
+
+* [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
+* [Kubernetes LoadBalancer Service](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)
+* [Istio Virtual Service](https://istio.io/latest/docs/reference/config/networking/virtual-service/)
+* Gateway API's [HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/) and [GRPCRoute](https://gateway-api.sigs.k8s.io/api-types/grpcroute/) - to be released in v0.17.0
 
 ## 1. Declaration by Name
 The simplest way is to directly specify the name of the resource you want to reference in your GSLB. The namespace will be automatically taken from the GSLB’s namespace.
@@ -21,6 +23,19 @@ spec:
     apiVersion: networking.k8s.io/v1
     kind: Ingress
     name: playground-failover-ingress
+```
+
+LoadBalancer Service:
+```yaml
+apiVersion: k8gb.absa.oss/v1beta1
+kind: Gslb
+metadata:
+  name: playground-failover
+spec:
+  resourceRef:
+    apiVersion: v1
+    kind: Service
+    name: playground-failover-lbservice
 ```
 
 Istio Virtual Service:

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -24,7 +24,6 @@ This section provides comprehensive tutorials for deploying and configuring K8GB
 
 ## Configuration
 
-* [Ingress annotations](ingress_annotations.md)
 * [Resource References](resource_ref.md)
 * [Address Discovery](address_discovery.md)
 * [Dynamic Geotags](dynamic_geotags.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,19 +20,18 @@ nav:
     - Windows DNS: deploy_windowsdns.md
     - Cloudflare: deploy_cloudflare.md
     - RFC2136/Bind9: provider_rfc2136.md
+  - Configuration:
+    - Resource References: resource_ref.md
+    - Address Discovery: address_discovery.md
+    - Dynamic Geotags: dynamic_geotags.md
+    - Multi-zone Setup: multizone.md
+    - Exposing DNS: exposing_dns.md
   - Development & Testing:
     - Local Setup: local.md
     - Local with Kuar: local-kuar.md
   - Monitoring and Observability:
     - Metrics: metrics.md
     - Traces: traces.md
-  - Configuration:
-    - Ingress Annotations: ingress_annotations.md
-    - Resource References: resource_ref.md
-    - Address Discovery: address_discovery.md
-    - Dynamic Geotags: dynamic_geotags.md
-    - Multi-zone Setup: multizone.md
-    - Exposing DNS: exposing_dns.md
   - Platform Integrations:
     - Admiralty: admiralty.md
     - Liqo: liqo.md


### PR DESCRIPTION
All other integrations were already documented in our website, except services of type load balancer. This PR adds this missing example to https://www.k8gb.io/resource_ref/

Additionally, a couple of other smalls fixes are included in this PR:
* Removal of the documentation for Ingress Annotations since this feature is deprecated and is going to be removed in v0.17.0
* Fix the integration bullets in the website generation by replacing "-" with "*": https://www.k8gb.io/resource_ref/
<img width="898" height="91" alt="Screenshot 2025-11-22 at 17 45 31" src="https://github.com/user-attachments/assets/f03ac2f8-4dc3-492a-8242-731bf81ec40e" />
* Bringing the configuration up in the website's menu. A new user is more interested in Configuration options than on `Development & Testing` or `Monitoring and Observability`