### PR TITLE
Remove outdated workaround

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,11 +324,6 @@ deploy-k8gb-with-helm:
 	$(call setup-dns-provider-secrets,$(CLUSTER_ID))
 	helm repo add --force-update k8gb https://www.k8gb.io
 	cd chart/k8gb && helm dependency update
-	# Deletion of the coredns service is needed because of the bug below
-	# The bug is triggered by the local setup change where we start exposing the port tcp/53 using a LoadBalancer service
-	# Can be removed once we upgrade to k8gb v0.16.0
-	# https://github.com/kubernetes/kubernetes/issues/105610
-	kubectl -n k8gb delete svc k8gb-coredns --ignore-not-found
 	helm -n k8gb upgrade -i k8gb $(CHART) --version=${VERSION} \
 		-f $(call get-helm-values-file,$(CHART)) \
 		-f $(VALUES_YAML) \


### PR DESCRIPTION
Remove outdated service removal in deployment script.

Tested local e2e

```
K8GB_LOCAL_VERSION=test make deploy-full-local-setup
...
➜  k8gb git:(no-0.16) ✗ k -n test-gslb scale deploy frontend-podinfo --replicas=1 --context k3d-test-gslb1
deployment.apps/frontend-podinfo scaled
➜  k8gb git:(no-0.16) ✗ k -n test-gslb scale deploy frontend-podinfo --replicas=0 --context k3d-test-gslb1
deployment.apps/frontend-podinfo scaled
➜  k8gb git:(no-0.16) ✗ k -n test-gslb scale deploy frontend-podinfo --replicas=1 --context k3d-test-gslb1
```

`make demo` in parallel terminal - failover is proper
```
00
  "message": "Ingress NGINX: eu",
[Thu Feb  5 22:59:18 UTC 2026] ...
  "message": "Ingress NGINX: eu",

200
[Thu Feb  5 22:59:23 UTC 2026] ...

503
[Thu Feb  5 22:59:28 UTC 2026] ...

503
[Thu Feb  5 22:59:33 UTC 2026] ...

503
[Thu Feb  5 22:59:38 UTC 2026] ...

200
  "message": "Ingress NGINX: us",
[Thu Feb  5 22:59:43 UTC 2026] ...

200
  "message": "Ingress NGINX: us",
[Thu Feb  5 22:59:48 UTC 2026] ...
200
  "message": "Ingress NGINX: us",
[Thu Feb  5 22:59:43 UTC 2026] ...

200
  "message": "Ingress NGINX: us",
[Thu Feb  5 22:59:48 UTC 2026] ...

200
  "message": "Ingress NGINX: us",
[Thu Feb  5 22:59:54 UTC 2026] ...

200
  "message": "Ingress NGINX: us",
[Thu Feb  5 22:59:59 UTC 2026] ...
  "message": "Ingress NGINX: us",

200
[Thu Feb  5 23:00:04 UTC 2026] ...
  "message": "Ingress NGINX: us",

200
[Thu Feb  5 23:00:09 UTC 2026] ...
  "message": "Ingress NGINX: us",

200
[Thu Feb  5 23:00:14 UTC 2026] ...

200
  "message": "Ingress NGINX: eu",
[Thu Feb  5 23:00:19 UTC 2026] ...

200
  "message": "Ingress NGINX: eu",
```

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
