### PR TITLE
fix(docs): restore mkdocs.yml between mike tag checkouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -743,7 +743,7 @@ docs-deploy: ## Deploy docs with mike for VERSION (requires VERSION)
 	fi; \
 	git fetch --force --tags; \
 	ORIGINAL_REF=$$(git symbolic-ref --short -q HEAD || git rev-parse HEAD); \
-	cleanup() { git checkout --quiet "$$ORIGINAL_REF"; }; \
+	cleanup() { git checkout --quiet -- mkdocs.yml 2>/dev/null || true; git checkout --quiet "$$ORIGINAL_REF"; }; \
 	trap cleanup EXIT INT TERM; \
 	echo "Deploying documentation for $$VERSION"; \
 	if ! git show "$$VERSION:mkdocs.yml" >/dev/null 2>&1; then \
@@ -764,6 +764,7 @@ docs-deploy: ## Deploy docs with mike for VERSION (requires VERSION)
 		mike deploy --push --update-aliases "$$VERSION" latest; \
 		mike set-default --push latest; \
 	fi; \
+	git checkout --quiet -- mkdocs.yml; \
 	mike list
 
 docs-deploy-last-3: ## Deploy docs for latest 3 release tags
@@ -788,7 +789,7 @@ docs-deploy-last-3: ## Deploy docs for latest 3 release tags
 		exit 1; \
 	fi; \
 	ORIGINAL_REF=$$(git symbolic-ref --short -q HEAD || git rev-parse HEAD); \
-	cleanup() { git checkout --quiet "$$ORIGINAL_REF"; }; \
+	cleanup() { git checkout --quiet -- mkdocs.yml 2>/dev/null || true; git checkout --quiet "$$ORIGINAL_REF"; }; \
 	trap cleanup EXIT INT TERM; \
 	echo "Deploying latest 3 documentation versions:"; \
 	printf '%s\n' $$DEPLOYABLE_VERSIONS; \
@@ -803,6 +804,7 @@ docs-deploy-last-3: ## Deploy docs for latest 3 release tags
 		else \
 			mike deploy --push "$$version"; \
 		fi; \
+		git checkout --quiet -- mkdocs.yml; \
 	done; \
 	mike set-default --push latest; \
 	mike list


### PR DESCRIPTION
docs-deploy targets mutate mkdocs.yml via yq for legacy tags. Without resetting the file, the next tag checkout fails because the working tree is dirty.

Restore mkdocs.yml after each deploy and in cleanup handlers so multi-tag docs deployment remains idempotent and checkout-safe.

Should fix https://github.com/k8gb-io/k8gb/actions/runs/22233137964/job/64317862442
..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
