### PR TITLE
WIP: chore: bump coredns-crd-plugin to v0.2.1

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -92,7 +92,7 @@ coredns:
     # -- CoreDNS CRD plugin image
     repository: k8gb-io.gateway.scarf.sh/absaoss/k8s_crd
     # -- image tag
-    tag: v0.2.0
+    tag: v0.2.1
   # -- Creates serviceAccount for coredns
   serviceAccount:
     create: true


### PR DESCRIPTION
Updates CoreDNS CRD plugin to v0.2.1 which resolves stdlib vulnerabilities, improving k8gb's ArtifactHub security rating.

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
