### PR TITLE
fix(docs): deploy mike docs on master for latest 3 tags

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -55,11 +55,17 @@ jobs:
             test -f index.yaml && cp index.yaml /tmp/preserved/
             test -f CNAME && cp CNAME /tmp/preserved/
           fi
-          git checkout master      
+          git checkout master
 
       - name: Deploy documentation with Mike
         if: startsWith(github.ref, 'refs/tags/')
         run: make docs-deploy VERSION=${GITHUB_REF#refs/tags/}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy latest 3 documentation versions
+        if: github.ref == 'refs/heads/master'
+        run: make docs-deploy-last-3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -71,7 +77,7 @@ jobs:
           test -f /tmp/preserved/artifacthub-repo.yml && cp /tmp/preserved/artifacthub-repo.yml .
           test -f /tmp/preserved/index.yaml && cp /tmp/preserved/index.yaml .
           test -f /tmp/preserved/CNAME && cp /tmp/preserved/CNAME .
-          
+
           # Commit and push if there are changes
           git add .
           if ! git diff --cached --quiet; then


### PR DESCRIPTION
Run docs publishing for both release-tag pushes and docs updates on master. Tag pushes keep version-specific deployment, while master pushes now deploy the latest 3 release tags so versioned docs stay updated even when no new tag is cut.

Harden mike deployment targets in the Makefile to fail fast and restore the original git ref via trap-based cleanup. Remove error-swallowing behavior and only update the `latest` alias when deploying the newest deployable version.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
