### PR TITLE
feat(gslb): Add support to filter out non delegated zones

### DIFF
--- a/controllers/gslb_controller_reconciliation.go
+++ b/controllers/gslb_controller_reconciliation.go
@@ -137,18 +137,8 @@ func (r *GslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return result.RequeueError(fmt.Errorf("getting GSLB servers (%s)", err))
 	}
 
-	var filteredServers []*k8gbv1beta1.Server
+	filteredServers := filterServersByDelegationZones(servers, r.Config.DelegationZones)
 
-	for _, server := range servers {
-		if r.Config.DelegationZones.ContainsZone(server.Host) {
-			filteredServers = append(filteredServers, server)
-		} else {
-			log.Debug().
-				Str("host", server.Host).
-				Strs("delegationZones", r.Config.DelegationZones.ListZones()).
-				Msg("Skipping host - does not match any delegated zone")
-		}
-	}
 	if len(filteredServers) == 0 {
 		return result.RequeueError(fmt.Errorf("no hosts match delegated zones %v", r.Config.DelegationZones.ListZones()))
 	}
@@ -238,4 +228,20 @@ func splitIPsByVersion(ips []string) ([]string, []string) {
 		}
 	}
 	return ipv4Addresses, ipv6Addresses
+}
+
+// filterServersByDelegationZones filters servers to only include those with hosts that match the delegation zones
+func filterServersByDelegationZones(servers []*k8gbv1beta1.Server, delegationZones resolver.DelegationZones) []*k8gbv1beta1.Server {
+	var filtered []*k8gbv1beta1.Server
+	for _, server := range servers {
+		if delegationZones.ContainsZone(server.Host) {
+			filtered = append(filtered, server)
+		} else {
+			log.Debug().
+				Str("host", server.Host).
+				Strs("delegationZones", delegationZones.ListZones()).
+				Msg("Skipping host - does not match any delegated zone")
+		}
+	}
+	return filtered
 }


### PR DESCRIPTION
After fetching the servers from either Ingress, HttpRoute or VirtualService the gslb reconciliation will now filter only the hosts that have been delegated to k8gb.

This allows users to use a single resource to define both k8gb hosts and non k8gb hosts.

Fixes: #2183 