### PR TITLE
fix: repair broken contributor workflows in local deployment helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -423,7 +423,7 @@ deploy-gslb-operator: ## Deploy k8gb operator
 	kubectl create namespace k8gb --dry-run=client -o yaml | kubectl apply -f -
 	cd chart/k8gb && helm dependency update
 	helm -n k8gb upgrade -i k8gb chart/k8gb -f $(VALUES_YAML) $(HELM_ARGS) \
-		--set k8gb.log.format=$(LOG_FORMAT)
+		--set k8gb.log.format=$(LOG_FORMAT) \
 		--set k8gb.log.level=$(LOG_LEVEL)
 
 # destroy local test environment

--- a/dns-provider-test/route53/test.sh
+++ b/dns-provider-test/route53/test.sh
@@ -32,8 +32,7 @@ echo "---- Creating local clusters ----"
 cd "${SCRIPT_DIR}/../../"
 ZONE_ID=$(aws route53 list-hosted-zones --query "HostedZones[?Name == 'k8gb.io.'].Id" --output text)
 EDGE_DNS_SERVER=$(aws route53 list-resource-record-sets --hosted-zone-id "$ZONE_ID" --query "ResourceRecordSets[?Type == 'NS'].ResourceRecords[0]" --output text | sed 's/\.$//')
-cp dns-provider-test/route53/values-template.yaml dns-provider-test/route53/values.yaml
-sed -i '' "s/DNS_SERVER_TODO/$EDGE_DNS_SERVER/g" dns-provider-test/route53/values.yaml
+sed "s/DNS_SERVER_TODO/$EDGE_DNS_SERVER/g" dns-provider-test/route53/values-template.yaml > dns-provider-test/route53/values.yaml
 make create-local-clusters
 make release-images
 


### PR DESCRIPTION
fixes two small workflow breaks.

`dns-provider-test/route53/test.sh` used `sed -i ''`, which blows up on GNU sed on Linux.
`deploy-gslb-operator` missed a trailing `\`, so `k8gb.log.level` fell out of the Helm command.

repro

1. On Linux run `tmp=$(mktemp); cp dns-provider-test/route53/values-template.yaml "$tmp"; sed -i '' "s/DNS_SERVER_TODO/example.org/g" "$tmp"`.
   It fails with `sed: can't read s/DNS_SERVER_TODO/example.org/g: No such file or directory`.
2. Run `make -n deploy-gslb-operator LOG_LEVEL=info`.
   Before this patch the output split after `--set k8gb.log.format=simple`, so `set k8gb.log.level=info` was not part of the Helm command.

what changed

1. Build `values.yaml` from the template with plain `sed > file`, so no inplace sed gotcha.
2. Add the missing line continuation in `deploy-gslb-operator`.

thats it, small fix but pretty real.
