### PR TITLE
feat: master as part of version selector in docs site

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -63,6 +63,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Deploy master documentation
+        if: github.ref == 'refs/heads/master'
+        run: make docs-deploy-master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Deploy latest 3 documentation versions
         if: github.ref == 'refs/heads/master'
         run: make docs-deploy-last-3

--- a/Makefile
+++ b/Makefile
@@ -725,7 +725,7 @@ endef
 
 # Documentation with Mkdocs
 
-.PHONY: docs-deploy docs-deploy-master docs-deploy-last-3 docs-list
+.PHONY: docs-list docs-deploy docs-deploy-master docs-deploy-last-3
 
 docs-list: ## List deployed versions
 	mike list

--- a/Makefile
+++ b/Makefile
@@ -725,7 +725,7 @@ endef
 
 # Documentation with Mkdocs
 
-.PHONY: docs-deploy docs-deploy-last-3 docs-list
+.PHONY: docs-deploy docs-deploy-master docs-deploy-last-3 docs-list
 
 docs-list: ## List deployed versions
 	mike list
@@ -766,6 +766,17 @@ docs-deploy: ## Deploy docs with mike for VERSION (requires VERSION)
 	fi; \
 	git checkout --quiet -- mkdocs.yml; \
 	mike list
+
+docs-deploy-master: ## Deploy docs for master branch
+	@set -eu; \
+	if ! command -v yq >/dev/null 2>&1; then \
+		echo "ERROR: yq is required (https://github.com/mikefarah/yq)"; \
+		exit 1; \
+	fi; \
+	echo "Deploying documentation for master branch"; \
+	yq eval -i '.extra.version.provider = "mike"' mkdocs.yml; \
+	mike deploy --push master; \
+	git checkout --quiet -- mkdocs.yml
 
 docs-deploy-last-3: ## Deploy docs for latest 3 release tags
 	@set -eu; \

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -2,7 +2,13 @@
 :root {
   --md-primary-fg-color: #7b0000 !important;
   --md-primary-fg-color--light: #8b0000 !important;
-  --md-primary-fg-color--dark: #e53935 !important;
+  --md-primary-fg-color--dark: #e07070 !important;
+}
+
+/* Sidebar section labels in dark mode — readable rose-red, not harsh */
+[data-md-color-scheme="slate"] .md-nav__title,
+[data-md-color-scheme="slate"] .md-nav__item--section > .md-nav__link {
+  color: #e07070 !important;
 }
 
 /* Header styling */
@@ -17,9 +23,9 @@
 [data-md-color-scheme="slate"] .md-header,
 [data-md-color-scheme="slate"] .md-header[data-md-component="header"],
 [data-md-color-scheme="slate"] header.md-header {
-  background-color: #c62828 !important;
-  background: #c62828 !important;
-  border-bottom: 1px solid #a52a2a !important;
+  background-color: #3d1010 !important;
+  background: #3d1010 !important;
+  border-bottom: 1px solid #2a0a0a !important;
 }
 
 /* Header text color (excluding star button) */
@@ -94,8 +100,8 @@
 }
 
 [data-md-color-scheme="slate"] .md-tabs {
-  background-color: #c62828 !important;
-  border-bottom: 1px solid #a52a2a !important;
+  background-color: #3d1010 !important;
+  border-bottom: 1px solid #2a0a0a !important;
 }
 
 [data-md-color-scheme="slate"] .md-tabs__link {
@@ -163,8 +169,8 @@
 }
 
 [data-md-color-scheme="slate"] .star-banner {
-  background: linear-gradient(135deg, #c62828 0%, #e53935 100%);
-  box-shadow: 0 4px 20px rgba(198, 40, 40, 0.4);
+  background: linear-gradient(135deg, #3d1010 0%, #6b1a1a 100%);
+  box-shadow: 0 4px 20px rgba(61, 16, 16, 0.5);
 }
 
 /* Header star button */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -5,7 +5,7 @@
   --md-primary-fg-color--dark: #e07070 !important;
 }
 
-/* Sidebar section labels in dark mode — readable rose-red, not harsh */
+/* Sidebar section labels in dark mode */
 [data-md-color-scheme="slate"] .md-nav__title,
 [data-md-color-scheme="slate"] .md-nav__item--section > .md-nav__link {
   color: #e07070 !important;


### PR DESCRIPTION
I have added master branch deploy logic in Makefile.
Also fixed theme in dark mode as red colour looked too vivid.

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
