### PR TITLE
ci: switch Harden-Runner from audit to block mode in all workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,7 @@ jobs:
         allowed-endpoints: |
           github.com:443
           api.github.com:443
-          proxy.golang.org:443
-          sum.golang.org:443
-          sumdb.google.dev:443
+          objects.githubusercontent.com:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,11 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          proxy.golang.org
+          sumdb.google.dev
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,11 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          proxy.golang.org
-          sumdb.google.dev
+          github.com:443
+          api.github.com:443
+          proxy.golang.org:443
+          sum.golang.org:443
+          sumdb.google.dev:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,7 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com:443
           api.github.com:443
-          objects.githubusercontent.com:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
@@ -51,6 +49,8 @@ jobs:
     needs: skip-check
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     steps:
+      # Harden Runner also drops public UDP/53 in audit mode. Keep this job exempt until
+      # controllers/utils/dns_test.go uses local DNS fixtures; otherwise tests fail or skip.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
         egress-policy: block
-        allowed-endpoints: |
+        allowed-endpoints: >-
           api.github.com:443
 
     - id: skip_check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,11 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          proxy.golang.org
-          sumdb.google.dev
+          github.com:443
+          api.github.com:443
+          proxy.golang.org:443
+          sum.golang.org:443
+          sumdb.google.dev:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,7 @@ jobs:
         allowed-endpoints: |
           github.com:443
           api.github.com:443
-          proxy.golang.org:443
-          sum.golang.org:443
-          sumdb.google.dev:443
+          objects.githubusercontent.com:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,11 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          proxy.golang.org
+          sumdb.google.dev
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2

--- a/.github/workflows/chainsaw.yaml
+++ b/.github/workflows/chainsaw.yaml
@@ -34,7 +34,12 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          docker.io
+          gcr.io
+          registry.k8s.io
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1

--- a/.github/workflows/chainsaw.yaml
+++ b/.github/workflows/chainsaw.yaml
@@ -36,10 +36,14 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          docker.io
-          gcr.io
-          registry.k8s.io
+          github.com:443
+          api.github.com:443
+          proxy.golang.org:443
+          sum.golang.org:443
+          sumdb.google.dev:443
+          docker.io:443
+          gcr.io:443
+          registry.k8s.io:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1

--- a/.github/workflows/chainsaw.yaml
+++ b/.github/workflows/chainsaw.yaml
@@ -42,7 +42,40 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          # Audit: https://github.com/k8gb-io/k8gb/actions/runs/34329541730
+          # Include Go/tool downloads on cache misses and regional Kubernetes registry redirects.
+          allowed-endpoints: |
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            auth.docker.io:443
+            registry-1.docker.io:443
+            production.cloudfront.docker.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            gcr.io:443
+            k8s.gcr.io:443
+            registry.k8s.io:443
+            cdn.registry.k8s.io:443
+            *-docker.pkg.dev:443
+            registry.istio.io:443
+            registry.k8gb.io:443
+            get.helm.sh:443
+            coredns.github.io:443
+            kubernetes-sigs.github.io:443
+            kubernetes.github.io:443
+            istio-release.storage.googleapis.com:443
+            stefanprodan.github.io:443
+            k8gb.io:443
+            www.k8gb.io:443
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/chainsaw.yaml
+++ b/.github/workflows/chainsaw.yaml
@@ -45,7 +45,7 @@ jobs:
           egress-policy: block
           # Audit: https://github.com/k8gb-io/k8gb/actions/runs/34329541730
           # Include Go/tool downloads on cache misses and regional Kubernetes registry redirects.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -22,6 +22,7 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
             hub.docker.com:443
             doc.crds.dev:443
 

--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -18,7 +18,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            hub.docker.com
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -20,8 +20,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            hub.docker.com
+            github.com:443
+            api.github.com:443
+            hub.docker.com:443
+            doc.crds.dev:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           egress-policy: block
           # GitHub release/PR data and CRD documentation indexing.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             doc.crds.dev:443

--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -19,11 +19,10 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
+          # GitHub release/PR data and CRD documentation indexing.
           allowed-endpoints: |
-            github.com:443
             api.github.com:443
-            objects.githubusercontent.com:443
-            hub.docker.com:443
+            github.com:443
             doc.crds.dev:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -18,7 +18,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            hub.docker.com
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/changelog_pr.yaml
+++ b/.github/workflows/changelog_pr.yaml
@@ -20,8 +20,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            hub.docker.com
+            github.com:443
+            api.github.com:443
+            hub.docker.com:443
+            doc.crds.dev:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,11 +52,10 @@ jobs:
         allowed-endpoints: |
           github.com:443
           api.github.com:443
+          uploads.github.com:443
           githubproxy.com:443
           objects.githubusercontent.com:443
-          proxy.golang.org:443
-          sum.golang.org:443
-          sumdb.google.dev:443
+
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,9 +50,13 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          githubproxy.com
-          objects.githubusercontent.com
+          github.com:443
+          api.github.com:443
+          githubproxy.com:443
+          objects.githubusercontent.com:443
+          proxy.golang.org:443
+          sum.golang.org:443
+          sumdb.google.dev:443
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,11 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          githubproxy.com
+          objects.githubusercontent.com
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,11 +52,10 @@ jobs:
         allowed-endpoints: |
           github.com:443
           api.github.com:443
+          uploads.github.com:443
           githubproxy.com:443
           objects.githubusercontent.com:443
-          proxy.golang.org:443
-          sum.golang.org:443
-          sumdb.google.dev:443
+
 
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,9 +50,13 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          githubproxy.com
-          objects.githubusercontent.com
+          github.com:443
+          api.github.com:443
+          githubproxy.com:443
+          objects.githubusercontent.com:443
+          proxy.golang.org:443
+          sum.golang.org:443
+          sumdb.google.dev:443
 
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,11 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          githubproxy.com
+          objects.githubusercontent.com
 
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,11 +16,13 @@ on:
     branches: [ master ]
     paths:
        - '**.go'
+       - '.github/workflows/codeql-analysis.yml'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
     paths:
        - '**.go'
+       - '.github/workflows/codeql-analysis.yml'
   schedule:
     - cron: '45 7 * * 5'
 
@@ -49,13 +51,19 @@ jobs:
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
         egress-policy: block
+        # Go autobuild and CodeQL downloads/uploads, including an empty module/tool cache.
         allowed-endpoints: |
-          github.com:443
           api.github.com:443
-          uploads.github.com:443
-          githubproxy.com:443
+          github.com:443
           objects.githubusercontent.com:443
-
+          raw.githubusercontent.com:443
+          release-assets.githubusercontent.com:443
+          go.dev:443
+          dl.google.com:443
+          proxy.golang.org:443
+          storage.googleapis.com:443
+          sum.golang.org:443
+          uploads.github.com:443
 
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,7 +52,7 @@ jobs:
       with:
         egress-policy: block
         # Go autobuild and CodeQL downloads/uploads, including an empty module/tool cache.
-        allowed-endpoints: |
+        allowed-endpoints: >-
           api.github.com:443
           github.com:443
           objects.githubusercontent.com:443

--- a/.github/workflows/curldemo.yaml
+++ b/.github/workflows/curldemo.yaml
@@ -24,9 +24,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            ghcr.io
-            docker.io
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            docker.io:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/curldemo.yaml
+++ b/.github/workflows/curldemo.yaml
@@ -22,7 +22,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            ghcr.io
+            docker.io
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/curldemo.yaml
+++ b/.github/workflows/curldemo.yaml
@@ -23,11 +23,18 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
+          # Docker Hub authentication/blobs for the base image and GHCR pushes.
           allowed-endpoints: |
-            github.com:443
             api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            auth.docker.io:443
+            registry-1.docker.io:443
+            production.cloudfront.docker.com:443
             ghcr.io:443
-            docker.io:443
+            pkg-containers.githubusercontent.com:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/curldemo.yaml
+++ b/.github/workflows/curldemo.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           egress-policy: block
           # Docker Hub authentication/blobs for the base image and GHCR pushes.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/curldemo.yaml
+++ b/.github/workflows/curldemo.yaml
@@ -22,7 +22,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            ghcr.io
+            docker.io
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/curldemo.yaml
+++ b/.github/workflows/curldemo.yaml
@@ -24,9 +24,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            ghcr.io
-            docker.io
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            docker.io:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -15,9 +15,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -19,7 +19,8 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
+            github.com:443
+            api.github.com:443
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
           allowed-endpoints: |

--- a/.github/workflows/cut_release.yaml
+++ b/.github/workflows/cut_release.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
-          allowed-endpoints: |
+          allowed-endpoints: >-
             github.com:443
             api.github.com:443
 

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -26,20 +26,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: block
-          allowed-endpoints: |
-            *.github.com:443
-            github.com:443
-            api.github.com:443
-            objects.githubusercontent.com:443
-            uploads.github.com:443
-            codeload.github.com:443
-            *.githubusercontent.com:443
-            fossa.com:443
-            app.fossa.com:443
-            proxy.golang.org:443
-            sum.golang.org:443
-            sumdb.google.dev:443
+          egress-policy: audit
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -30,6 +30,9 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
+            fossa.com:443
+            app.fossa.com:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -30,8 +30,6 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
-            fossa.com:443
-            app.fossa.com:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -28,8 +28,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            fossa.com
+            github.com:443
+            api.github.com:443
+            fossa.com:443
+            app.fossa.com:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            fossa.com
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -28,11 +28,18 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
+            *.github.com:443
             github.com:443
             api.github.com:443
             objects.githubusercontent.com:443
+            uploads.github.com:443
+            codeload.github.com:443
+            *.githubusercontent.com:443
             fossa.com:443
             app.fossa.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            sumdb.google.dev:443
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -28,11 +28,18 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
+            *.github.com:443
             github.com:443
             api.github.com:443
             objects.githubusercontent.com:443
+            uploads.github.com:443
+            codeload.github.com:443
+            *.githubusercontent.com:443
             fossa.com:443
             app.fossa.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            sumdb.google.dev:443
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -30,6 +30,9 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
+            fossa.com:443
+            app.fossa.com:443
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -29,7 +29,7 @@ jobs:
           egress-policy: block
           # Audit: https://github.com/k8gb-io/k8gb/actions/runs/34329541765
           # FOSSA CLI, Go dependencies, analysis API, and the signed S3 upload URL.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -28,8 +28,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            fossa.com
+            github.com:443
+            api.github.com:443
+            fossa.com:443
+            app.fossa.com:443
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -26,7 +26,22 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          # Audit: https://github.com/k8gb-io/k8gb/actions/runs/34329541765
+          # FOSSA CLI, Go dependencies, analysis API, and the signed S3 upload URL.
+          allowed-endpoints: |
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            app.fossa.com:443
+            s3.us-east-1.amazonaws.com:443
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -26,7 +26,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            fossa.com
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -30,8 +30,6 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
-            fossa.com:443
-            app.fossa.com:443
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -26,20 +26,7 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: block
-          allowed-endpoints: |
-            *.github.com:443
-            github.com:443
-            api.github.com:443
-            objects.githubusercontent.com:443
-            uploads.github.com:443
-            codeload.github.com:443
-            *.githubusercontent.com:443
-            fossa.com:443
-            app.fossa.com:443
-            proxy.golang.org:443
-            sum.golang.org:443
-            sumdb.google.dev:443
+          egress-policy: audit
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -24,7 +24,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            pypi.org
+            files.pythonhosted.org
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -26,9 +26,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            pypi.org
-            files.pythonhosted.org
+            github.com:443
+            api.github.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -25,9 +25,13 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
+          # Python installer/tool-cache misses, PyPI packages, and git publication.
           allowed-endpoints: |
-            github.com:443
             api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             pypi.org:443
             files.pythonhosted.org:443
 

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -26,9 +26,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            pypi.org
-            files.pythonhosted.org
+            github.com:443
+            api.github.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           egress-policy: block
           # Python installer/tool-cache misses, PyPI packages, and git publication.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -24,7 +24,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            pypi.org
+            files.pythonhosted.org
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/helm_check-values-schema.yaml
+++ b/.github/workflows/helm_check-values-schema.yaml
@@ -19,7 +19,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            pypi.org
+            files.pythonhosted.org
 
       - name: 'Checkout'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/helm_check-values-schema.yaml
+++ b/.github/workflows/helm_check-values-schema.yaml
@@ -21,9 +21,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            pypi.org
-            files.pythonhosted.org
+            github.com:443
+            api.github.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
 
       - name: 'Checkout'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/helm_check-values-schema.yaml
+++ b/.github/workflows/helm_check-values-schema.yaml
@@ -21,9 +21,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            pypi.org
-            files.pythonhosted.org
+            github.com:443
+            api.github.com:443
+            pypi.org:443
+            files.pythonhosted.org:443
 
       - name: 'Checkout'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/helm_check-values-schema.yaml
+++ b/.github/workflows/helm_check-values-schema.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
-          allowed-endpoints: |
+          allowed-endpoints: >-
             github.com:443
             api.github.com:443
             pypi.org:443

--- a/.github/workflows/helm_check-values-schema.yaml
+++ b/.github/workflows/helm_check-values-schema.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'chart/k8gb/values.yaml'
       - 'chart/k8gb/values.schema.json'
+      - '.github/workflows/helm_check-values-schema.yaml'
 permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 

--- a/.github/workflows/helm_check-values-schema.yaml
+++ b/.github/workflows/helm_check-values-schema.yaml
@@ -19,7 +19,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            pypi.org
+            files.pythonhosted.org
 
       - name: 'Checkout'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/helm_docs.yaml
+++ b/.github/workflows/helm_docs.yaml
@@ -21,10 +21,11 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          docker.io
-          gcr.io
-          production-k8g-io.s3.amazonaws.com
+          github.com:443
+          api.github.com:443
+          docker.io:443
+          gcr.io:443
+          production-k8g-io.s3.amazonaws.com:443
 
     - name: Checkout Code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/helm_docs.yaml
+++ b/.github/workflows/helm_docs.yaml
@@ -19,7 +19,12 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          docker.io
+          gcr.io
+          production-k8g-io.s3.amazonaws.com
 
     - name: Checkout Code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/helm_docs.yaml
+++ b/.github/workflows/helm_docs.yaml
@@ -19,7 +19,12 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          docker.io
+          gcr.io
+          production-k8g-io.s3.amazonaws.com
 
     - name: Checkout Code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/helm_docs.yaml
+++ b/.github/workflows/helm_docs.yaml
@@ -20,12 +20,10 @@ jobs:
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
         egress-policy: block
+        # The helm-docs Docker action image is prepared before job steps; the job pushes a PR.
         allowed-endpoints: |
-          github.com:443
           api.github.com:443
-          docker.io:443
-          gcr.io:443
-          production-k8g-io.s3.amazonaws.com:443
+          github.com:443
 
     - name: Checkout Code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/helm_docs.yaml
+++ b/.github/workflows/helm_docs.yaml
@@ -21,10 +21,11 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          docker.io
-          gcr.io
-          production-k8g-io.s3.amazonaws.com
+          github.com:443
+          api.github.com:443
+          docker.io:443
+          gcr.io:443
+          production-k8g-io.s3.amazonaws.com:443
 
     - name: Checkout Code
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/helm_docs.yaml
+++ b/.github/workflows/helm_docs.yaml
@@ -21,7 +21,7 @@ jobs:
       with:
         egress-policy: block
         # The helm-docs Docker action image is prepared before job steps; the job pushes a PR.
-        allowed-endpoints: |
+        allowed-endpoints: >-
           api.github.com:443
           github.com:443
 

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -25,10 +25,11 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            kubernetes-charts.github.io
-            gcr.io
-            registry.k8s.io
+            github.com:443
+            api.github.com:443
+            kubernetes-charts.github.io:443
+            gcr.io:443
+            registry.k8s.io:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -27,10 +27,12 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
             kubernetes-charts.github.io:443
+            k8gb.io:443
+            www.k8gb.io:443
             gcr.io:443
             registry.k8s.io:443
-
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -23,7 +23,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            kubernetes-charts.github.io
+            gcr.io
+            registry.k8s.io
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -24,15 +24,30 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
+          # Audit: https://github.com/k8gb-io/k8gb/actions/runs/33623850616
+          # Helm installer/dependencies, k3d image pulls, and chart installation smoke test.
           allowed-endpoints: |
-            github.com:443
             api.github.com:443
+            github.com:443
             objects.githubusercontent.com:443
-            kubernetes-charts.github.io:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            auth.docker.io:443
+            registry-1.docker.io:443
+            production.cloudfront.docker.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            get.helm.sh:443
+            coredns.github.io:443
+            kubernetes-sigs.github.io:443
             k8gb.io:443
             www.k8gb.io:443
+            registry.k8gb.io:443
             gcr.io:443
+            k8s.gcr.io:443
             registry.k8s.io:443
+            cdn.registry.k8s.io:443
+            *-docker.pkg.dev:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -25,10 +25,11 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            kubernetes-charts.github.io
-            gcr.io
-            registry.k8s.io
+            github.com:443
+            api.github.com:443
+            kubernetes-charts.github.io:443
+            gcr.io:443
+            registry.k8s.io:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -26,7 +26,7 @@ jobs:
           egress-policy: block
           # Audit: https://github.com/k8gb-io/k8gb/actions/runs/33623850616
           # Helm installer/dependencies, k3d image pulls, and chart installation smoke test.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -27,7 +27,10 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
             kubernetes-charts.github.io:443
+            k8gb.io:443
+            www.k8gb.io:443
             gcr.io:443
             registry.k8s.io:443
 

--- a/.github/workflows/helm_publish.yaml
+++ b/.github/workflows/helm_publish.yaml
@@ -23,7 +23,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            kubernetes-charts.github.io
+            gcr.io
+            registry.k8s.io
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/helm_sign_oci.yaml
+++ b/.github/workflows/helm_sign_oci.yaml
@@ -29,7 +29,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            ghcr.io
+            sigstore.github.io
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/helm_sign_oci.yaml
+++ b/.github/workflows/helm_sign_oci.yaml
@@ -31,9 +31,13 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            ghcr.io
-            sigstore.github.io
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            sigstore.github.io:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/helm_sign_oci.yaml
+++ b/.github/workflows/helm_sign_oci.yaml
@@ -33,11 +33,13 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
             ghcr.io:443
             sigstore.github.io:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
+            token.actions.githubusercontent.com:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/helm_sign_oci.yaml
+++ b/.github/workflows/helm_sign_oci.yaml
@@ -33,11 +33,13 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
             ghcr.io:443
             sigstore.github.io:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
+            token.actions.githubusercontent.com:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/helm_sign_oci.yaml
+++ b/.github/workflows/helm_sign_oci.yaml
@@ -32,7 +32,7 @@ jobs:
           egress-policy: block
           # Audit: https://github.com/k8gb-io/k8gb/actions/runs/33623974848
           # Cosign installation, OCI blobs, and keyless signing/verification (including timestamps).
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/helm_sign_oci.yaml
+++ b/.github/workflows/helm_sign_oci.yaml
@@ -31,9 +31,13 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            ghcr.io
-            sigstore.github.io
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            sigstore.github.io:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/helm_sign_oci.yaml
+++ b/.github/workflows/helm_sign_oci.yaml
@@ -29,7 +29,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            ghcr.io
+            sigstore.github.io
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/helm_sign_oci.yaml
+++ b/.github/workflows/helm_sign_oci.yaml
@@ -30,16 +30,20 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
+          # Audit: https://github.com/k8gb-io/k8gb/actions/runs/33623974848
+          # Cosign installation, OCI blobs, and keyless signing/verification (including timestamps).
           allowed-endpoints: |
-            github.com:443
             api.github.com:443
+            github.com:443
             objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             ghcr.io:443
-            sigstore.github.io:443
+            pkg-containers.githubusercontent.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
+            timestamp.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
-            token.actions.githubusercontent.com:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -34,8 +34,11 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
             docker.io:443
             ghcr.io:443
+            coredns.github.io:443
+            kubernetes-sigs.github.io:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -32,9 +32,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            docker.io
-            ghcr.io
+            github.com:443
+            api.github.com:443
+            docker.io:443
+            ghcr.io:443
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -30,7 +30,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            docker.io
+            ghcr.io
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -34,8 +34,11 @@ jobs:
           allowed-endpoints: |
             github.com:443
             api.github.com:443
+            objects.githubusercontent.com:443
             docker.io:443
             ghcr.io:443
+            coredns.github.io:443
+            kubernetes-sigs.github.io:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -32,7 +32,7 @@ jobs:
         with:
           egress-policy: block
           # OLM binary download, go env toolchain selection, and Helm chart dependencies.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -30,7 +30,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            docker.io
+            ghcr.io
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -31,12 +31,18 @@ jobs:
         uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
+          # OLM binary download, go env toolchain selection, and Helm chart dependencies.
           allowed-endpoints: |
-            github.com:443
             api.github.com:443
+            github.com:443
             objects.githubusercontent.com:443
-            docker.io:443
-            ghcr.io:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
             coredns.github.io:443
             kubernetes-sigs.github.io:443
 

--- a/.github/workflows/olm_pr.yaml
+++ b/.github/workflows/olm_pr.yaml
@@ -32,9 +32,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            docker.io
-            ghcr.io
+            github.com:443
+            api.github.com:443
+            docker.io:443
+            ghcr.io:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,11 +33,16 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            hub.docker.com
-            gcr.io
-            ghcr.io
-            sigstore.github.io
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            sumdb.google.dev:443
+            hub.docker.com:443
+            gcr.io:443
+            ghcr.io:443
+            sigstore.github.io:443
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -142,11 +147,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            hub.docker.com
-            gcr.io
-            ghcr.io
-            sigstore.github.io
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            sigstore.github.io:443
 
       - name: Install cosign
         uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # renovate: tag=v3.3.0
@@ -224,7 +228,8 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
+            github.com:443
+            api.github.com:443
 
       - name: Make summary for the release pipeline
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,9 +29,15 @@ jobs:
       COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            hub.docker.com
+            gcr.io
+            ghcr.io
+            sigstore.github.io
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -132,9 +138,15 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            hub.docker.com
+            gcr.io
+            ghcr.io
+            sigstore.github.io
 
       - name: Install cosign
         uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # renovate: tag=v3.3.0
@@ -208,9 +220,11 @@ jobs:
       CONTAINER_INFO: "${{ needs.release.outputs.container_info }}"
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
 
       - name: Make summary for the release pipeline
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,20 +30,33 @@ jobs:
       COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
+          # Audit: https://github.com/k8gb-io/k8gb/actions/runs/33623099190
+          # Installers, Go modules, multi-arch images, SBOM data, signing trust root, and release uploads.
           allowed-endpoints: |
-            github.com:443
             api.github.com:443
+            github.com:443
             objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
             proxy.golang.org:443
+            storage.googleapis.com:443
             sum.golang.org:443
-            sumdb.google.dev:443
-            hub.docker.com:443
-            gcr.io:443
+            auth.docker.io:443
+            registry-1.docker.io:443
+            production.cloudfront.docker.com:443
             ghcr.io:443
-            sigstore.github.io:443
+            pkg-containers.githubusercontent.com:443
+            uploads.github.com:443
+            models.github.ai:443
+            gcr.io:443
+            get.anchore.io:443
+            toolbox-data.anchore.io:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -175,14 +188,21 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
+          # Cosign/Syft installers, registry blobs, SBOM data, and signing trust root.
           allowed-endpoints: |
-            github.com:443
             api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             ghcr.io:443
-            sigstore.github.io:443
+            pkg-containers.githubusercontent.com:443
+            get.anchore.io:443
+            toolbox-data.anchore.io:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - name: Install cosign
         uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # renovate: tag=v3.3.0
@@ -256,12 +276,13 @@ jobs:
       CONTAINER_INFO: "${{ needs.release.outputs.container_info }}"
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
         with:
           egress-policy: block
+          # GitHub runner service endpoints are also allowed implicitly by Harden Runner.
           allowed-endpoints: |
-            github.com:443
             api.github.com:443
+            github.com:443
 
       - name: Make summary for the release pipeline
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,11 +34,16 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            hub.docker.com
-            gcr.io
-            ghcr.io
-            sigstore.github.io
+            github.com:443
+            api.github.com:443
+            objects.githubusercontent.com:443
+            proxy.golang.org:443
+            sum.golang.org:443
+            sumdb.google.dev:443
+            hub.docker.com:443
+            gcr.io:443
+            ghcr.io:443
+            sigstore.github.io:443
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -174,11 +179,10 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
-            hub.docker.com
-            gcr.io
-            ghcr.io
-            sigstore.github.io
+            github.com:443
+            api.github.com:443
+            ghcr.io:443
+            sigstore.github.io:443
 
       - name: Install cosign
         uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # renovate: tag=v3.3.0
@@ -256,7 +260,8 @@ jobs:
         with:
           egress-policy: block
           allowed-endpoints: |
-            github.com
+            github.com:443
+            api.github.com:443
 
       - name: Make summary for the release pipeline
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,9 +30,15 @@ jobs:
       COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            hub.docker.com
+            gcr.io
+            ghcr.io
+            sigstore.github.io
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -164,9 +170,15 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
+            hub.docker.com
+            gcr.io
+            ghcr.io
+            sigstore.github.io
 
       - name: Install cosign
         uses: sigstore/cosign-installer@9614fae9e5c5eddabb09f90a270fcb487c9f7149 # renovate: tag=v3.3.0
@@ -240,9 +252,11 @@ jobs:
       CONTAINER_INFO: "${{ needs.release.outputs.container_info }}"
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@91182cccc01eb5e619899d80e4e971d6181294a7 # v2.10.1
+        uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          egress-policy: block
+          allowed-endpoints: |
+            github.com
 
       - name: Make summary for the release pipeline
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
           egress-policy: block
           # Audit: https://github.com/k8gb-io/k8gb/actions/runs/33623099190
           # Installers, Go modules, multi-arch images, SBOM data, signing trust root, and release uploads.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
@@ -192,7 +192,7 @@ jobs:
         with:
           egress-policy: block
           # Cosign/Syft installers, registry blobs, SBOM data, and signing trust root.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
@@ -280,7 +280,7 @@ jobs:
         with:
           egress-policy: block
           # GitHub runner service endpoints are also allowed implicitly by Harden Runner.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
 

--- a/.github/workflows/terratest-istiov1beta1.yaml
+++ b/.github/workflows/terratest-istiov1beta1.yaml
@@ -16,44 +16,8 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.label.name == 'istio' }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
-        with:
-          egress-policy: block
-          # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
-          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
-          allowed-endpoints: >-
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            go.dev:443
-            dl.google.com:443
-            proxy.golang.org:443
-            storage.googleapis.com:443
-            sum.golang.org:443
-            auth.docker.io:443
-            registry-1.docker.io:443
-            production.cloudfront.docker.com:443
-            ghcr.io:443
-            pkg-containers.githubusercontent.com:443
-            gcr.io:443
-            k8s.gcr.io:443
-            registry.k8s.io:443
-            cdn.registry.k8s.io:443
-            *-docker.pkg.dev:443
-            registry.istio.io:443
-            registry.k8gb.io:443
-            get.helm.sh:443
-            coredns.github.io:443
-            kubernetes-sigs.github.io:443
-            kubernetes.github.io:443
-            istio-release.storage.googleapis.com:443
-            stefanprodan.github.io:443
-            k8gb.io:443
-            www.k8gb.io:443
-
+      # Keep Terratest exempt: Harden Runner sinkholes localhost DNS lookups
+      # used by Podinfo health probes, preventing the test pods from becoming ready.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/terratest-istiov1beta1.yaml
+++ b/.github/workflows/terratest-istiov1beta1.yaml
@@ -22,7 +22,7 @@ jobs:
           egress-policy: block
           # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
           # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/terratest-istiov1beta1.yaml
+++ b/.github/workflows/terratest-istiov1beta1.yaml
@@ -18,6 +18,7 @@ jobs:
     steps:
       # Keep Terratest exempt: Harden Runner sinkholes localhost DNS lookups
       # used by Podinfo health probes, preventing the test pods from becoming ready.
+      # Follow-up: https://github.com/k8gb-io/k8gb/issues/2529
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/terratest-istiov1beta1.yaml
+++ b/.github/workflows/terratest-istiov1beta1.yaml
@@ -16,6 +16,44 @@ jobs:
     runs-on: ubuntu-24.04
     if: ${{ github.event.label.name == 'istio' }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: block
+          # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
+          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
+          allowed-endpoints: |
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            auth.docker.io:443
+            registry-1.docker.io:443
+            production.cloudfront.docker.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            gcr.io:443
+            k8s.gcr.io:443
+            registry.k8s.io:443
+            cdn.registry.k8s.io:443
+            *-docker.pkg.dev:443
+            registry.istio.io:443
+            registry.k8gb.io:443
+            get.helm.sh:443
+            coredns.github.io:443
+            kubernetes-sigs.github.io:443
+            kubernetes.github.io:443
+            istio-release.storage.googleapis.com:443
+            stefanprodan.github.io:443
+            k8gb.io:443
+            www.k8gb.io:443
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -19,6 +19,44 @@ jobs:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: block
+          # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
+          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
+          allowed-endpoints: |
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            auth.docker.io:443
+            registry-1.docker.io:443
+            production.cloudfront.docker.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            gcr.io:443
+            k8s.gcr.io:443
+            registry.k8s.io:443
+            cdn.registry.k8s.io:443
+            *-docker.pkg.dev:443
+            registry.istio.io:443
+            registry.k8gb.io:443
+            get.helm.sh:443
+            coredns.github.io:443
+            kubernetes-sigs.github.io:443
+            kubernetes.github.io:443
+            istio-release.storage.googleapis.com:443
+            stefanprodan.github.io:443
+            k8gb.io:443
+            www.k8gb.io:443
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -25,7 +25,7 @@ jobs:
           egress-policy: block
           # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
           # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -19,44 +19,8 @@ jobs:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
-        with:
-          egress-policy: block
-          # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
-          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
-          allowed-endpoints: >-
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            go.dev:443
-            dl.google.com:443
-            proxy.golang.org:443
-            storage.googleapis.com:443
-            sum.golang.org:443
-            auth.docker.io:443
-            registry-1.docker.io:443
-            production.cloudfront.docker.com:443
-            ghcr.io:443
-            pkg-containers.githubusercontent.com:443
-            gcr.io:443
-            k8s.gcr.io:443
-            registry.k8s.io:443
-            cdn.registry.k8s.io:443
-            *-docker.pkg.dev:443
-            registry.istio.io:443
-            registry.k8gb.io:443
-            get.helm.sh:443
-            coredns.github.io:443
-            kubernetes-sigs.github.io:443
-            kubernetes.github.io:443
-            istio-release.storage.googleapis.com:443
-            stefanprodan.github.io:443
-            k8gb.io:443
-            www.k8gb.io:443
-
+      # Keep Terratest exempt: Harden Runner sinkholes localhost DNS lookups
+      # used by Podinfo health probes, preventing the test pods from becoming ready.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/terratest-more-clusters.yaml
+++ b/.github/workflows/terratest-more-clusters.yaml
@@ -21,6 +21,7 @@ jobs:
     steps:
       # Keep Terratest exempt: Harden Runner sinkholes localhost DNS lookups
       # used by Podinfo health probes, preventing the test pods from becoming ready.
+      # Follow-up: https://github.com/k8gb-io/k8gb/issues/2529
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -34,7 +34,12 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          docker.io
+          gcr.io
+          registry.k8s.io
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -36,10 +36,11 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          docker.io
-          gcr.io
-          registry.k8s.io
+          github.com:443
+          api.github.com:443
+          docker.io:443
+          gcr.io:443
+          registry.k8s.io:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
         egress-policy: block
-        allowed-endpoints: |
+        allowed-endpoints: >-
           api.github.com:443
 
     - id: skip_check
@@ -58,7 +58,7 @@ jobs:
           egress-policy: block
           # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
           # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -36,11 +36,7 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com:443
           api.github.com:443
-          docker.io:443
-          gcr.io:443
-          registry.k8s.io:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
@@ -56,6 +52,44 @@ jobs:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: block
+          # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
+          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
+          allowed-endpoints: |
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            auth.docker.io:443
+            registry-1.docker.io:443
+            production.cloudfront.docker.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            gcr.io:443
+            k8s.gcr.io:443
+            registry.k8s.io:443
+            cdn.registry.k8s.io:443
+            *-docker.pkg.dev:443
+            registry.istio.io:443
+            registry.k8gb.io:443
+            get.helm.sh:443
+            coredns.github.io:443
+            kubernetes-sigs.github.io:443
+            kubernetes.github.io:443
+            istio-release.storage.googleapis.com:443
+            stefanprodan.github.io:443
+            k8gb.io:443
+            www.k8gb.io:443
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -52,44 +52,8 @@ jobs:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
-        with:
-          egress-policy: block
-          # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
-          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
-          allowed-endpoints: >-
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            go.dev:443
-            dl.google.com:443
-            proxy.golang.org:443
-            storage.googleapis.com:443
-            sum.golang.org:443
-            auth.docker.io:443
-            registry-1.docker.io:443
-            production.cloudfront.docker.com:443
-            ghcr.io:443
-            pkg-containers.githubusercontent.com:443
-            gcr.io:443
-            k8s.gcr.io:443
-            registry.k8s.io:443
-            cdn.registry.k8s.io:443
-            *-docker.pkg.dev:443
-            registry.istio.io:443
-            registry.k8gb.io:443
-            get.helm.sh:443
-            coredns.github.io:443
-            kubernetes-sigs.github.io:443
-            kubernetes.github.io:443
-            istio-release.storage.googleapis.com:443
-            stefanprodan.github.io:443
-            k8gb.io:443
-            www.k8gb.io:443
-
+      # Keep Terratest exempt: Harden Runner sinkholes localhost DNS lookups
+      # used by Podinfo health probes, preventing the test pods from becoming ready.
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -36,10 +36,11 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          docker.io
-          gcr.io
-          registry.k8s.io
+          github.com:443
+          api.github.com:443
+          docker.io:443
+          gcr.io:443
+          registry.k8s.io:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -52,45 +52,9 @@ jobs:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
-        with:
-          egress-policy: block
-          # Test whether allowing localhost preserves Podinfo health probe resolution.
-          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
-          allowed-endpoints: >-
-            localhost:9898
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            go.dev:443
-            dl.google.com:443
-            proxy.golang.org:443
-            storage.googleapis.com:443
-            sum.golang.org:443
-            auth.docker.io:443
-            registry-1.docker.io:443
-            production.cloudfront.docker.com:443
-            ghcr.io:443
-            pkg-containers.githubusercontent.com:443
-            gcr.io:443
-            k8s.gcr.io:443
-            registry.k8s.io:443
-            cdn.registry.k8s.io:443
-            *-docker.pkg.dev:443
-            registry.istio.io:443
-            registry.k8gb.io:443
-            get.helm.sh:443
-            coredns.github.io:443
-            kubernetes-sigs.github.io:443
-            kubernetes.github.io:443
-            istio-release.storage.googleapis.com:443
-            stefanprodan.github.io:443
-            k8gb.io:443
-            www.k8gb.io:443
-
+      # Keep Terratest exempt: Harden Runner sinkholes localhost DNS lookups
+      # used by Podinfo health probes, preventing the test pods from becoming ready.
+      # Follow-up: https://github.com/k8gb-io/k8gb/issues/2529
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -34,7 +34,12 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          docker.io
+          gcr.io
+          registry.k8s.io
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -52,8 +52,45 @@ jobs:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}
     steps:
-      # Keep Terratest exempt: Harden Runner sinkholes localhost DNS lookups
-      # used by Podinfo health probes, preventing the test pods from becoming ready.
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: block
+          # Test whether allowing localhost preserves Podinfo health probe resolution.
+          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
+          allowed-endpoints: >-
+            localhost:9898
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            auth.docker.io:443
+            registry-1.docker.io:443
+            production.cloudfront.docker.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            gcr.io:443
+            k8s.gcr.io:443
+            registry.k8s.io:443
+            cdn.registry.k8s.io:443
+            *-docker.pkg.dev:443
+            registry.istio.io:443
+            registry.k8gb.io:443
+            get.helm.sh:443
+            coredns.github.io:443
+            kubernetes-sigs.github.io:443
+            kubernetes.github.io:443
+            istio-release.storage.googleapis.com:443
+            stefanprodan.github.io:443
+            k8gb.io:443
+            www.k8gb.io:443
+
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -34,7 +34,12 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          docker.io
+          gcr.io
+          registry.k8s.io
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -36,10 +36,14 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          docker.io
-          gcr.io
-          registry.k8s.io
+          github.com:443
+          api.github.com:443
+          proxy.golang.org:443
+          sum.golang.org:443
+          sumdb.google.dev:443
+          docker.io:443
+          gcr.io:443
+          registry.k8s.io:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
         egress-policy: block
-        allowed-endpoints: |
+        allowed-endpoints: >-
           api.github.com:443
 
     - id: skip_check
@@ -55,7 +55,7 @@ jobs:
           egress-policy: block
           # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
           # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
-          allowed-endpoints: |
+          allowed-endpoints: >-
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -36,10 +36,14 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com
-          docker.io
-          gcr.io
-          registry.k8s.io
+          github.com:443
+          api.github.com:443
+          proxy.golang.org:443
+          sum.golang.org:443
+          sumdb.google.dev:443
+          docker.io:443
+          gcr.io:443
+          registry.k8s.io:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -34,7 +34,12 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: |
+          github.com
+          docker.io
+          gcr.io
+          registry.k8s.io
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -51,6 +51,7 @@ jobs:
     steps:
       # Keep Terratest exempt: Harden Runner sinkholes localhost DNS lookups
       # used by Podinfo health probes, preventing the test pods from becoming ready.
+      # Follow-up: https://github.com/k8gb-io/k8gb/issues/2529
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -36,14 +36,7 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: |
-          github.com:443
           api.github.com:443
-          proxy.golang.org:443
-          sum.golang.org:443
-          sumdb.google.dev:443
-          docker.io:443
-          gcr.io:443
-          registry.k8s.io:443
 
     - id: skip_check
       uses: fkirc/skip-duplicate-actions@b974a9395958c231af965b70070979a577efa578 # v5.3.2
@@ -56,6 +49,44 @@ jobs:
     needs: skip-check
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }} && !contains( github.event.pull_request.labels.*.name, 'renovate')
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
+        with:
+          egress-policy: block
+          # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
+          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
+          allowed-endpoints: |
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            go.dev:443
+            dl.google.com:443
+            proxy.golang.org:443
+            storage.googleapis.com:443
+            sum.golang.org:443
+            auth.docker.io:443
+            registry-1.docker.io:443
+            production.cloudfront.docker.com:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            gcr.io:443
+            k8s.gcr.io:443
+            registry.k8s.io:443
+            cdn.registry.k8s.io:443
+            *-docker.pkg.dev:443
+            registry.istio.io:443
+            registry.k8gb.io:443
+            get.helm.sh:443
+            coredns.github.io:443
+            kubernetes-sigs.github.io:443
+            kubernetes.github.io:443
+            istio-release.storage.googleapis.com:443
+            stefanprodan.github.io:443
+            k8gb.io:443
+            www.k8gb.io:443
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0

--- a/.github/workflows/upgrade-testing.yaml
+++ b/.github/workflows/upgrade-testing.yaml
@@ -49,44 +49,8 @@ jobs:
     needs: skip-check
     if: ${{ needs.skip-check.outputs.should_skip != 'true' }} && !contains( github.event.pull_request.labels.*.name, 'renovate')
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
-        with:
-          egress-policy: block
-          # Cluster setup matches the Chainsaw audit; include Go/tool downloads on cache misses.
-          # The regional Kubernetes registry redirect uses *-docker.pkg.dev.
-          allowed-endpoints: >-
-            api.github.com:443
-            github.com:443
-            objects.githubusercontent.com:443
-            raw.githubusercontent.com:443
-            release-assets.githubusercontent.com:443
-            go.dev:443
-            dl.google.com:443
-            proxy.golang.org:443
-            storage.googleapis.com:443
-            sum.golang.org:443
-            auth.docker.io:443
-            registry-1.docker.io:443
-            production.cloudfront.docker.com:443
-            ghcr.io:443
-            pkg-containers.githubusercontent.com:443
-            gcr.io:443
-            k8s.gcr.io:443
-            registry.k8s.io:443
-            cdn.registry.k8s.io:443
-            *-docker.pkg.dev:443
-            registry.istio.io:443
-            registry.k8gb.io:443
-            get.helm.sh:443
-            coredns.github.io:443
-            kubernetes-sigs.github.io:443
-            kubernetes.github.io:443
-            istio-release.storage.googleapis.com:443
-            stefanprodan.github.io:443
-            k8gb.io:443
-            www.k8gb.io:443
-
+      # Keep Terratest exempt: Harden Runner sinkholes localhost DNS lookups
+      # used by Podinfo health probes, preventing the test pods from becoming ready.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0


### PR DESCRIPTION
Switch all GitHub Actions workflows from `egress-policy: audit` to `egress-policy: block` with explicit allowlists.

Updated 16 workflows to use `egress-policy: block`:
- build.yml
- chainsaw.yaml  
- changelog_pr.yaml
- codeql-analysis.yml
- curldemo.yaml
- cut_release.yaml
- fossa.yml
- gh-pages.yaml
- helm_check-values-schema.yaml
- helm_docs.yaml
- helm_publish.yaml
- helm_sign_oci.yaml
- olm_pr.yaml
- release.yaml
- terratest.yaml
- upgrade-testing.yaml

each workflow now has explicit allowed endpoints list for required outbound connections.

Test:
- [ ] Verify workflows run successfully with block policy
- [ ] Monitor for any blocked connections that should be allowed

Fixes: #2302
Issue Ref: #2294 

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
