### PR TITLE
ci: centralize k3d version in workflow env and use the latest one

### DIFF
--- a/.github/workflows/chainsaw.yaml
+++ b/.github/workflows/chainsaw.yaml
@@ -21,6 +21,9 @@ on:
 permissions:
   contents: read
 
+env:
+  K3D_VERSION: v5.8.3
+
 jobs:
   skip-check:
     runs-on: ubuntu-latest
@@ -80,18 +83,23 @@ jobs:
         with:
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
+
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
+
 
       - name: K8GB deployment
         run: |

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -12,8 +12,11 @@ on:
         type: string
 permissions:
   contents: read
-  id-token: write  
-  packages: write 
+  id-token: write
+  packages: write
+
+env:
+  K3D_VERSION: v5.8.3
 
 jobs:
   publish:
@@ -83,6 +86,8 @@ jobs:
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
+
       - name: Smoke test helm installation
         run: |
           helm repo add k8gb https://k8gb.io/

--- a/.github/workflows/terratest-istiov1beta1.yaml
+++ b/.github/workflows/terratest-istiov1beta1.yaml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  K3D_VERSION: v5.8.3
+
 jobs:
   terratest-istio:
     runs-on: ubuntu-24.04
@@ -40,18 +43,21 @@ jobs:
         with:
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: K8GB deployment
         run: |

--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
 
+env:
+  K3D_VERSION: v5.8.3
+
 jobs:
   terratest-n-clusters:
     runs-on: ubuntu-24.04
@@ -34,24 +37,28 @@ jobs:
         with:
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 3rd k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb3"
           args: -c k3d/test-gslb3.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: K8GB deployment
         run: |

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -21,6 +21,9 @@ on:
 permissions:
   contents: read
 
+env:
+  K3D_VERSION: v5.8.3
+
 jobs:
   skip-check:
     runs-on: ubuntu-latest
@@ -53,12 +56,12 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: ./go.mod
-      
+
       - name: Setup helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.18.4
-      
+
       - name: Build artifacts
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
@@ -72,18 +75,21 @@ jobs:
         with:
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: K8GB deployment
         run: |

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -21,6 +21,9 @@ on:
 permissions:
   contents: read
 
+env:
+  K3D_VERSION: v5.8.3
+
 jobs:
   skip-check:
     runs-on: ubuntu-latest
@@ -70,18 +73,21 @@ jobs:
         with:
           cluster-name: "edgedns"
           args: -c k3d/edge-dns.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 1st k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb1"
           args: -c k3d/test-gslb1.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: Create 2nd k3s Cluster
         uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79
         with:
           cluster-name: "test-gslb2"
           args: -c k3d/test-gslb2.yaml
+          k3d-version: ${{ env.K3D_VERSION }}
 
       - name: K8GB deploy stable version
         run: make deploy-stable-version list-running-pods


### PR DESCRIPTION
* Define K3D_VERSION once at workflow level and reference it from all `AbsaOSS/k3d-action` steps.
* Main reason is to resolve recently appearing errors in pipelines E.g. https://github.com/k8gb-io/k8gb/actions/runs/22043744882/job/63688877482
```
Downloading k3d@v5.4.6 see: https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh
Preparing to install k3d into /usr/local/bin
k3d installed into /usr/local/bin/k3d
Run 'k3d --help' to see what you can do with it.
Deploy cluster edgedns
INFO[0000] Using config file k3d/edge-dns.yaml (k3d.io/v1alpha4#simple)
ERRO[0000] Failed to get nodes for cluster 'edgedns': docker failed to get containers with labels 'map[k3d.cluster:edgedns]': failed to list containers: Error response from daemon: client version 1.41 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version
```

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
