### PR TITLE
feat: ZoneDelegation (3.12/4) ZoneDelegation CRD, doFinalize: false as default, Zones validation

### DIFF
--- a/api/k8gb.io/v1beta1/zonedelegation_types.go
+++ b/api/k8gb.io/v1beta1/zonedelegation_types.go
@@ -25,7 +25,8 @@ import (
 )
 
 // ZoneDelegationSpec defines the desired state of ZoneDelegation
-
+// +kubebuilder:validation:XValidation:rule="self.loadBalancedZone != self.parentZone",message="loadBalancedZone must not equal parentZone"
+// +kubebuilder:validation:XValidation:rule="self.loadBalancedZone.endsWith('.' + self.parentZone)",message="loadBalancedZone must be subdomain"
 type ZoneDelegationSpec struct {
 	// LoadBalancedZone is the DNS zone managed by this ZoneDelegation
 	LoadBalancedZone string `json:"loadBalancedZone"`
@@ -39,6 +40,7 @@ type ZoneDelegationSpec struct {
 	// DoFinalize indicates that this ZoneDelegation should be withdrawn
 	// from edge DNS. The controller removes the delegation only when it is no
 	// longer served by any known cluster (based on configured geoTags).
+	// +kubebuilder:default=false
 	DoFinalize bool `json:"doFinalize,omitempty"`
 }
 

--- a/chart/k8gb/crd/k8gb.absa.oss_gslbs.yaml
+++ b/chart/k8gb/crd/k8gb.absa.oss_gslbs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: gslbs.k8gb.absa.oss
 spec:
   group: k8gb.absa.oss

--- a/chart/k8gb/crd/k8gb.io_zonedelegation.yaml
+++ b/chart/k8gb/crd/k8gb.io_zonedelegation.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.20.1
+    controller-gen.kubebuilder.io/version: v0.21.0
   name: zonedelegations.k8gb.io
 spec:
   group: k8gb.io
@@ -49,12 +49,14 @@ spec:
           metadata:
             type: object
           spec:
+            description: ZoneDelegationSpec defines the desired state of ZoneDelegation
             properties:
               dnsZoneNegTTL:
                 description: DNSZoneNegTTL specifies the negative TTL for the DNS
                   zone (in seconds)
                 type: integer
               doFinalize:
+                default: false
                 description: |-
                   DoFinalize indicates that this ZoneDelegation should be withdrawn
                   from edge DNS. The controller removes the delegation only when it is no
@@ -72,6 +74,11 @@ spec:
             - loadBalancedZone
             - parentZone
             type: object
+            x-kubernetes-validations:
+            - message: loadBalancedZone must not equal parentZone
+              rule: self.loadBalancedZone != self.parentZone
+            - message: loadBalancedZone must be subdomain
+              rule: self.loadBalancedZone.endsWith('.' + self.parentZone)
           status:
             description: ZoneDelegationStatus defines the observed state of ZoneDelegation
             properties:


### PR DESCRIPTION
following change adds `doFinalize: false` as default into ZoneDelegation resource, when zoneDelegation is made automatically via migration.   

```yaml
  spec:
    dnsZoneNegTTL: 60
    doFinalize: false
    loadBalancedZone: apex-local-example.app.apex.absa.africa
    parentZone: apex.absa.africa
```