### PR TITLE
feat: Remove dynamicZones from values.yaml

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -95,7 +95,6 @@ Note: k8gb is architected to run on top of any compliant Kubernetes cluster and 
 | k8gb.deployCrds | bool | `true` | whether it should also deploy the gslb and dnsendpoints CRDs |
 | k8gb.deployRbac | bool | `true` | whether it should also deploy the service account, cluster role and cluster role binding |
 | k8gb.dnsZones | list | `[{"dnsZoneNegTTL":30,"extraPlugins":[],"extraServerBlocks":"","geoDataField":"","geoDataFilePath":"","loadBalancedZone":"cloud.example.com","parentZone":"example.com"}]` | array of dns zones controlled by gslb |
-| k8gb.dynamicZones | bool | `false` | whether to use Dynamic Zone Delegation feature |
 | k8gb.edgeDNSServers[0] | string | `"1.1.1.1"` | use this DNS server as a main resolver to enable cross k8gb DNS based communication |
 | k8gb.exposeMetrics | bool | `false` | Exposing metrics |
 | k8gb.extGslbClustersGeoTags | string | `"eu,us"` | Comma-separated list of geotags for external K8GB clusters. These are arbitrary, user-defined identifiers (e.g., "eu,us" or "dc2,dc3") used for coordination between K8GB instances If the value remains empty, dynamic geotags extracted from the NS records on the edge DNS will be used. |

--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -142,8 +142,6 @@ spec:
               value: "true"
             - name: METRICS_ADDRESS
               value: {{ .Values.k8gb.metricsAddress }}
-            - name: DYNAMIC_ZONES
-              value: "true"
       {{- if .Values.tracing.enabled }}
         - image: {{ .Values.tracing.sidecarImage.repository }}:{{ .Values.tracing.sidecarImage.tag }}
           name: otel-collector

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -15,8 +15,6 @@ k8gb:
   installLegacyCrds: true
   # -- whether it should also deploy the service account, cluster role and cluster role binding
   deployRbac: true
-  # -- whether to use Dynamic Zone Delegation feature
-  dynamicZones: false
   # -- dynamic zones configmap
   extraVolumeMounts:
     - name: dynamic-zones

--- a/controllers/resolver/config.go
+++ b/controllers/resolver/config.go
@@ -55,8 +55,6 @@ type Config struct {
 
 	MetricsAddress string `env:"METRICS_ADDRESS" optional:"" default:"0.0.0.0:8080" validate:"iphostport" help:"format address:port where address can be empty, IP address, or hostname, e.g: 10.10.0.0:8080"`
 
-	DynamicZones bool `env:"DYNAMIC_ZONES" optional:"" default:"false" help:"decides whether to use dynamic zones"`
-
 	TracingEnabled bool `env:"TRACING_ENABLED" optional:"" default:"false" help:"decides whether to use a real otlp tracer or a noop one"`
 
 	TracingSamplingRatio float64 `env:"TRACING_SAMPLING_RATIO" optionl:"" default:"1.0" help:"how many traces should be kept and sent (1.0 - all, 0.0 - none)"`

--- a/deploy/helm/next.yaml
+++ b/deploy/helm/next.yaml
@@ -1,7 +1,6 @@
 k8gb:
   reconcileRequeueSeconds: 10
 
-  dynamicZones: false
   extraVolumeMounts:
     - name: dynamic-zones
       mountPath: /etc/dynamic


### PR DESCRIPTION
This comes from beginning of implementations and is not needed now. K8gb create automatically ZoneDelegation resources out of ZoneDelegation `dnsZones` configuration, or resources are made manually by admin. Keeping  custom property in `values.yaml` is useless. 