### PR TITLE
[Enhancement]: adding Cosign signing to the OCI charts

### DIFF
--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -46,12 +46,13 @@ jobs:
         env:
           COSIGN_EXPERIMENTAL: 1
         run: |
-          echo ${{ secrets.CR_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
-          echo ${{ secrets.CR_TOKEN }} | cosign login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GITHUB_TOKEN }} | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo ${{ secrets.GITHUB_TOKEN }} | cosign login ghcr.io -u ${{ github.actor }} --password-stdin
           git fetch origin gh-pages
           git checkout origin/gh-pages -- charts/
           ls -la charts/
           OCI_REPO="${OCI_REPO:-oci://ghcr.io/k8gb-io/charts}"
+          PUSHED_CHARTS=()
           for chart in charts/k8gb-*.tgz; do
             if [ -f "$chart" ]; then
               PUSH_OUTPUT=$(helm push "$chart" "$OCI_REPO" 2>&1)
@@ -59,31 +60,22 @@ jobs:
               if [ -n "$DIGEST" ]; then
                 # Sign using digest
                 CHART_REF="ghcr.io/k8gb-io/charts/k8gb@${DIGEST}"
-                echo "Signing with digest: $CHART_REF"
-                if cosign sign --yes "$CHART_REF"; then
-                  echo "Successfully signed: $CHART_REF"
-                else
-                  echo "Failed to sign: $CHART_REF"
-                  exit 1
-                fi
               else
                 # Incase digest didnt worked then tag signing
                 CHART_NAME=$(basename "$chart" .tgz)
                 CHART_VERSION=$(echo "$CHART_NAME" | sed 's/k8gb-//')
                 CHART_REF="ghcr.io/k8gb-io/charts/k8gb:${CHART_VERSION}"
-                echo "Signing with tag: $CHART_REF"
-                if cosign sign --yes "$CHART_REF"; then
-                  echo "Successfully signed: $CHART_REF"
-                else
-                  echo "Failed to sign: $CHART_REF"
-                  exit 1
-                fi
               fi              
-              echo "Verifying signature for: $CHART_REF"
-              cosign verify "$CHART_REF" \
-                --certificate-identity-regexp "https://github.com/${{ github.repository }}/.*" \
-                --certificate-oidc-issuer "https://token.actions.githubusercontent.com" || echo "Verification failed, but continuing..."
+              echo "Signing chart: $CHART_REF"
+              cosign sign --yes "$CHART_REF"
+              PUSHED_CHARTS+=("$CHART_REF")
             fi
+          done
+          echo "Verifying all pushed charts"
+          for chart_ref in "${PUSHED_CHARTS[@]}"; do
+            cosign verify "$chart_ref" \
+              --certificate-identity "https://github.com/k8gb-io/k8gb/.github/workflows/helm_publish.yaml@${{ github.ref }}" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
           done
 
       - name: Create k3s cluster


### PR DESCRIPTION
### Adds Cosign signing to the Helm publish workflow to makes OCI charts secure. 

By design #2089 logic stays same but adds cosign command to sign the charts. Below are few additional or modified implementations
- Logins helm registry with GITHUB_TOKEN instead of custom CR_TOKEN. As there is issue of permissions in CR_TOKEN
- Loop through all charts in the charts/ directory
- Extract the correct version from each filename
- capture digest and sign the chart and if not digest, then sign with tag (v0.16.0) 
- Push all the charts along with latest release.
- verify if the charts are signed. 

References: https://docs.sigstore.dev/cosign/signing/other_types/
https://docs.sigstore.dev/cosign/verifying/verify/
https://tech.aabouzaid.com/2023/08/helm-chart-keyless-signing-with-sigstore-cosign.html
https://github.com/DevOpsHiveHQ/cosign-helm-chart-keyless-signing-example/blob/main/.github/workflows/sign.yaml

Fixes #1973 
Fixes #2142 
Fixes #2150

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
