### PR TITLE
Add Bradley to chart metadata

### DIFF
--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -32,6 +32,8 @@ keywords:
 maintainers:
   - email: andre.aguas@protonmail.com
     name: Andre Baptista Aguas
+  - email: bradley@0ttl.ai
+    name: Bradley Andersen
   - email: dinar.valeev@absa.africa
     name: Dinar Valeev
   - email: jiri.kremser@gmail.com


### PR DESCRIPTION
Add Bradley as maintainer to proper place - `Chart.yaml`

helm-docs pipeline will eventually compile the `chart/k8gb/README.md`

Follow up to https://github.com/k8gb-io/k8gb/pull/2259

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
