### PR TITLE
feat: Pipeline doesn't rely on init-ingress but service type LoadBalancer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,17 +229,22 @@ deploy-local-cluster:
 	helm -n k8gb upgrade -i nginx-ingress nginx-stable/ingress-nginx \
 		--version "$(NGINX_INGRESS_VERSION)" -f $(NGINX_INGRESS_VALUES_PATH)
 
-	@echo -e "\n$(YELLOW)Create coredns init-ingress $(NC)"
-	kubectl apply -f ./deploy/gslb/init-ingress.yaml
-	@echo -e "\n$(YELLOW)Wait for ingress IP $(NC)"
-	@while [ -z "$$(kubectl get ingress init-ingress -n k8gb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do \
-		echo "Waiting for external IP..."; \
-		sleep 5; \
-	done
-	@echo "Ingress is ready with IP: $$(kubectl get ingress init-ingress -n k8gb -o jsonpath='{.status.loadBalancer.ingress[0].ip}')"
-
 	@echo -e "\n$(YELLOW)Deploy GSLB operator from $(VERSION) $(NC)"
 	$(MAKE) deploy-k8gb-with-helm
+
+	@echo -e "\n$(YELLOW)Wait for CoreDNS service to exist $(NC)"
+	@until kubectl get svc k8gb-coredns -n k8gb >/dev/null 2>&1; do \
+		echo "Waiting for CoreDNS service..."; \
+		sleep 10; \
+	done
+
+	@echo -e "\n$(YELLOW)Wait for CoreDNS service external IPs (2) $(NC)"
+	@while [ "$$(kubectl get svc k8gb-coredns -n k8gb -o jsonpath='{.status.loadBalancer.ingress[*].ip}' 2>/dev/null | wc -w)" -lt 2 ]; do \
+		echo "Waiting for CoreDNS service external IPs..."; \
+		sleep 10; \
+	done
+
+	@echo "CoreDNS service is ready with IPs: $$(kubectl get svc k8gb-coredns -n k8gb -o jsonpath='{.status.loadBalancer.ingress[*].ip}' 2>/dev/null)"
 
 	@echo -e "\n$(YELLOW)Install Gateway API CRDs $(NC)"
 	kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml

--- a/chainsaw/step-templates/assert-dnsendpoint.yaml
+++ b/chainsaw/step-templates/assert-dnsendpoint.yaml
@@ -22,7 +22,7 @@ spec:
         EXPECTED_TARGETS=gslb-ns-eu-cloud.example.com,gslb-ns-us-cloud.example.com
         EXPECTED_A_RECORD=A
         EXPECTED_GLUE_NAME=gslb-ns-$GEO_TAG-cloud.example.com
-        EXPECTED_GLUE_TARGETS=$(kubectl get ing -n k8gb init-ingress -ojson | jq -r '[.status.loadBalancer.ingress[].ip] | join(",")')
+        EXPECTED_GLUE_TARGETS=$(kubectl get svc k8gb-coredns -n k8gb -o json | jq -r '[.status.loadBalancer.ingress[].ip] | join(",")')
         
         ACTUAL_NS_RECORD=$(kubectl get dnsendpoint k8gb-ns-extdns-cloud-example-com -n k8gb -o json | jq -r '.spec.endpoints[0].recordType')
         ACTUAL_DNS_NAME=$(kubectl get dnsendpoint k8gb-ns-extdns-cloud-example-com -n k8gb -o json | jq -r '.spec.endpoints[0].dnsName')

--- a/k3d/test-gslb1.yaml
+++ b/k3d/test-gslb1.yaml
@@ -42,6 +42,11 @@ ports:
       - loadbalancer
 options:
   k3s:
+    nodeLabels:
+      - label: svccontroller.k3s.cattle.io/enablelb=true
+        nodeFilters:
+          - agent:*
+          - server:*
     extraArgs:
       - arg: --disable=traefik,metrics-server,local-storage
         nodeFilters:

--- a/k3d/test-gslb2.yaml
+++ b/k3d/test-gslb2.yaml
@@ -38,6 +38,11 @@ ports:
       - loadbalancer
 options:
   k3s:
+    nodeLabels:
+      - label: svccontroller.k3s.cattle.io/enablelb=true
+        nodeFilters:
+          - agent:*
+          - server:*
     extraArgs:
       - arg: --disable=traefik,metrics-server,local-storage
         nodeFilters:


### PR DESCRIPTION
Our pipeline no longer depends on init-ingress, which previously served as one of the sources of IP addresses. In our case, it addressed an undocumented chicken-and-egg problem, where we had to wait for k8gb to obtain IP addresses to prevent failures during bootstrap. This issue no longer occurs.

We intentionally expose two IP addresses (even though a single one would be sufficient) to maintain consistency with tests that expect and validate two IP addresses.

(im enabling loadbalancer for servers and agents in us/eu regions )