### PR TITLE
Use Scarf gateway image repos and keep local test deploys working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -719,7 +719,7 @@ endef
 # values here are only available in the not released (next) version.
 # by releases the content would be moved into get-helm-args
 define get-next-args
-$(if $(filter ./chart/k8gb,$(1)),--set extdns.txtPrefix='k8gb-$(call nth-geo-tag,$2)-' --set extdns.txtOwnerId='k8gb-$(call nth-geo-tag,$2)')
+$(if $(filter ./chart/k8gb,$(1)),--set extdns.txtPrefix='k8gb-$(call nth-geo-tag,$2)-' --set extdns.txtOwnerId='k8gb-$(call nth-geo-tag,$2)' --set-string k8gb.imageRepo='$(REPO)')
 endef
 
 define setup-dns-provider-secrets

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -6,7 +6,7 @@ global:
 
 k8gb:
   # -- image repository
-  imageRepo: "docker.io/absaoss/k8gb"
+  imageRepo: k8gb-io.gateway.scarf.sh/absaoss/k8gb
   # -- ( string ) image tag defaults to Chart.AppVersion, see Chart.yaml, but can be overrided with imageTag key
   imageTag:
   # -- whether it should also deploy the gslb and dnsendpoints CRDs
@@ -90,7 +90,7 @@ coredns:
     skipConfig: true
   image:
     # -- CoreDNS CRD plugin image
-    repository: absaoss/k8s_crd
+    repository: k8gb-io.gateway.scarf.sh/absaoss/k8s_crd
     # -- image tag
     tag: v0.2.0
   # -- Creates serviceAccount for coredns


### PR DESCRIPTION
Route image pulls through Scarf to support CNCF-approved usage metrics and a stable gateway path for distribution.

Switch Helm chart default image repositories to the Scarf gateway for both k8gb and the CoreDNS CRD plugin image.

Also set k8gb.imageRepo from $(REPO) for local chart deployments so deploy-test-version keeps using the image imported into k3d.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
