### PR TITLE
Fix: K8gb site banner fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,20 +15,7 @@
        width="1" height="1" alt="" />
 </p>
 
-<div class="star-banner">
-  <div class="star-content">
-    <h3>⭐ Love K8GB? Show your support!</h3>
-    <p>Join <strong>1000+</strong> developers who trust K8GB for global load balancing</p>
-    <a href="https://github.com/k8gb-io/k8gb" class="star-button" target="_blank">
-      <svg class="star-icon" viewBox="0 0 16 16" width="16" height="16">
-        <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"></path>
-      </svg>
-      Star K8GB on GitHub
-    </a>
-    <p class="star-subtext">Spread the word about cloud-native global load balancing!</p>
-  </div>
-</div>
-
+<div id="star-banner-placeholder"></div>
 
 [![License: Apache_2](https://img.shields.io/badge/License-Apache_2.0-yellow.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Golang lint, golic and test](https://github.com/k8gb-io/k8gb/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/k8gb-io/k8gb/actions/workflows/build.yml)

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,2 +1,31 @@
 <!-- K8GB Material for MkDocs base template -->
 {% extends "base.html" %}
+
+{% block scripts %}
+  {{ super() }}
+  {% if page and page.file and page.file.src_path == "index.md" %}
+    <script>
+      document.addEventListener("DOMContentLoaded", function() {
+        var placeholder = document.getElementById('star-banner-placeholder');
+        if (placeholder) {
+          var banner = document.createElement('div');
+          banner.className = 'star-banner';
+          banner.innerHTML = `
+            <div class="star-content">
+              <h3>⭐ Love K8GB? Show your support!</h3>
+              <p>Join <strong>1000+</strong> developers who trust K8GB for global load balancing</p>
+              <a href="{{ config.repo_url }}" class="star-button" target="_blank" rel="noopener">
+                <svg class="star-icon" viewBox="0 0 16 16" width="16" height="16">
+                  <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.75.75 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z"></path>
+                </svg>
+                Star K8GB on GitHub
+              </a>
+              <p class="star-subtext">Spread the word about cloud-native global load balancing!</p>
+            </div>
+          `;
+          placeholder.appendChild(banner);
+        }
+      });
+    </script>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Changes in banner
Removed html template from readme file. 
And added as script in main.html to display below logo. 
Called class of banner in readme to display below k8gb logo.

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
