### PR TITLE
chore: configure renovate for deploy/edge/deployment.yaml

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -85,6 +85,14 @@
       ],
       "extractVersionTemplate": "^(?<version>.+)(-k3s1)?(-k3s2)?$",
     },
+    // update bind9 and busybox images in deploy/edge/deployment.yaml
+    {
+      "fileMatch": ["^deploy/edge/deployment\\.yaml$"],
+      "datasourceTemplate": "docker",
+      "matchStrings": [
+        "image: (?<depName>.*):(?<currentValue>.*)"
+      ],
+    },
     // update Istio version in Makefile
     {
       "fileMatch": ["^Makefile$"],


### PR DESCRIPTION
Configure Renovate to automatically update Docker images in test deployment files.

Added regexManagers rule in renovate.json5 to track `deploy/edge/deployment.yaml` (i.e. bind9, busybox images). Now, this prevents test failures due to outdated or unavailable image tags.

Fixes: #1679 

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
