### PR TITLE
fix(trivy): Fixing build.yml to upload same categories as security-scan.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,24 @@ jobs:
           sarif_file: 'trivy-fs-results.sarif'
           category: 'trivy-filesystem'
 
+      # Configuration scan (creates trivy-config category for security-scan.yml)
+      - name: Run Trivy configuration scan (SARIF)
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          scan-type: 'config'
+          scan-ref: '.'
+          trivy-config: trivy.yaml
+          format: 'sarif'
+          output: 'trivy-config-results.sarif'
+          exit-code: '0'
+
+      - name: Upload configuration scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4
+        if: always()
+        with:
+          sarif_file: 'trivy-config-results.sarif'
+          category: 'trivy-config'
+
       # Table output for logs (non-blocking for PRs, blocking for main branch)
       - name: Run Trivy vulnerability scanner (table output)
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
@@ -115,6 +133,26 @@ jobs:
           severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
       # Secrets should always block (in both PRs and main)
+      # First upload SARIF for Security tab (creates trivy-secrets category)
+      - name: Run Trivy secret scanner (SARIF)
+        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          trivy-config: trivy.yaml
+          format: 'sarif'
+          output: 'trivy-secret-results.sarif'
+          scanners: 'secret'
+          exit-code: '0'
+
+      - name: Upload secret scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@b20883b0cd1f46c72ae0ba6d1090936928f9fa30 # v4
+        if: always()
+        with:
+          sarif_file: 'trivy-secret-results.sarif'
+          category: 'trivy-secrets'
+
+      # Then run blocking check (table format for logs)
       - name: Run Trivy secret scanner (blocking)
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # 0.33.1
         with:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -53,7 +53,9 @@ jobs:
           trivy-config: trivy.yaml
           format: 'sarif'
           output: 'trivy-fs-results.sarif'
+          scanners: 'vuln,misconfig'
           severity: ${{ github.event.inputs.severity || 'HIGH,CRITICAL' }}
+          exit-code: '0'
 
       - name: Upload filesystem scan results
         if: ${{ github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event.inputs.scan_type == 'all' || github.event.inputs.scan_type == 'filesystem' }}
@@ -72,6 +74,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-config-results.sarif'
           severity: ${{ github.event.inputs.severity || 'HIGH,CRITICAL' }}
+          exit-code: '0'
 
       - name: Upload configuration scan results
         if: ${{ github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event.inputs.scan_type == 'all' || github.event.inputs.scan_type == 'config' }}

--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,36 @@
 
 # Add specific CVE ignores below as needed for accepted risks
 # Format: CVE-ID per line with optional comment explaining why
+
+# Trivy ignore files/dirs
+
+# Documentation directories (match anywhere in the tree)
+**/docs/**
+**/mkdocs-venv/**
+**/site/**
+**/overrides/**
+**/adr/**
+
+# Test directories
+**/tests/**
+**/terratest/**
+**/chainsaw/**
+**/dns-provider-test/**
+
+# Development/tooling directories
+**/.git/**
+**/node_modules/**
+**/hack/**
+**/deploy/**
+**/k3d/**
+**/grafana/**
+**/olm/**
+
+# Helm chart dependencies
+**/chart/k8gb/charts/**
+
+# Specific file patterns
+**/*.md
+**/*.svg
+**/*.drawio
+**/*_test.go

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -4,18 +4,19 @@ severity:
   - MEDIUM
   - LOW
 
-scanners:
-  - vuln
-  - secret
-  - misconfig
-  - license
+scan:
+  scanners:
+    - vuln
+    - secret
+    - misconfig
+    - license
 
-pkg:
+vulnerability:
   types:
     - os
     - library
+  ignore-unfixed: false
 
-ignore-unfixed: false
 timeout: 15m
 exit-code: 0
 format: table
@@ -25,6 +26,8 @@ misconfig:
 
 skip-files:
   - "**/*.md"
+  - "**/*.svg"
+  - "**/*.drawio"
   - "**/tests/**"
   - "**/*_test.go"
 


### PR DESCRIPTION
There has been a error in trivy security scan yaml file and shows neutral on every pr creation scan.

Following error:
> Code scanning cannot determine the alerts introduced by this pull request, because 2 configurations present on refs/heads/master were not found:
trivy-config
trivy-secrets

Basically what happening is, when PR runs, github tries to compare the security scan results
- Checks what categories exist on master -> finds trivy-config and trivy-secrets from scheduled scans
- Looks for same categories in PR -> can't find them because build.yml doesn't upload them

To solve this I made build.yml upload to ALL the same categories as security-scan.yml


<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
