### PR TITLE
fix(release): enable buildx attestation support for multi-arch images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,6 +73,20 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+
+      # Required for linux/arm64 builds on amd64 GitHub runners
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Required for multi-arch builds and OCI attestations (SBOM/provenance)
+      # Default docker driver does not support --attest
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container
+          install: true
+          use: true
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:


### PR DESCRIPTION
Switch Docker Buildx to the docker-container driver and enable QEMU to support multi-arch builds (amd64/arm64) and OCI attestations (SBOM/provenance) used by GoReleaser.

Fix tested e2e in https://github.com/k8gb-io/k8gb/actions/runs/20487499565

<img width="1485" height="537" alt="image" src="https://github.com/user-attachments/assets/51c3eb67-2471-4272-80a6-dac1fb66f654" />

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
