### PR TITLE
fix(docs): correct broken internal markdown links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ This document outlines the resources and guidelines necessary to follow by contr
 ## Getting started
 
 - Fork the repository on GitHub
-- See the [local playground guide](local.md) for local dev environment setup
+- See the [local playground guide](docs/local.md) for local dev environment setup
 
 ## Getting help
 
@@ -144,7 +144,7 @@ There is a dedicated make target available for Goland:
 3. Attach debugger of your IDE to port `2345`.
 
 ## Metrics
-More info about k8gb metrics can be found in the [metrics.md](metrics.md) document.
+More info about k8gb metrics can be found in the [metrics.md](docs/metrics.md) document.
 If you need to check and query the k8gb metrics locally, you can install a Prometheus in the local clusters using the `make deploy-prometheus` command.
 
 The deployed Prometheus scrapes metrics from the dedicated k8gb operator endpoint and makes them accessible via Prometheus web UI:

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -92,8 +92,9 @@ authors:
 
 ### Images and Assets
 
-- Place images in `docs/images/blog/` directory
-- Use relative paths: `![Alt text](../../images/blog/my-image.png)`
+- Place shared banner images in `docs/blog/blog-banners/`
+- For post-specific assets, keep them next to the post in `docs/blog/posts/`
+- Use relative paths such as `![Banner](../blog-banners/k8gb-blog-1.png)` or `![Diagram](ai-inf-arch.png)`
 - Optimize images for web (compress, appropriate formats)
 
 ### Code Blocks
@@ -113,8 +114,8 @@ spec:
 ### Internal Links
 
 Link to other documentation:
-- `[Installation Guide](../../tutorials.md)`
-- `[Components](../../components.md)`
+- `[Installation Guide](../tutorials.md)`
+- `[Components](../components.md)`
 
 ### External Links
 


### PR DESCRIPTION
tiny docs paper cut, but real.

what broke
- `CONTRIBUTING.md` links `local.md` and `metrics.md` from repo root, but both files live under `docs/`
- `docs/blog/README.md` links `../../tutorials.md` and `../../components.md`, which resolve to missing repo root files
- the blog asset note was also out of sync with the dirs we actually use today

how to repro
- open `CONTRIBUTING.md` and click `local playground guide` or `metrics.md`
- open `docs/blog/README.md` and click `Installation Guide` or `Components`
- those links go to missing targets, so yeah pretty busted

what this fixes
- point the links at the real files
- update the blog asset guidance to match the current layout

related
- similar docs fixes: #1832, #1986