### PR TITLE
docs: prevent prerelease tags from publishing to gh-pages

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -58,7 +58,7 @@ jobs:
           git checkout master
 
       - name: Deploy documentation with Mike
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')
         run: make docs-deploy VERSION=${GITHUB_REF#refs/tags/}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -754,7 +754,7 @@ docs-deploy: ## Deploy docs with mike for VERSION (requires VERSION)
 	echo "Ensuring mike version provider in mkdocs.yml for $$VERSION"; \
 	yq eval -i '.extra.version.provider = "mike"' mkdocs.yml; \
 	mike deploy --push "$$VERSION"; \
-	LATEST_VERSION=$$(git tag -l 'v*' | sort -V | awk '/^v0\.1[4-9]\.|^v0\.[2-9][0-9]\.|^v[1-9]\./' | while read version; do \
+	LATEST_VERSION=$$(git tag -l 'v*' | sort -V | awk '/^v0\.1[4-9]\.|^v0\.[2-9][0-9]\.|^v[1-9]\./ && $$0 !~ /-/' | while read version; do \
 		if git show "$$version:mkdocs.yml" >/dev/null 2>&1; then \
 			echo "$$version"; \
 		fi; \
@@ -774,7 +774,7 @@ docs-deploy-last-3: ## Deploy docs for latest 3 release tags
 		exit 1; \
 	fi; \
 	git fetch --force --tags; \
-	VERSIONS=$$(git tag -l 'v*' | sort -V | awk '/^v0\.1[4-9]\.|^v0\.[2-9][0-9]\.|^v[1-9]\./' | tail -n 3); \
+	VERSIONS=$$(git tag -l 'v*' | sort -V | awk '/^v0\.1[4-9]\.|^v0\.[2-9][0-9]\.|^v[1-9]\./ && $$0 !~ /-/' | tail -n 3); \
 	if [ -z "$$VERSIONS" ]; then \
 		echo "ERROR: no release tags found to deploy docs"; \
 		exit 1; \


### PR DESCRIPTION
Prevent RC/test tags (for example, v0.99.0-rc-ghcrtest1) from being published to the docs site and from being selected as the latest version alias.

This updates the gh-pages workflow to skip tag refs containing a dash, and hardens Makefile docs deployment tag selection logic to exclude prerelease tags when computing latest and latest-3 versions.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
