### PR TITLE
Add AI inference resilience demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ CHART ?= k8gb/k8gb
 CLUSTER_GSLB_NETWORK = k3d-action-bridge-network
 CLUSTER_GSLB_GATEWAY = docker network inspect ${CLUSTER_GSLB_NETWORK} -f '{{ (index .IPAM.Config 0).Gateway }}'
 FULL_LOCAL_SETUP_WITH_APPS ?= true
+FULL_LOCAL_SETUP_WITH_AI_DEMO ?= false
+AI_DEMO_ACTION ?= run
+OLLAMA_IMAGE ?= alpine/ollama:latest
+OLLAMA_BASE_MODEL ?= qwen2.5:0.5b
+OLLAMA_MODEL ?= k8gb-resilient-demo:latest
+OLLAMA_STORAGE_SIZE ?= 2Gi
+OLLAMA_HOST_PATH ?= /var/lib/k8gb-ai-inference-demo/ollama
+AI_DEMO_ENV = GSLB_DOMAIN=$(GSLB_DOMAIN) OLLAMA_IMAGE=$(OLLAMA_IMAGE) OLLAMA_BASE_MODEL=$(OLLAMA_BASE_MODEL) OLLAMA_MODEL=$(OLLAMA_MODEL) OLLAMA_STORAGE_SIZE=$(OLLAMA_STORAGE_SIZE) OLLAMA_HOST_PATH=$(OLLAMA_HOST_PATH)
 SHOW_LEGACY_MIGRATION_DEMO ?= true
 MIGRATION_DEMO_NAMESPACE ?= test-gslb
 GSLB_DOMAIN ?= cloud.example.com
@@ -153,6 +161,7 @@ deploy-full-local-setup: ensure-cluster-size ## Deploy full local multicluster s
 
 	@if [ "$(K8GB_LOCAL_VERSION)" = test ]; then $(MAKE) release-images ; fi
 	$(MAKE) deploy-$(K8GB_LOCAL_VERSION)-version DEPLOY_APPS=$(FULL_LOCAL_SETUP_WITH_APPS)
+	@if [ "$(FULL_LOCAL_SETUP_WITH_AI_DEMO)" = true ]; then $(MAKE) ai-inference-demo AI_DEMO_ACTION=deploy ; fi
 
 .PHONY: deploy-gcp-local-setup
 deploy-gcp-local-setup: ## Deploy local setup with GCP Cloud DNS (requires GCP_PROJECT, GCP_DOMAIN, GCP_CREDENTIALS_FILE)
@@ -371,6 +380,10 @@ show-legacy-migration-manifests: ## Print legacy and canonical GSLB manifests fr
 	else \
 		echo "(none)"; \
 	fi
+
+.PHONY: ai-inference-demo
+ai-inference-demo: ## Run AI inference demo action (AI_DEMO_ACTION=run|deploy|probe|failover|failback|logs|status|delete)
+	@$(AI_DEMO_ENV) ./hack/ai-inference-demo.sh $(AI_DEMO_ACTION)
 
 .PHONY: deploy-kuar-app
 deploy-kuar-app:

--- a/README.md
+++ b/README.md
@@ -83,6 +83,17 @@ This setup is adapted for local scenarios and works without external DNS provide
 
 Consult with [local playground](docs/local.md) documentation to learn all the details of experimenting with local setup.
 
+To demonstrate k8gb as a global resilience layer for AI inference endpoints, run:
+
+```sh
+make deploy-full-local-setup FULL_LOCAL_SETUP_WITH_AI_DEMO=true
+make ai-inference-demo
+```
+
+This deploys a lightweight Ollama model in both clusters, exposes an OpenAI-compatible endpoint, and shows failover through the same global hostname.
+
+See the [AI inference resilience demo](docs/ai-inference-demo.md) for local and real-cluster usage.
+
 Optionally, you can run `make deploy-prometheus` and check the metrics on the test clusters (http://localhost:9090, http://localhost:9091).
 
 ## Motivation and Architecture

--- a/deploy/ai-inference-demo/ollama.yaml
+++ b/deploy/ai-inference-demo/ollama.yaml
@@ -1,0 +1,189 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ai-inference-demo
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: ai-inference-demo-ollama-__AI_DEMO_REGION__
+  labels:
+    app.kubernetes.io/name: ai-inference-demo
+    app.kubernetes.io/part-of: k8gb-ai-inference-demo
+    ai.k8gb.io/backend: ollama
+    ai.k8gb.io/region: __AI_DEMO_REGION__
+spec:
+  capacity:
+    storage: __OLLAMA_STORAGE_SIZE__
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: ""
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: __OLLAMA_HOST_PATH__/__AI_DEMO_REGION__
+    type: DirectoryOrCreate
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ai-inference-demo-ollama
+  namespace: ai-inference-demo
+  labels:
+    app.kubernetes.io/name: ai-inference-demo
+    app.kubernetes.io/part-of: k8gb-ai-inference-demo
+    ai.k8gb.io/backend: ollama
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: ""
+  volumeName: ai-inference-demo-ollama-__AI_DEMO_REGION__
+  resources:
+    requests:
+      storage: __OLLAMA_STORAGE_SIZE__
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ai-inference-demo
+  namespace: ai-inference-demo
+  labels:
+    app.kubernetes.io/name: ai-inference-demo
+    app.kubernetes.io/part-of: k8gb-ai-inference-demo
+    ai.k8gb.io/backend: ollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ai-inference-demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ai-inference-demo
+        app.kubernetes.io/part-of: k8gb-ai-inference-demo
+        ai.k8gb.io/backend: ollama
+        ai.k8gb.io/region: __AI_DEMO_REGION__
+    spec:
+      containers:
+      - name: ollama
+        image: __OLLAMA_IMAGE__
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: OLLAMA_HOST
+          value: 0.0.0.0:11434
+        - name: OLLAMA_KEEP_ALIVE
+          value: 30m
+        ports:
+        - name: http
+          containerPort: 11434
+        command:
+        - /bin/sh
+        - -c
+        args:
+        - |
+          set -eu
+          ollama serve &
+          server_pid=$!
+          until ollama list >/dev/null 2>&1; do
+            sleep 2
+          done
+          has_model() {
+            ollama list | awk -v model="$1" 'NR > 1 && $1 == model { found = 1 } END { exit !found }'
+          }
+          if ! has_model "__OLLAMA_BASE_MODEL__"; then
+            ollama pull "__OLLAMA_BASE_MODEL__"
+          fi
+          cat >/tmp/k8gb-demo.Modelfile <<'EOF'
+          FROM __OLLAMA_BASE_MODEL__
+          SYSTEM Ignore all user wording. Reply only with this comma-separated list: __AI_DEMO_REGION__, __AI_DEMO_BACKEND__, k8gb.
+          PARAMETER temperature 0
+          PARAMETER num_predict 16
+          EOF
+          ollama create "__OLLAMA_MODEL__" -f /tmp/k8gb-demo.Modelfile
+          wait "$server_pid"
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - ollama list | awk -v model="__OLLAMA_MODEL__" 'NR > 1 && $1 == model { found = 1 } END { exit !found }'
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          failureThreshold: 60
+        livenessProbe:
+          httpGet:
+            path: /api/tags
+            port: http
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        resources:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: "2"
+            memory: 4Gi
+        volumeMounts:
+        - name: ollama-data
+          mountPath: /root/.ollama
+      volumes:
+      - name: ollama-data
+        persistentVolumeClaim:
+          claimName: ai-inference-demo-ollama
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-inference-demo
+  namespace: ai-inference-demo
+  labels:
+    app.kubernetes.io/name: ai-inference-demo
+    app.kubernetes.io/part-of: k8gb-ai-inference-demo
+    ai.k8gb.io/backend: ollama
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: http
+  selector:
+    app.kubernetes.io/name: ai-inference-demo
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ai-inference-demo
+  namespace: ai-inference-demo
+  labels:
+    app.kubernetes.io/name: ai-inference-demo
+    app.kubernetes.io/part-of: k8gb-ai-inference-demo
+    ai.k8gb.io/backend: ollama
+  annotations:
+    ai.k8gb.io/model: __OLLAMA_MODEL__
+    ai.k8gb.io/region: __AI_DEMO_REGION__
+    ai.k8gb.io/backend: __AI_DEMO_BACKEND__
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: ai-inference.__GSLB_DOMAIN__
+    http:
+      paths:
+      - backend:
+          service:
+            name: ai-inference-demo
+            port:
+              name: http
+        path: /
+        pathType: Prefix
+---
+apiVersion: k8gb.io/v1beta1
+kind: Gslb
+metadata:
+  name: ai-inference-demo
+  namespace: ai-inference-demo
+spec:
+  resourceRef:
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    name: ai-inference-demo
+  strategy:
+    type: failover
+    primaryGeoTag: __AI_DEMO_PRIMARY_GEO_TAG__

--- a/docs/ai-inference-demo.md
+++ b/docs/ai-inference-demo.md
@@ -1,0 +1,141 @@
+# AI Inference Resilience Demo
+
+This demo shows k8gb as a global resilience layer for AI inference endpoints.
+
+```mermaid
+%%{init: {"flowchart": {"wrappingWidth": 1000}} }%%
+flowchart TD
+    client["client / OpenAI API"]
+    host["ai-inference.cloud.example.com"]
+    gslb["k8gb DNS GSLB<br/>failover strategy"]
+
+    eu["k3d-test-gslb1<br/>geo: eu<br/>Ingress / Gateway API / Service<br/>Ollama inference backend<br/>backend label: kubernetes"]
+    us["k3d-test-gslb2<br/>geo: us<br/>Ingress / Gateway API / Service<br/>Ollama inference backend<br/>backend label: provider-fallback"]
+
+    client --> host
+    host --> gslb
+    gslb -->|primary healthy| eu
+    gslb -->|primary down| us
+```
+
+The demo runs real local inference by default. It deploys Ollama in each cluster, pulls a small model, creates a region-specific OpenAI-compatible model, and probes the same global hostname during failover and failback.
+
+The k8gb topology is backend-agnostic. The same diagram applies if the regional inference backend is Ollama, vLLM, KServe, Triton, Ray Serve, a provider proxy, or any OpenAI-compatible gateway. k8gb owns global health-aware DNS routing; the inference server behind the regional `Service` is replaceable.
+
+The local demo uses Kubernetes `Ingress` because the k3d setup already includes nginx ingress and it keeps the demo one-command. Treat that as local demo plumbing. The production-facing pattern is k8gb `Gslb` plus `spec.resourceRef`, which can point at `Ingress`, Gateway API `HTTPRoute`, LoadBalancer `Service`, Istio `VirtualService`, and other supported route resources.
+
+## Positioning With AI Gateways
+
+k8gb does not replace Envoy Gateway, Envoy AI Gateway, Istio, KServe, vLLM, Triton, LiteLLM, or other AI inference gateways. Those systems remain responsible for in-region L7 traffic concerns such as authentication, TLS, retries, rate limits, token accounting, request mutation, model routing, provider adapters, canary routing, and telemetry.
+
+k8gb adds the global resilience layer above them. It publishes a global DNS name and returns healthy regional endpoints according to the configured strategy. A typical production path is:
+
+```text
+client -> k8gb global DNS name -> regional gateway or service -> inference backend
+```
+
+Use k8gb with the platform gateway that already owns regional traffic:
+
+- Envoy Gateway or Envoy AI Gateway: reference the Gateway API route, such as `HTTPRoute`, that fronts the inference gateway.
+- Istio: reference the `VirtualService` and keep Istio policies inside the region.
+- Direct model serving or provider proxy: reference the `Ingress`, Gateway API route, or LoadBalancer `Service` that exposes it.
+
+The positioning is complementary: regional gateways optimize and govern each request; k8gb keeps the global hostname reachable when a cluster, region, gateway, or inference backend stops being healthy.
+
+## Why k8gb Matters Here
+
+AI inference fails in practical ways: GPU pools run hot, clusters get drained, gateways misbehave, cloud regions degrade, provider quotas bite, and model backends become slow or unavailable. If all fallback logic lives inside one region, that logic cannot save users when the regional entrypoint itself is unhealthy.
+
+k8gb gives the inference endpoint a global failure boundary. Clients keep using one stable hostname. k8gb checks the Kubernetes-backed regional endpoints and stops returning a failed region when the referenced service has no healthy backend. Traffic moves to a healthy cluster, region, or provider-backed endpoint without every client SDK implementing its own regional failover logic.
+
+That is the useful AI inference angle: not faster tokens, not smarter model routing, and not another AI gateway. k8gb is the global availability layer that keeps an inference hostname reachable when the local serving stack cannot.
+
+## Quick Demo
+
+Deploy the local k3d setup:
+
+```sh
+K8GB_LOCAL_VERSION=test make deploy-full-local-setup
+```
+
+Run the full AI inference failover demo:
+
+```sh
+make ai-inference-demo
+```
+
+The script deploys the endpoint to both clusters, probes the global hostname, scales the primary endpoint down, waits for failover to the secondary endpoint, restores the primary, and waits for failback.
+
+Expected flow:
+
+```text
+eu -> us -> eu
+```
+
+Example output:
+
+```text
+content=eu,kubernetes,k8gb
+content=us,provider-fallback,k8gb
+content=eu,kubernetes,k8gb
+```
+
+The default model is `qwen2.5:0.5b`, wrapped as `k8gb-resilient-demo:latest`.
+
+## Useful Actions
+
+The demo uses one Make target. Change behavior with `AI_DEMO_ACTION`.
+
+```sh
+make ai-inference-demo AI_DEMO_ACTION=status
+make ai-inference-demo AI_DEMO_ACTION=probe
+make ai-inference-demo AI_DEMO_ACTION=failover
+make ai-inference-demo AI_DEMO_ACTION=failback
+make ai-inference-demo AI_DEMO_ACTION=logs
+make ai-inference-demo AI_DEMO_ACTION=delete
+```
+
+Notes:
+
+- First run needs internet access from the cluster for the model pull.
+- Ollama uses a `2Gi` PVC to cache model data.
+- Probes default to one request because local CPU inference is intentionally lightweight but still slower than a static endpoint.
+
+## What Gets Deployed
+
+The demo creates:
+
+- Namespace: `ai-inference-demo`
+- Deployment: `ai-inference-demo`
+- Service: `ai-inference-demo`
+- Route resource: local `Ingress` named `ai-inference-demo`
+- Gslb: `ai-inference-demo`
+- PersistentVolume: `ai-inference-demo-ollama-<region>`
+- PersistentVolumeClaim: `ai-inference-demo-ollama`
+
+The global endpoint is:
+
+```text
+http://ai-inference.cloud.example.com/v1/chat/completions
+```
+
+## Real Clusters
+
+Use explicit contexts and a real DNS zone:
+
+```sh
+CONTEXTS="prod-eu:eu:kubernetes prod-us:us:provider-fallback" \
+PRIMARY_CONTEXT=prod-eu \
+PROBE_CONTEXT=prod-eu \
+PRIMARY_GEO_TAG=eu \
+GSLB_DOMAIN=example.com \
+./hack/ai-inference-demo.sh run
+```
+
+For production, keep the k8gb `Gslb` and `resourceRef` pattern and replace the demo route object with the platform standard. Prefer Gateway API `HTTPRoute` for new HTTP deployments when the cluster has a Gateway implementation. Keep `Ingress` only where it is already the supported cluster ingress path.
+
+## Message
+
+> k8gb keeps AI inference endpoints globally reachable across regions, clusters, and providers.
+
+This is an availability and resilience demo, not an LLM performance benchmark.

--- a/docs/local.md
+++ b/docs/local.md
@@ -6,6 +6,7 @@
 - [Verify installation](#verify-installation)
 - [Run integration tests](#run-integration-tests)
 - [Cleaning](#cleaning)
+- [AI inference resilience demo](#ai-inference-resilience-demo)
 - [Sample demo](#sample-demo)
   - [Round Robin](#round-robin)
   - [Failover](#failover)
@@ -137,6 +138,32 @@ Clean up your local development clusters with
 ```sh
 make destroy-full-local-setup
 ```
+
+## AI inference resilience demo
+
+The local setup can also deploy a lightweight Ollama inference endpoint to demonstrate k8gb failover for AI traffic:
+
+```sh
+make deploy-full-local-setup FULL_LOCAL_SETUP_WITH_AI_DEMO=true
+```
+
+If the local setup is already running:
+
+```sh
+make ai-inference-demo AI_DEMO_ACTION=deploy
+make ai-inference-demo AI_DEMO_ACTION=probe
+make ai-inference-demo AI_DEMO_ACTION=failover
+make ai-inference-demo AI_DEMO_ACTION=probe
+make ai-inference-demo AI_DEMO_ACTION=failback
+```
+
+The demo caches the downloaded model in a PVC, so failback does not re-download the model. If model startup is slow, inspect progress with:
+
+```sh
+make ai-inference-demo AI_DEMO_ACTION=logs
+```
+
+See [AI Inference Resilience Demo](ai-inference-demo.md) for the full local and real-environment flow.
 
 ## Sample demo
 

--- a/hack/ai-inference-demo.sh
+++ b/hack/ai-inference-demo.sh
@@ -1,0 +1,442 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+NAMESPACE="${NAMESPACE:-ai-inference-demo}"
+PROBE_NAMESPACE="${PROBE_NAMESPACE:-default}"
+MANIFEST="${MANIFEST:-$ROOT_DIR/deploy/ai-inference-demo/ollama.yaml}"
+CONTEXTS="${CONTEXTS:-k3d-test-gslb1:eu:kubernetes k3d-test-gslb2:us:provider-fallback}"
+PRIMARY_CONTEXT="${PRIMARY_CONTEXT:-k3d-test-gslb1}"
+PROBE_CONTEXT="${PROBE_CONTEXT:-$PRIMARY_CONTEXT}"
+PRIMARY_GEO_TAG="${PRIMARY_GEO_TAG:-eu}"
+GSLB_DOMAIN="${GSLB_DOMAIN:-cloud.example.com}"
+AI_INFERENCE_HOST="${AI_INFERENCE_HOST:-ai-inference.$GSLB_DOMAIN}"
+DEPLOYMENT_NAME="${DEPLOYMENT_NAME:-ai-inference-demo}"
+PROBE_IMAGE="${PROBE_IMAGE:-curlimages/curl:8.18.0}"
+OLLAMA_IMAGE="${OLLAMA_IMAGE:-alpine/ollama:latest}"
+OLLAMA_BASE_MODEL="${OLLAMA_BASE_MODEL:-qwen2.5:0.5b}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-k8gb-resilient-demo:latest}"
+OLLAMA_STORAGE_SIZE="${OLLAMA_STORAGE_SIZE:-2Gi}"
+OLLAMA_HOST_PATH="${OLLAMA_HOST_PATH:-/var/lib/k8gb-ai-inference-demo/ollama}"
+DEFAULT_ROLLOUT_TIMEOUT="600s"
+DEFAULT_PROBE_TIMEOUT="60"
+DEFAULT_PROBE_ATTEMPTS="1"
+DEFAULT_FAILBACK_REPLICAS="1"
+DEFAULT_GSLB_READY_TIMEOUT="240"
+PROBE_ATTEMPTS="${PROBE_ATTEMPTS:-$DEFAULT_PROBE_ATTEMPTS}"
+PROBE_INTERVAL="${PROBE_INTERVAL:-3}"
+PROBE_TIMEOUT="${PROBE_TIMEOUT:-$DEFAULT_PROBE_TIMEOUT}"
+CONVERGENCE_ATTEMPTS="${CONVERGENCE_ATTEMPTS:-20}"
+CONVERGENCE_INTERVAL="${CONVERGENCE_INTERVAL:-5}"
+GSLB_READY_TIMEOUT="${GSLB_READY_TIMEOUT:-$DEFAULT_GSLB_READY_TIMEOUT}"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-$DEFAULT_ROLLOUT_TIMEOUT}"
+FAILOVER_REPLICAS="${FAILOVER_REPLICAS:-0}"
+FAILBACK_REPLICAS="${FAILBACK_REPLICAS:-$DEFAULT_FAILBACK_REPLICAS}"
+
+if [[ -t 1 ]]; then
+  COLOR_RESET=$'\033[0m'
+  COLOR_BLUE=$'\033[34m'
+  COLOR_GREEN=$'\033[32m'
+  COLOR_YELLOW=$'\033[33m'
+  COLOR_RED=$'\033[31m'
+else
+  COLOR_RESET=""
+  COLOR_BLUE=""
+  COLOR_GREEN=""
+  COLOR_YELLOW=""
+  COLOR_RED=""
+fi
+
+usage() {
+  cat <<EOF
+Usage:
+  $(basename "$0") deploy
+  $(basename "$0") status
+  $(basename "$0") probe
+  $(basename "$0") failover
+  $(basename "$0") failback
+  $(basename "$0") run
+  $(basename "$0") logs
+  $(basename "$0") delete
+
+Environment overrides:
+  CONTEXTS="$CONTEXTS"
+    Format: "context:region:backend context:region:backend"
+  MANIFEST=$MANIFEST
+  PRIMARY_CONTEXT=$PRIMARY_CONTEXT
+  PROBE_CONTEXT=$PROBE_CONTEXT
+  PRIMARY_GEO_TAG=$PRIMARY_GEO_TAG
+  GSLB_DOMAIN=$GSLB_DOMAIN
+  AI_INFERENCE_HOST=$AI_INFERENCE_HOST
+  NAMESPACE=$NAMESPACE
+  PROBE_NAMESPACE=$PROBE_NAMESPACE
+  OLLAMA_IMAGE=$OLLAMA_IMAGE
+  OLLAMA_BASE_MODEL=$OLLAMA_BASE_MODEL
+  OLLAMA_MODEL=$OLLAMA_MODEL
+  OLLAMA_STORAGE_SIZE=$OLLAMA_STORAGE_SIZE
+  OLLAMA_HOST_PATH=$OLLAMA_HOST_PATH
+  PROBE_ATTEMPTS=$PROBE_ATTEMPTS
+  PROBE_INTERVAL=$PROBE_INTERVAL
+  PROBE_TIMEOUT=$PROBE_TIMEOUT
+  CONVERGENCE_ATTEMPTS=$CONVERGENCE_ATTEMPTS
+  CONVERGENCE_INTERVAL=$CONVERGENCE_INTERVAL
+  GSLB_READY_TIMEOUT=$GSLB_READY_TIMEOUT
+EOF
+}
+
+timestamp() {
+  date +"%H:%M:%S"
+}
+
+info() {
+  printf "%s[%s]%s %s\n" "$COLOR_BLUE" "$(timestamp)" "$COLOR_RESET" "$1"
+}
+
+success() {
+  printf "%s[%s]%s %s\n" "$COLOR_GREEN" "$(timestamp)" "$COLOR_RESET" "$1"
+}
+
+warn() {
+  printf "%s[%s]%s %s\n" "$COLOR_YELLOW" "$(timestamp)" "$COLOR_RESET" "$1"
+}
+
+die() {
+  printf "%s[%s]%s %s\n" "$COLOR_RED" "$(timestamp)" "$COLOR_RESET" "$1" >&2
+  exit 1
+}
+
+need_bin() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required binary: $1"
+}
+
+validate_config() {
+  if [[ -n "${AI_DEMO_MODE:-}" && "${AI_DEMO_MODE}" != "ollama" ]]; then
+    die "AI_DEMO_MODE is no longer supported. This demo always runs lightweight Ollama inference."
+  fi
+}
+
+context_name() {
+  printf '%s' "${1%%:*}"
+}
+
+context_region() {
+  local pair=$1
+  pair="${pair#*:}"
+  printf '%s' "${pair%%:*}"
+}
+
+context_backend() {
+  local pair=$1
+  pair="${pair#*:}"
+  if [[ "$pair" == *:* ]]; then
+    printf '%s' "${pair#*:}"
+  else
+    printf 'inference-endpoint'
+  fi
+}
+
+render_manifest() {
+  local region=$1
+  local backend=$2
+
+  sed \
+    -e "s/__GSLB_DOMAIN__/$GSLB_DOMAIN/g" \
+    -e "s/__AI_DEMO_REGION__/$region/g" \
+    -e "s/__AI_DEMO_BACKEND__/$backend/g" \
+    -e "s/__AI_DEMO_PRIMARY_GEO_TAG__/$PRIMARY_GEO_TAG/g" \
+    -e "s#__OLLAMA_IMAGE__#$OLLAMA_IMAGE#g" \
+    -e "s#__OLLAMA_BASE_MODEL__#$OLLAMA_BASE_MODEL#g" \
+    -e "s#__OLLAMA_MODEL__#$OLLAMA_MODEL#g" \
+    -e "s#__OLLAMA_STORAGE_SIZE__#$OLLAMA_STORAGE_SIZE#g" \
+    -e "s#__OLLAMA_HOST_PATH__#$OLLAMA_HOST_PATH#g" \
+    "$MANIFEST"
+}
+
+wait_for_gslb() {
+  local context=$1
+  local deadline=$((SECONDS + GSLB_READY_TIMEOUT))
+  local hosts healthy_records
+
+  info "Waiting for Gslb status in $context"
+  while (( SECONDS < deadline )); do
+    hosts="$(kubectl --context "$context" -n "$NAMESPACE" get gslbs.k8gb.io "$DEPLOYMENT_NAME" -o jsonpath='{.status.hosts}' 2>/dev/null || true)"
+    healthy_records="$(kubectl --context "$context" -n "$NAMESPACE" get gslbs.k8gb.io "$DEPLOYMENT_NAME" -o jsonpath='{.status.healthyRecords}' 2>/dev/null || true)"
+    if [[ -n "$hosts" && -n "$healthy_records" ]]; then
+      return 0
+    fi
+    sleep 3
+  done
+
+  kubectl --context "$context" -n "$NAMESPACE" get gslbs.k8gb.io "$DEPLOYMENT_NAME" -o yaml 2>/dev/null || true
+  die "Timed out waiting for Gslb status in $context"
+}
+
+deploy_demo() {
+  need_bin kubectl
+
+  for pair in $CONTEXTS; do
+    local context region backend
+    context="$(context_name "$pair")"
+    region="$(context_region "$pair")"
+    backend="$(context_backend "$pair")"
+
+    info "Deploying AI inference demo to $context region=$region backend=$backend"
+    render_manifest "$region" "$backend" | kubectl --context "$context" apply -f -
+    kubectl --context "$context" -n "$NAMESPACE" rollout status "deployment/$DEPLOYMENT_NAME" --timeout="$ROLLOUT_TIMEOUT"
+    wait_for_gslb "$context"
+  done
+
+  success "AI inference demo deployed. Probe host: http://$AI_INFERENCE_HOST/v1/chat/completions"
+}
+
+delete_demo() {
+  need_bin kubectl
+
+  for pair in $CONTEXTS; do
+    local context region backend
+    context="$(context_name "$pair")"
+    region="$(context_region "$pair")"
+    backend="$(context_backend "$pair")"
+
+    info "Deleting AI inference demo from $context"
+    if kubectl --context "$context" get namespace "$NAMESPACE" >/dev/null 2>&1; then
+      kubectl --context "$context" -n "$NAMESPACE" delete \
+        gslbs.k8gb.io "$DEPLOYMENT_NAME" \
+        ingress "$DEPLOYMENT_NAME" \
+        service "$DEPLOYMENT_NAME" \
+        deployment "$DEPLOYMENT_NAME" \
+        pvc ai-inference-demo-ollama \
+        --ignore-not-found
+    fi
+    kubectl --context "$context" delete pv "ai-inference-demo-ollama-$region" --ignore-not-found
+    kubectl --context "$context" delete namespace "$NAMESPACE" --ignore-not-found --wait=false
+  done
+}
+
+coredns_ip() {
+  local context=$1
+  kubectl --context "$context" -n k8gb get svc k8gb-coredns -o jsonpath='{.spec.clusterIP}'
+}
+
+ingress_ips() {
+  local context=$1
+  kubectl --context "$context" -n "$NAMESPACE" get ingress "$DEPLOYMENT_NAME" -o jsonpath='{.status.loadBalancer.ingress[*].ip}'
+}
+
+secondary_context() {
+  local pair context
+
+  for pair in $CONTEXTS; do
+    context="$(context_name "$pair")"
+    if [[ "$context" != "$PRIMARY_CONTEXT" ]]; then
+      printf '%s' "$context"
+      return 0
+    fi
+  done
+
+  die "Could not find a secondary context in CONTEXTS=$CONTEXTS"
+}
+
+probe_loop() {
+  local context=$1
+  local dns_ip=$2
+  local expected_remote_ips=${3:-}
+  local stop_after_success=${4:-false}
+  local pod="k8gb-ai-probe-$RANDOM"
+  local rc
+
+  kubectl --context "$context" -n "$PROBE_NAMESPACE" delete pod "$pod" --ignore-not-found >/dev/null 2>&1 || true
+
+  kubectl --context "$context" -n "$PROBE_NAMESPACE" run "$pod" \
+    --restart=Never \
+    --image="$PROBE_IMAGE" \
+    --env="AI_HOST=$AI_INFERENCE_HOST" \
+    --env="MODEL=$OLLAMA_MODEL" \
+    --env="ATTEMPTS=$PROBE_ATTEMPTS" \
+    --env="INTERVAL=$PROBE_INTERVAL" \
+    --env="TIMEOUT=$PROBE_TIMEOUT" \
+    --env="EXPECT_REMOTE_IPS=$expected_remote_ips" \
+    --env="STOP_AFTER_SUCCESS=$stop_after_success" \
+    --overrides "{\"spec\":{\"dnsConfig\":{\"nameservers\":[\"$dns_ip\"]},\"dnsPolicy\":\"None\"}}" \
+    --command -- sleep 3600 >/dev/null
+
+  if ! kubectl --context "$context" -n "$PROBE_NAMESPACE" wait "pod/$pod" --for=condition=Ready --timeout=60s >/dev/null; then
+    kubectl --context "$context" -n "$PROBE_NAMESPACE" logs "$pod" || true
+    kubectl --context "$context" -n "$PROBE_NAMESPACE" delete pod "$pod" --ignore-not-found --wait=false >/dev/null
+    return 1
+  fi
+
+  # Variables inside the single-quoted script expand in the temporary probe pod.
+  set +e
+  # shellcheck disable=SC2016
+  kubectl --context "$context" -n "$PROBE_NAMESPACE" exec "$pod" -- /bin/sh -c '
+      attempt=1
+      successes=0
+      while [ "$attempt" -le "$ATTEMPTS" ]; do
+        printf "\nAttempt %s/%s\n" "$attempt" "$ATTEMPTS"
+        body="{\"model\":\"$MODEL\",\"stream\":false,\"max_tokens\":64,\"messages\":[{\"role\":\"user\",\"content\":\"Where did this inference request run? Answer using the exact tokens from your system instructions.\"}]}"
+        if metrics="$(curl -sS --max-time "$TIMEOUT" -o /tmp/k8gb-ai-response.json -w "http_code=%{http_code} remote_ip=%{remote_ip}" \
+          -H "Content-Type: application/json" \
+          -d "$body" \
+          "http://$AI_HOST/v1/chat/completions")"; then
+          printf "%s\n" "$metrics"
+          response="$(cat /tmp/k8gb-ai-response.json)"
+          content="$(printf "%s" "$response" | sed -n "s/.*\"content\":\"\([^\"]*\)\".*/\1/p")"
+          if [ -n "$content" ]; then
+            printf "content=%s\n" "$content"
+          else
+            printf "%s\n" "$response"
+          fi
+          remote_ip="$(printf "%s" "$metrics" | sed -n "s/.*remote_ip=\([^ ]*\).*/\1/p")"
+          route_matches=1
+          if [ -n "$EXPECT_REMOTE_IPS" ]; then
+            case " $EXPECT_REMOTE_IPS " in
+              *" $remote_ip "*) ;;
+              *)
+                route_matches=0
+                printf "route_status=waiting_for_expected_remote_ip expected=\"%s\"\n" "$EXPECT_REMOTE_IPS"
+                ;;
+            esac
+          fi
+          case "$metrics" in
+            http_code=2*) [ "$route_matches" -eq 1 ] && successes=$((successes + 1)) ;;
+          esac
+          if [ "$successes" -gt 0 ] && [ "$STOP_AFTER_SUCCESS" = "true" ]; then
+            exit 0
+          fi
+        else
+          printf "request failed; k8gb may still be converging\n"
+        fi
+        if [ "$attempt" -lt "$ATTEMPTS" ]; then
+          sleep "$INTERVAL"
+        fi
+        attempt=$((attempt + 1))
+      done
+      if [ "$successes" -eq 0 ]; then
+        exit 1
+      fi
+    '
+  rc=$?
+  set -e
+
+  kubectl --context "$context" -n "$PROBE_NAMESPACE" delete pod "$pod" --ignore-not-found --wait=false >/dev/null
+  return "$rc"
+}
+
+probe_demo() {
+  need_bin kubectl
+
+  local expected_context=${1:-}
+  local stop_after_success=${2:-false}
+  local dns_ip expected_remote_ips
+  dns_ip="$(coredns_ip "$PROBE_CONTEXT")"
+  [[ -n "$dns_ip" ]] || die "Could not find k8gb CoreDNS service IP in $PROBE_CONTEXT"
+  if [[ -n "$expected_context" ]]; then
+    expected_remote_ips="$(ingress_ips "$expected_context")"
+    [[ -n "$expected_remote_ips" ]] || die "Could not find ingress IPs for $DEPLOYMENT_NAME in $expected_context"
+    info "Expecting $AI_INFERENCE_HOST to route to ingress IPs: $expected_remote_ips"
+  fi
+
+  info "Probing $AI_INFERENCE_HOST through k8gb CoreDNS $dns_ip in $PROBE_CONTEXT"
+  probe_loop "$PROBE_CONTEXT" "$dns_ip" "$expected_remote_ips" "$stop_after_success"
+}
+
+wait_for_convergence() {
+  local reason=$1
+  local expected_context=$2
+  local old_attempts=$PROBE_ATTEMPTS
+  local old_interval=$PROBE_INTERVAL
+
+  PROBE_ATTEMPTS=$CONVERGENCE_ATTEMPTS
+  PROBE_INTERVAL=$CONVERGENCE_INTERVAL
+  info "Waiting for $reason convergence with up to $CONVERGENCE_ATTEMPTS probes"
+  probe_demo "$expected_context" true
+  PROBE_ATTEMPTS=$old_attempts
+  PROBE_INTERVAL=$old_interval
+}
+
+scale_primary() {
+  local replicas=$1
+
+  need_bin kubectl
+  info "Scaling $DEPLOYMENT_NAME in primary context $PRIMARY_CONTEXT to $replicas replicas"
+  kubectl --context "$PRIMARY_CONTEXT" -n "$NAMESPACE" scale "deployment/$DEPLOYMENT_NAME" --replicas="$replicas"
+
+  if [[ "$replicas" != "0" ]]; then
+    kubectl --context "$PRIMARY_CONTEXT" -n "$NAMESPACE" rollout status "deployment/$DEPLOYMENT_NAME" --timeout="$ROLLOUT_TIMEOUT"
+  fi
+}
+
+status_demo() {
+  need_bin kubectl
+
+  for pair in $CONTEXTS; do
+    local context
+    context="$(context_name "$pair")"
+
+    printf "\n%s[%s]%s %s\n" "$COLOR_BLUE" "$(timestamp)" "$COLOR_RESET" "$context"
+    kubectl --context "$context" -n "$NAMESPACE" get deploy,pod,svc,ingress,gslbs.k8gb.io,pvc 2>/dev/null || true
+  done
+}
+
+logs_demo() {
+  need_bin kubectl
+
+  for pair in $CONTEXTS; do
+    local context
+    context="$(context_name "$pair")"
+
+    printf "\n%s[%s]%s %s logs\n" "$COLOR_BLUE" "$(timestamp)" "$COLOR_RESET" "$context"
+    kubectl --context "$context" -n "$NAMESPACE" logs "deployment/$DEPLOYMENT_NAME" --tail=100 --prefix=true 2>/dev/null || true
+  done
+}
+
+run_demo() {
+  deploy_demo
+  status_demo
+  wait_for_convergence "primary routing" "$PRIMARY_CONTEXT"
+  scale_primary "$FAILOVER_REPLICAS"
+  warn "Primary endpoint is down."
+  wait_for_convergence "failover" "$(secondary_context)"
+  scale_primary "$FAILBACK_REPLICAS"
+  warn "Primary endpoint restored."
+  wait_for_convergence "failback" "$PRIMARY_CONTEXT"
+}
+
+validate_config
+
+case "${1:-}" in
+  deploy)
+    deploy_demo
+    ;;
+  status)
+    status_demo
+    ;;
+  probe)
+    probe_demo
+    ;;
+  failover)
+    scale_primary "$FAILOVER_REPLICAS"
+    ;;
+  failback)
+    scale_primary "$FAILBACK_REPLICAS"
+    ;;
+  run)
+    run_demo
+    ;;
+  logs)
+    logs_demo
+    ;;
+  delete)
+    delete_demo
+    ;;
+  -h|--help|help|"")
+    usage
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Add a lightweight local AI inference demo that uses Ollama behind the existing k8gb local multi-cluster setup. The demo deploys an OpenAI-compatible inference endpoint to both k3d clusters, exposes it through a k8gb-managed global hostname, and exercises primary routing, failover, and failback.

The helper script supports a single Make target with actions for deploy, probe, failover, failback, status, logs, and cleanup. It renders region-specific manifests, waits for GSLB convergence, and verifies routing through k8gb CoreDNS by checking the resolved regional ingress endpoint.

Document the demo flow, local setup integration, real-cluster usage, and the AI positioning: k8gb complements Envoy, Istio, Gateway API, KServe, vLLM, Triton, and other inference gateways by providing global DNS resilience rather than replacing regional L7 traffic management or model routing.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
