### PR TITLE
fix(dns): use dot separator for localtargets DNS prefix

### DIFF
--- a/controllers/providers/k8gbendpoint/applicationDNSEndpoint.go
+++ b/controllers/providers/k8gbendpoint/applicationDNSEndpoint.go
@@ -233,6 +233,18 @@ func (d *ApplicationDNSEndpoint) GetExternalTargets(host string) (targets Target
 				Msg("can't resolve FQDN using nameservers")
 			continue
 		}
+		// Fall back to legacy naming scheme for backward compatibility during migration
+		if len(d.queryService.ExtractARecords(dnsResult.Msg)) == 0 {
+			lHostLegacy, err := getLocalTargetsHostLegacy(host)
+			if err != nil {
+				continue
+			}
+			dnsResultLegacy := d.queryService.Query(lHostLegacy, nameServersToUse)
+			if dnsResultLegacy.Err != nil {
+				continue
+			}
+			dnsResult = dnsResultLegacy
+		}
 		clusterTargets := d.queryService.ExtractARecords(dnsResult.Msg)
 		if len(clusterTargets) > 0 {
 			targets[authServer.GeoTag] = &Target{clusterTargets}

--- a/controllers/providers/k8gbendpoint/applicationDNSEndpoint_weight_test.go
+++ b/controllers/providers/k8gbendpoint/applicationDNSEndpoint_weight_test.go
@@ -340,12 +340,12 @@ func TestWeight(t *testing.T) {
 				ns := fmt.Sprintf("gslb-ns-%s-cloud.example.com", d.region)
 				nsIP := test.authServers[ns].IP
 				for _, v := range d.targets {
-					record := &dns.A{Hdr: dns.RR_Header{Name: dns.Fqdn("localtargets-app.gslb.cloud.example.com"), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
+					record := &dns.A{Hdr: dns.RR_Header{Name: dns.Fqdn("localtargets.app.gslb.cloud.example.com"), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 30},
 						A: net.ParseIP(v)}
 					ips = append(ips, record)
 				}
 				qs.EXPECT().
-					Query("localtargets-app.gslb.cloud.example.com", utils.DNSList{utils.DNSServer{Host: nsIP, Port: 53}}).
+					Query("localtargets.app.gslb.cloud.example.com", utils.DNSList{utils.DNSServer{Host: nsIP, Port: 53}}).
 					Return(utils.DNSQueryResult{Msg: &dns.Msg{Answer: ips}, Err: nil, Status: utils.DNSQueryStatusResolved}).
 					AnyTimes()
 			}

--- a/controllers/providers/k8gbendpoint/dns_validation.go
+++ b/controllers/providers/k8gbendpoint/dns_validation.go
@@ -24,13 +24,22 @@ import (
 )
 
 const (
-	localTargetsPrefix = "localtargets."
-	dnsNameMax         = 253
-	dnsLabelMax        = 63
+	localTargetsPrefix    = "localtargets."
+	localTargetsPrefixOld = "localtargets-"
+	dnsNameMax            = 253
+	dnsLabelMax           = 63
 )
 
 func getLocalTargetsHost(host string) (string, error) {
 	localTargetsHost := fmt.Sprintf("%s%s", localTargetsPrefix, host)
+	if err := validateDNSName(localTargetsHost); err != nil {
+		return "", fmt.Errorf("derived localtargets name %q is invalid: %w", localTargetsHost, err)
+	}
+	return localTargetsHost, nil
+}
+
+func getLocalTargetsHostLegacy(host string) (string, error) {
+	localTargetsHost := fmt.Sprintf("%s%s", localTargetsPrefixOld, host)
 	if err := validateDNSName(localTargetsHost); err != nil {
 		return "", fmt.Errorf("derived localtargets name %q is invalid: %w", localTargetsHost, err)
 	}

--- a/controllers/providers/k8gbendpoint/dns_validation.go
+++ b/controllers/providers/k8gbendpoint/dns_validation.go
@@ -24,7 +24,7 @@ import (
 )
 
 const (
-	localTargetsPrefix = "localtargets-"
+	localTargetsPrefix = "localtargets."
 	dnsNameMax         = 253
 	dnsLabelMax        = 63
 )

--- a/controllers/providers/k8gbendpoint/dns_validation_test.go
+++ b/controllers/providers/k8gbendpoint/dns_validation_test.go
@@ -47,6 +47,26 @@ func TestGetLocalTargetsHostRejectsTooLongFirstLabel(t *testing.T) {
 	assert.EqualError(t, err, expectedErr)
 }
 
+func TestGetLocalTargetsHostLegacyRejectsTooLongFirstLabel(t *testing.T) {
+	host := strings.Repeat("a", 51) + ".cloud.example.com"
+	expectedErr := `derived localtargets name "localtargets-` +
+		strings.Repeat("a", 51) +
+		`.cloud.example.com" is invalid: label "localtargets-` +
+		strings.Repeat("a", 51) +
+		`" exceeds 63 characters`
+
+	_, err := getLocalTargetsHostLegacy(host)
+
+	assert.EqualError(t, err, expectedErr)
+}
+
+func TestGetLocalTargetsHostLegacyAcceptsValidHost(t *testing.T) {
+	host := "my-app.cloud.example.com"
+	result, err := getLocalTargetsHostLegacy(host)
+	assert.NoError(t, err)
+	assert.Equal(t, "localtargets-my-app.cloud.example.com", result)
+}
+
 func TestGetDNSEndpointRejectsInvalidLocalTargetsHost(t *testing.T) {
 	logger := zerolog.New(io.Discard).With().Timestamp().Logger()
 	metrics := func(*k8gbv1beta1io.Gslb, bool, k8gbv1beta1io.HealthStatus, []string) {}

--- a/controllers/providers/k8gbendpoint/dns_validation_test.go
+++ b/controllers/providers/k8gbendpoint/dns_validation_test.go
@@ -36,9 +36,9 @@ import (
 
 func TestGetLocalTargetsHostRejectsTooLongFirstLabel(t *testing.T) {
 	host := strings.Repeat("a", 51) + ".cloud.example.com"
-	expectedErr := `derived localtargets name "localtargets-` +
+	expectedErr := `derived localtargets name "localtargets.` +
 		strings.Repeat("a", 51) +
-		`.cloud.example.com" is invalid: label "localtargets-` +
+		`.cloud.example.com" is invalid: label "localtargets.` +
 		strings.Repeat("a", 51) +
 		`" exceeds 63 characters`
 

--- a/controllers/utils/fakedns_test.go
+++ b/controllers/utils/fakedns_test.go
@@ -109,15 +109,15 @@ func TestFakeDNSBasic(t *testing.T) {
 func TestFakeDNSStress(t *testing.T) {
 	for i := 1; i < 10; i++ {
 		NewFakeDNS(testSettings).
-			AddARecord("localtargets-roundrobin.cloud.example.com.", net.IPv4(10, 1, 0, 3)).
-			AddARecord("localtargets-roundrobin.cloud.example.com.", net.IPv4(10, 1, 0, 2)).
-			AddARecord("localtargets-roundrobin.cloud.example.com.", net.IPv4(10, 1, 0, 1)).
-			AddTXTRecord("localtargets-heartbeat-us.cloud.example.com.", "5m").
+			AddARecord("localtargets.roundrobin.cloud.example.com.", net.IPv4(10, 1, 0, 3)).
+			AddARecord("localtargets.roundrobin.cloud.example.com.", net.IPv4(10, 1, 0, 2)).
+			AddARecord("localtargets.roundrobin.cloud.example.com.", net.IPv4(10, 1, 0, 1)).
+			AddTXTRecord("localtargets.heartbeat-us.cloud.example.com.", "5m").
 			Start().
 			RunTestFunc(func() {
 				t.Log("FakeDNS test: ", i)
 				g := new(dns.Msg)
-				g.SetQuestion("localtargets-roundrobin.cloud.example.com.", dns.TypeA)
+				g.SetQuestion("localtargets.roundrobin.cloud.example.com.", dns.TypeA)
 				// put server under load....
 				for i := 0; i <= 100; i++ {
 					a, err := dns.Exchange(g, fmt.Sprintf("%s:%v", server, port))

--- a/terratest/utils/extensions.go
+++ b/terratest/utils/extensions.go
@@ -541,7 +541,7 @@ func (i *Instance) waitForApp(predicate func(instances int) bool, stop bool) (er
 	// second conditions
 	endpointReady := false
 	for n := 0; n < maxRetries/2; n++ {
-		ep, err := i.Resources().GetExternalDNSEndpointByName(i.w.state.gslb.name, i.w.namespace).GetEndpointByName(fmt.Sprintf("localtargets-%s", i.w.state.gslb.host))
+		ep, err := i.Resources().GetExternalDNSEndpointByName(i.w.state.gslb.name, i.w.namespace).GetEndpointByName(fmt.Sprintf("localtargets.%s", i.w.state.gslb.host))
 		if err != nil {
 			if err.Error() == notFoundError {
 				// During startup the local DNSEndpoint can lag behind the app becoming ready,
@@ -607,7 +607,7 @@ func (i *Instance) Dig() []string {
 
 // GetLocalTargets returns instance local targets
 func (i *Instance) GetLocalTargets() []string {
-	dnsName := fmt.Sprintf("localtargets-%s", i.w.state.gslb.host)
+	dnsName := fmt.Sprintf("localtargets.%s", i.w.state.gslb.host)
 	dig, err := dns.Dig("localhost:"+strconv.Itoa(i.w.state.gslb.port), dnsName, i.w.settings.digUsingUDP)
 	i.logIfError(err, "GetLocalTargets(), dig: %s", err)
 	return dig


### PR DESCRIPTION
The localtargets-<host> naming scheme could produce DNS labels exceeding the 63-character limit when the hostname's first label was long enough. Changed the separator from '-' to '.' so 'localtargets' becomes its own DNS label, keeping the original hostname labels intact.

Fixes #2366