### PR TITLE
Fix: Sync blogs across all versions

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -84,6 +84,14 @@ jobs:
           test -f /tmp/preserved/index.yaml && cp /tmp/preserved/index.yaml .
           test -f /tmp/preserved/CNAME && cp /tmp/preserved/CNAME .
 
+      - name: Sync blog posts to all versions
+        if: github.ref == 'refs/heads/master'
+        run: make docs-sync-blog
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and push
+        run: |
           # Commit and push if there are changes
           git add .
           if ! git diff --cached --quiet; then

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Restore preserved files
         run: |
+          git fetch origin gh-pages:gh-pages
           git checkout gh-pages
           # Restore preserved files
           test -d /tmp/preserved/charts && cp -r /tmp/preserved/charts .

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -77,27 +77,29 @@ jobs:
 
       - name: Restore preserved files
         run: |
-          git fetch origin gh-pages:gh-pages
-          git checkout gh-pages
+          git fetch --force origin gh-pages:gh-pages
+          GHPAGES_DIR="${RUNNER_TEMP}/gh-pages"
+          echo "GHPAGES_DIR=${GHPAGES_DIR}" >> "${GITHUB_ENV}"
+          git worktree add "${GHPAGES_DIR}" gh-pages
           # Restore preserved files
-          test -d /tmp/preserved/charts && cp -r /tmp/preserved/charts .
-          test -f /tmp/preserved/artifacthub-repo.yml && cp /tmp/preserved/artifacthub-repo.yml .
-          test -f /tmp/preserved/index.yaml && cp /tmp/preserved/index.yaml .
-          test -f /tmp/preserved/CNAME && cp /tmp/preserved/CNAME .
+          for path in charts artifacthub-repo.yml index.yaml CNAME; do
+            if [ -e "/tmp/preserved/${path}" ]; then
+              cp -r "/tmp/preserved/${path}" "${GHPAGES_DIR}/"
+            fi
+          done
 
       - name: Sync blog posts to all versions
         if: github.ref == 'refs/heads/master'
         run: make docs-sync-blog
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit and push
         run: |
           # Commit and push if there are changes
-          git add .
-          if ! git diff --cached --quiet; then
-            git commit -m "Deploy documentation from ${{ github.sha }}"
-            git push origin gh-pages
+          git -C "${GHPAGES_DIR}" add .
+          if ! git -C "${GHPAGES_DIR}" diff --cached --quiet; then
+            COMMIT_MESSAGE="Deploy documentation from ${{ github.sha }}"
+            git -C "${GHPAGES_DIR}" commit -m "${COMMIT_MESSAGE}"
+            git -C "${GHPAGES_DIR}" push origin gh-pages
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -55,7 +55,7 @@ jobs:
             test -f index.yaml && cp index.yaml /tmp/preserved/
             test -f CNAME && cp CNAME /tmp/preserved/
           fi
-          git checkout master
+          git checkout "$GITHUB_REF_NAME"
 
       - name: Deploy documentation with Mike
         if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-')

--- a/Makefile
+++ b/Makefile
@@ -804,23 +804,25 @@ docs-list: ## List deployed versions
 
 docs-sync-blog: ## Sync blog posts to all deployed documentation versions
 	@set -eu; \
-	git fetch origin gh-pages:gh-pages --quiet; \
-	if ! git checkout gh-pages 2>/dev/null; then \
-		echo "WARN: gh-pages not found, skipping blog sync"; \
-		exit 0; \
+	echo "Syncing blog posts across all deployed versions..."; \
+	if [ ! -d "blog" ]; then \
+		echo "ERROR: blog/ directory not found. This target must be run from gh-pages branch after deployment."; \
+		exit 1; \
 	fi; \
-	BLOG_DIR="docs/blog"; \
-	if [ ! -d "$$BLOG_DIR/posts" ]; then \
-		echo "No blog posts to sync"; \
-		exit 0; \
-	fi; \
-	for version in */; do \
-		if [ -d "$$version/$$BLOG_DIR" ]; then \
-			echo "Syncing blog to $$version"; \
-			cp -n "$$BLOG_DIR/posts"/*.md "$$version/$$BLOG_DIR/posts/" 2>/dev/null || true; \
-			cp -n "$$BLOG_DIR/blog-banners"/* "$$version/$$BLOG_DIR/blog-banners/" 2>/dev/null || true; \
+	SYNCED_COUNT=0; \
+	for version_dir in v*/; do \
+		if [ -d "$$version_dir" ] && [ -d "$$version_dir/blog" ]; then \
+			echo "Syncing blog to $$version_dir"; \
+			rm -rf "$$version_dir/blog"; \
+			cp -r blog "$$version_dir/blog"; \
+			SYNCED_COUNT=$$((SYNCED_COUNT + 1)); \
 		fi \
-	done
+	done; \
+	if [ $$SYNCED_COUNT -eq 0 ]; then \
+		echo "WARN: No versioned directories found to sync"; \
+	else \
+		echo "Successfully synced blog to $$SYNCED_COUNT version(s)"; \
+	fi
 
 docs-deploy: ## Deploy docs with mike for VERSION (requires VERSION)
 	@if [ -z "$(VERSION)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -797,10 +797,30 @@ endef
 
 # Documentation with Mkdocs
 
-.PHONY: docs-list docs-deploy docs-deploy-master docs-deploy-last-3
+.PHONY: docs-list docs-deploy docs-deploy-master docs-deploy-last-3 docs-sync-blog
 
 docs-list: ## List deployed versions
 	mike list
+
+docs-sync-blog: ## Sync blog posts to all deployed documentation versions
+	@set -eu; \
+	git fetch origin gh-pages:gh-pages --quiet; \
+	if ! git checkout gh-pages 2>/dev/null; then \
+		echo "WARN: gh-pages not found, skipping blog sync"; \
+		exit 0; \
+	fi; \
+	BLOG_DIR="docs/blog"; \
+	if [ ! -d "$$BLOG_DIR/posts" ]; then \
+		echo "No blog posts to sync"; \
+		exit 0; \
+	fi; \
+	for version in */; do \
+		if [ -d "$$version/$$BLOG_DIR" ]; then \
+			echo "Syncing blog to $$version"; \
+			cp -n "$$BLOG_DIR/posts"/*.md "$$version/$$BLOG_DIR/posts/" 2>/dev/null || true; \
+			cp -n "$$BLOG_DIR/blog-banners"/* "$$version/$$BLOG_DIR/blog-banners/" 2>/dev/null || true; \
+		fi \
+	done
 
 docs-deploy: ## Deploy docs with mike for VERSION (requires VERSION)
 	@if [ -z "$(VERSION)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -802,27 +802,8 @@ endef
 docs-list: ## List deployed versions
 	mike list
 
-docs-sync-blog: ## Sync blog posts to all deployed documentation versions
-	@set -eu; \
-	echo "Syncing blog posts across all deployed versions..."; \
-	if [ ! -d "blog" ]; then \
-		echo "ERROR: blog/ directory not found. This target must be run from gh-pages branch after deployment."; \
-		exit 1; \
-	fi; \
-	SYNCED_COUNT=0; \
-	for version_dir in v*/; do \
-		if [ -d "$$version_dir" ] && [ -d "$$version_dir/blog" ]; then \
-			echo "Syncing blog to $$version_dir"; \
-			rm -rf "$$version_dir/blog"; \
-			cp -r blog "$$version_dir/blog"; \
-			SYNCED_COUNT=$$((SYNCED_COUNT + 1)); \
-		fi \
-	done; \
-	if [ $$SYNCED_COUNT -eq 0 ]; then \
-		echo "WARN: No versioned directories found to sync"; \
-	else \
-		echo "Successfully synced blog to $$SYNCED_COUNT version(s)"; \
-	fi
+docs-sync-blog: ## Sync blog posts to all deployed documentation versions (requires GHPAGES_DIR)
+	@hack/docs-sync-blog.sh "$(GHPAGES_DIR)"
 
 docs-deploy: ## Deploy docs with mike for VERSION (requires VERSION)
 	@if [ -z "$(VERSION)" ]; then \

--- a/hack/docs-sync-blog.sh
+++ b/hack/docs-sync-blog.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+ghpages_dir="${1:-${GHPAGES_DIR:-}}"
+site_url_base="${SITE_URL_BASE:-https://k8gb.io}"
+site_url_base="${site_url_base%/}"
+
+[[ -n "$ghpages_dir" ]] || die "GHPAGES_DIR is required"
+[[ -d "$ghpages_dir" ]] || die "GHPAGES_DIR does not exist: $ghpages_dir"
+[[ -d docs/blog ]] || die "docs/blog not found; run from the source checkout"
+
+require_cmd find
+require_cmd mkdocs
+require_cmd yq
+
+versions=()
+while IFS= read -r version; do
+  versions+=("$version")
+done < <(find "$ghpages_dir" -mindepth 1 -maxdepth 1 -type d -name 'v*' \
+  -exec basename {} \; | sort -V)
+
+if [[ "${#versions[@]}" -eq 0 ]]; then
+  echo "WARN: No versioned directories found to sync"
+  exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+echo "Syncing blog posts across all deployed versions..."
+for version in "${versions[@]}"; do
+  site_dir="$tmp_dir/$version"
+  echo "Building blog for $version"
+
+  yq eval ".site_url = \"$site_url_base/$version\" | .extra.version.provider = \"mike\"" mkdocs.yml \
+    | mkdocs build --config-file - --site-dir "$site_dir"
+
+  [[ -d "$site_dir/blog" ]] || die "mkdocs did not produce blog output for $version"
+
+  rm -rf "$ghpages_dir/$version/blog"
+  mkdir -p "$ghpages_dir/$version"
+  cp -R "$site_dir/blog" "$ghpages_dir/$version/blog"
+done
+
+echo "Successfully synced blog to ${#versions[@]} version(s)"


### PR DESCRIPTION
All blog posts now available across all versions immediately, not just when new release cuts

Fixes: #2330 

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
