### PR TITLE
fix(trivy): fixing security-scan.yml file 

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -23,9 +23,9 @@ on:
         type: choice
         options:
           - CRITICAL
-          - HIGH
-          - MEDIUM
-          - LOW
+          - HIGH,CRITICAL
+          - MEDIUM,HIGH,CRITICAL
+          - LOW,MEDIUM,HIGH,CRITICAL
 
 permissions:
   contents: read
@@ -83,13 +83,14 @@ jobs:
       - name: Run Trivy Helm chart scan
         if: ${{ github.event.inputs.scan_type == 'all' || github.event.inputs.scan_type == 'config' || github.event_name == 'schedule' }}
         uses: aquasecurity/trivy-action@0.33.1
+        env:
+          TRIVY_SEVERITY: ${{ github.event.inputs.severity || 'MEDIUM,HIGH,CRITICAL' }}
         with:
           scan-type: 'config'
           scan-ref: 'chart/k8gb'
           trivy-config: trivy.yaml
           format: 'sarif'
           output: 'trivy-helm-results.sarif'
-          severity: ${{ github.event.inputs.severity || 'MEDIUM,HIGH,CRITICAL' }}
 
       - name: Upload Helm chart scan results
         if: ${{ github.event.inputs.scan_type == 'all' || github.event.inputs.scan_type == 'config' || github.event_name == 'schedule' }}


### PR DESCRIPTION


<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
