### PR TITLE
DynamicZones (2/4): add Helm chart integration and installation support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ DNS_ZONE ?= cloud.example.com
 DEMO_URL ?= http://failover.cloud.example.com
 DEMO_DEBUG ?=0
 DEMO_DELAY ?=5
-GSLB_CRD_YAML ?= chart/k8gb/crd/k8gb.io_gslbs.yaml
-DZ_CRD_YAML ?= chart/k8gb/crd/k8gb.io_zonedelegation.yaml
+GSLB_CRD_YAML ?= chart/k8gb/crd/k8gb.absa.oss_gslbs.yaml
+ZD_CRD_YAML ?= chart/k8gb/crd/k8gb.io_zonedelegation.yaml
 
 # GCP Cloud DNS testing variables
 GCP_PROJECT ?=
@@ -711,7 +711,7 @@ define crd-manifest
 	@echo -e "\n$(YELLOW)Generating the CRD manifests$(NC)"
 	$(GOBIN)/controller-gen crd:crdVersions=v1 paths="./api/v1beta1" output:crd:stdout > $(GSLB_CRD_YAML)
 	@echo -e "\n$(YELLOW)Generating the k8gb.io CRD manifests$(NC)"
-	$(GOBIN)/controller-gen crd:crdVersions=v1 paths="./api/k8gb.io/v1beta1" output:crd:stdout > $(DZ_CRD_YAML)
+	$(GOBIN)/controller-gen crd:crdVersions=v1 paths="./api/k8gb.io/v1beta1" output:crd:stdout > $(ZD_CRD_YAML)
 endef
 
 define install-controller-gen

--- a/chart/k8gb/templates/clusterrole.yaml
+++ b/chart/k8gb/templates/clusterrole.yaml
@@ -7,6 +7,19 @@ metadata:
   labels:
 {{ include "chart.labels" . | indent 4  }}
 rules:
+{{- if .Values.k8gb.dynamicZones }}
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  verbs:
+    - list
+    - get
+    - update
+    - patch
+  resourceNames:
+    - "coredns-dynamic"
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -8,18 +8,12 @@ metadata:
 {{ include "chart.labels" . | indent 4  }}
 data:
   Corefile: |-
-{{- range .Values.k8gb.dnsZones }}
-    {{ .loadBalancedZone }}:5353 {
+    (k8gbplugins) {
         errors
         health
         {{- if $.Values.coredns.corefile.reload.enabled }}
         reload {{ $.Values.coredns.corefile.reload.interval }} {{ $.Values.coredns.corefile.reload.jitter }}
         {{- end }}
-{{- if .extraPlugins }}
-{{- range .extraPlugins }}
-{{ . | nindent 8 }}
-{{- end }}
-{{- end }}
         ready
         prometheus 0.0.0.0:9153
         forward . /etc/resolv.conf
@@ -35,8 +29,29 @@ data:
             {{- end }}
         }
     }
+{{- range .Values.k8gb.dnsZones }}
+    {{ .loadBalancedZone }}:5353 {
+        import k8gbplugins
+{{- if .extraPlugins }}
+{{- range .extraPlugins }}
+{{ . | nindent 8 }}
 {{- end }}
-    {{- with .extraServerBlocks -}}
-    {{- tpl . $ | nindent 4 }}
-    {{- end }}
+{{- end }}
+    }
+{{- end }}
+{{- with .extraServerBlocks -}}
+{{- tpl . $ | nindent 4 }}
+{{- end }}
+{{- if .Values.k8gb.dynamicZones }}
+    import ../dynamic/*.conf
+{{- end }}
+{{- end }}
+---
+{{- if .Values.k8gb.dynamicZones }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-dynamic
+  namespace: {{ .Release.Namespace }}
+data: {}
 {{- end }}

--- a/chart/k8gb/templates/crds-template.yaml
+++ b/chart/k8gb/templates/crds-template.yaml
@@ -2,6 +2,7 @@
 
 {{- $files := .Files }}
 {{ $files.Get "crd/k8gb.io_gslbs.yaml" }}
+{{ $files.Get "crd/k8gb.io_zonedelegation.yaml" }}
 {{- if .Values.k8gb.installLegacyCrds }}
 {{ $files.Get "crd/k8gb.absa.oss_gslbs.yaml" }}
 {{- end }}

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -142,6 +142,8 @@ spec:
               value: "true"
             - name: METRICS_ADDRESS
               value: {{ .Values.k8gb.metricsAddress }}
+            - name: DYNAMIC_ZONES
+              value: {{ .Values.k8gb.dynamicZones | quote }}
       {{- if .Values.tracing.enabled }}
         - image: {{ .Values.tracing.sidecarImage.repository }}:{{ .Values.tracing.sidecarImage.tag }}
           name: otel-collector

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -345,6 +345,70 @@
                 "deployRbac": {
                     "type": "boolean"
                 },
+                "dynamicZones": {
+                    "type": "boolean"
+                },
+                "extraVolumeMounts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["name", "mountPath"],
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "mountPath": {
+                                "type": "string"
+                            },
+                            "readOnly": {
+                                "type": "boolean"
+                            },
+                            "subPath": {
+                                "type": "string"
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
+                "extraVolumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "required": ["name"],
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "configMap": {
+                                "type": "object",
+                                "required": ["name"],
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "optional": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "additionalProperties": false
+                            },
+                            "secret": {
+                                "type": "object",
+                                "required": ["secretName"],
+                                "properties": {
+                                    "secretName": {
+                                        "type": "string"
+                                    },
+                                    "optional": {
+                                        "type": "boolean"
+                                    }
+                                },
+                                "additionalProperties": false
+                            }
+                        },
+                        "additionalProperties": false
+                    }
+                },
                 "dnsZones": {
                     "type": "array",
                     "items": {

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -15,6 +15,17 @@ k8gb:
   installLegacyCrds: true
   # -- whether it should also deploy the service account, cluster role and cluster role binding
   deployRbac: true
+  # -- whether to use Dynamic Zone Delegation feature
+  dynamicZones: false
+  # -- dynamic zones configmap
+  extraVolumeMounts:
+    - name: dynamic-zones
+      mountPath: /etc/dynamic
+  extraVolumes:
+    - name: dynamic-zones
+      configMap:
+        name: coredns-dynamic
+        optional: true
   # DNSZones - For backward compatibility, the dnsZone and edgeDNSZone fields are allowed; otherwise,
   # the dnsZones array is used. For valid values, use either dnsZone and edgeDNSZone or dnsZones.
   #

--- a/controllers/resolver/config.go
+++ b/controllers/resolver/config.go
@@ -55,6 +55,8 @@ type Config struct {
 
 	MetricsAddress string `env:"METRICS_ADDRESS" optional:"" default:"0.0.0.0:8080" validate:"iphostport" help:"format address:port where address can be empty, IP address, or hostname, e.g: 10.10.0.0:8080"`
 
+	DynamicZones bool `env:"DYNAMIC_ZONES" optional:"" default:"false" help:"decides whether to use dynamic zones"`
+
 	TracingEnabled bool `env:"TRACING_ENABLED" optional:"" default:"false" help:"decides whether to use a real otlp tracer or a noop one"`
 
 	TracingSamplingRatio float64 `env:"TRACING_SAMPLING_RATIO" optionl:"" default:"1.0" help:"how many traces should be kept and sent (1.0 - all, 0.0 - none)"`

--- a/deploy/helm/next.yaml
+++ b/deploy/helm/next.yaml
@@ -1,5 +1,16 @@
 k8gb:
   reconcileRequeueSeconds: 10
+
+  dynamicZones: false
+  extraVolumeMounts:
+    - name: dynamic-zones
+      mountPath: /etc/dynamic
+  extraVolumes:
+    - name: dynamic-zones
+      configMap:
+        name: coredns-dynamic
+        optional: true
+
   dnsZones:
     - dnsZoneNegTTL: 10
       loadBalancedZone: cloud.example.com


### PR DESCRIPTION
This PR extends the Helm chart to support DynamicZones installation introduced in PR #2102 originally implemented by @k0da.

Changes include:

- new dynamicZones toggle in values.yaml
- schema validation updates in values.schema.json
- support for extraVolumes and extraVolumeMounts
- CoreDNS ConfigMap adjustments to mount dynamic zone configuration
- validation against upgrade pipeline scenarios

No application code changes are included.
