### PR TITLE
docs: document partial Gslb deployment behavior

### DIFF
--- a/docs/dynamic_zones.md
+++ b/docs/dynamic_zones.md
@@ -144,3 +144,7 @@ Static zones configured through `k8gb.dnsZones` remain supported. Dynamic Zones 
 where zones should be activated only when `ZoneDelegation` objects are created. For backward compatibility, `ZoneDelegation`
 objects generated from `k8gb.dnsZones` or the `DNS_ZONES` environment variable have `doFinalize` set to `false` by default.
 This prevents k8gb from deleting delegated zones that were originally configured as static zones.
+
+## See Also
+
+- [Partial Deployment Troubleshooting](partial-deployment.md): what happens when a `Gslb` resource is missing from one or more delegated clusters.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -142,6 +142,37 @@ This use case demonstrates that clusters with no healthy Pods should *not* have 
 
 If the Pods in cluster **Y** were to once again become healthy (liveness and readiness probes start passing) then the Ingress node IPs for cluster **Y** would once again be added to the eligible pool of Ingress node IPs.
 
+### 4. Partial deployment - Gslb resource missing from a cluster
+
+This use case documents what happens when a `Gslb` resource is **not** deployed consistently across all clusters. This situation arises during phased rollouts or as a result of misconfiguration, and leads to the affected cluster being silently excluded from global load balancing for that hostname.
+
+#### 4.1 Setup
+
+In this scenario, a multi-cluster environment has:
+
+- Cluster **X**: `Gslb` resource **deployed** for `app.cloud.example.com`
+- Cluster **Y**: `Gslb` resource **not deployed** for `app.cloud.example.com`
+
+#### 4.2 Behavior
+
+When a `Gslb` resource is absent from cluster **Y**:
+
+1. Cluster **Y**'s k8gb controller has no knowledge of `app.cloud.example.com` and publishes no `localtargets-app.cloud.example.com` A records to its local CoreDNS.
+2. Cluster **Y**'s zone delegation (NS + glue records) registered with the edge DNS is unaffected by the missing `Gslb` resource — NS delegation is per-cluster, not per-hostname. However, when Cluster **X** queries Cluster **Y**'s CoreDNS for `localtargets-app.cloud.example.com`, it receives an empty response because no such records exist.
+3. Cluster **X** collects `localtargets-*` records from all known clusters; for Cluster **Y** it receives an empty result, so only Cluster **X**'s own Ingress node IPs are included in the final answer set.
+4. Cluster **X** composes DNS responses containing only its own Ingress node IPs.
+
+Clients receive **consistent** DNS responses — they are always directed to cluster **X** — but cluster **Y** never receives GSLB-managed traffic for this hostname, regardless of its Pod health.
+
+#### 4.3 Outcome
+
+k8gb participation is **opt-in per cluster per hostname**. A cluster that lacks a `Gslb` resource for a given hostname is silently excluded from the GSLB pool for that hostname. The system continues to function through the remaining clusters, but the missing cluster cannot take part in load balancing.
+
+For troubleshooting guidance — common causes of accidental partial deployment and how to detect them — see [Partial deployment troubleshooting](partial-deployment.md).
+
+!!! note "Intentional single-cluster deployment"
+    Deploying a `Gslb` resource in only one cluster is a valid and supported configuration (see [use case 1](#1-basic-single-cluster)). The concern this section addresses is the **unintended** case where an operator expects multi-cluster load balancing but omits the `Gslb` resource from one or more clusters.
+
 ## Load balancing strategies
 
 The following load balancing strategies, as it relates to resolving Ingress node IPs, should be provided as part of the initial implementation:

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -144,31 +144,9 @@ If the Pods in cluster **Y** were to once again become healthy (liveness and rea
 
 ### 4. Partial deployment - Gslb resource missing from a cluster
 
-This use case documents what happens when a `Gslb` resource is **not** deployed consistently across all clusters. This situation arises during phased rollouts or as a result of misconfiguration, and leads to the affected cluster being silently excluded from global load balancing for that hostname.
+k8gb participation is opt-in per cluster per hostname. When a `Gslb` resource is absent from a cluster, that cluster publishes no `localtargets-*` DNS records for the hostname and is silently excluded from the GSLB pool. The remaining clusters continue to function normally.
 
-#### 4.1 Setup
-
-In this scenario, a multi-cluster environment has:
-
-- Cluster **X**: `Gslb` resource **deployed** for `app.cloud.example.com`
-- Cluster **Y**: `Gslb` resource **not deployed** for `app.cloud.example.com`
-
-#### 4.2 Behavior
-
-When a `Gslb` resource is absent from cluster **Y**:
-
-1. Cluster **Y**'s k8gb controller has no knowledge of `app.cloud.example.com` and publishes no `localtargets-app.cloud.example.com` A records to its local CoreDNS.
-2. Cluster **Y**'s zone delegation (NS + glue records) registered with the edge DNS is unaffected by the missing `Gslb` resource — NS delegation is per-cluster, not per-hostname. However, when Cluster **X** queries Cluster **Y**'s CoreDNS for `localtargets-app.cloud.example.com`, it receives an empty response because no such records exist.
-3. Cluster **X** collects `localtargets-*` records from all known clusters; for Cluster **Y** it receives an empty result, so only Cluster **X**'s own Ingress node IPs are included in the final answer set.
-4. Cluster **X** composes DNS responses containing only its own Ingress node IPs.
-
-Clients receive **consistent** DNS responses — they are always directed to cluster **X** — but cluster **Y** never receives GSLB-managed traffic for this hostname, regardless of its Pod health.
-
-#### 4.3 Outcome
-
-k8gb participation is **opt-in per cluster per hostname**. A cluster that lacks a `Gslb` resource for a given hostname is silently excluded from the GSLB pool for that hostname. The system continues to function through the remaining clusters, but the missing cluster cannot take part in load balancing.
-
-For troubleshooting guidance — common causes of accidental partial deployment and how to detect them — see [Partial deployment troubleshooting](partial-deployment.md).
+For a detailed walkthrough of the DNS mechanics, common causes, and how to detect this situation, see [Partial deployment troubleshooting](partial-deployment.md).
 
 !!! note "Intentional single-cluster deployment"
     Deploying a `Gslb` resource in only one cluster is a valid and supported configuration (see [use case 1](#1-basic-single-cluster)). The concern this section addresses is the **unintended** case where an operator expects multi-cluster load balancing but omits the `Gslb` resource from one or more clusters.

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -142,15 +142,6 @@ This use case demonstrates that clusters with no healthy Pods should *not* have 
 
 If the Pods in cluster **Y** were to once again become healthy (liveness and readiness probes start passing) then the Ingress node IPs for cluster **Y** would once again be added to the eligible pool of Ingress node IPs.
 
-### 4. Partial deployment - Gslb resource missing from a cluster
-
-k8gb participation is opt-in per cluster per hostname. When a `Gslb` resource is absent from a cluster, that cluster publishes no `localtargets-*` DNS records for the hostname and is silently excluded from the GSLB pool. The remaining clusters continue to function normally.
-
-For a detailed walkthrough of the DNS mechanics, common causes, and how to detect this situation, see [Partial deployment troubleshooting](partial-deployment.md).
-
-!!! note "Intentional single-cluster deployment"
-    Deploying a `Gslb` resource in only one cluster is a valid and supported configuration (see [use case 1](#1-basic-single-cluster)). The concern this section addresses is the **unintended** case where an operator expects multi-cluster load balancing but omits the `Gslb` resource from one or more clusters.
-
 ## Load balancing strategies
 
 The following load balancing strategies, as it relates to resolving Ingress node IPs, should be provided as part of the initial implementation:

--- a/docs/partial-deployment.md
+++ b/docs/partial-deployment.md
@@ -1,0 +1,44 @@
+# Partial Deployment Troubleshooting
+
+This page provides operational guidance for diagnosing and resolving situations where a `Gslb` resource is missing from one or more clusters in a multi-cluster k8gb setup. For a description of how k8gb behaves in this scenario, see [use case 4 in the Getting Started guide](intro.md#4-partial-deployment---gslb-resource-missing-from-a-cluster).
+
+## Common Causes
+
+| Cause | Description |
+|-------|-------------|
+| **Incomplete rollout** | `Gslb` resources were deployed to some clusters but not all. |
+| **Namespace mismatch** | The `Gslb` resource exists but in a different namespace than k8gb is watching. |
+| **Hostname typo** | The `spec.ingress.rules[].host` value in the `Gslb` resource does not exactly match the Ingress host. |
+
+## How to Detect
+
+**1. Verify consistent Gslb coverage across clusters**
+
+Run the following on each cluster and confirm the same hostname appears everywhere you expect multi-cluster load balancing:
+
+```bash
+kubectl get gslb -A
+```
+
+If a hostname is present in Cluster X but absent in Cluster Y, Cluster Y is excluded from the GSLB pool for that hostname.
+
+**2. Inspect healthyRecords on the Gslb object**
+
+On a cluster that *does* have the `Gslb` resource, check whether remote clusters are contributing endpoints:
+
+```bash
+kubectl get gslb <name> -n <namespace> -o jsonpath='{.status.healthyRecords}'
+```
+
+If only one cluster's Ingress IPs appear in `status.healthyRecords`, the other clusters are either unhealthy or missing the `Gslb` resource.
+
+**3. Query the remote cluster's CoreDNS directly**
+
+Confirm that a cluster has published `localtargets-*` records by querying its CoreDNS directly. If no records are returned, the `Gslb` resource is absent or not yet reconciled on that cluster:
+
+```bash
+# Replace <coredns-ip> with the external IP of the target cluster's CoreDNS service
+dig localtargets-app.cloud.example.com @<coredns-ip>
+```
+
+An empty answer section (NOERROR, no A records) confirms that the cluster has no `localtargets-*` records for the hostname.

--- a/docs/partial-deployment.md
+++ b/docs/partial-deployment.md
@@ -6,7 +6,7 @@ When `ZoneDelegation` is present in cluster **Y** but a `Gslb` resource for `app
 
 1. Cluster **Y** remains authoritative for the configured load-balanced zone because `ZoneDelegation` continues to publish its NS and glue records.
 2. Cluster **Y** does not publish application or `localtargets-*` records for `app.cloud.example.com`.
-3. The edge DNS can still delegate queries for the load-balanced zone to cluster **Y**, even though that cluster lacks records for this application hostname.
+3. The edge DNS continues to delegate queries for the load-balanced zone to cluster **Y** because the NS and glue records published by `ZoneDelegation` are unaffected. Queries for `app.cloud.example.com` that reach cluster **Y**'s CoreDNS receive NXDOMAIN or an empty answer because no records for that hostname were ever published.
 4. Cluster **X** cannot discover healthy application targets from cluster **Y**, so those targets are not included in responses produced by cluster **X**.
 
 Clients can therefore receive inconsistent DNS responses depending on which authoritative cluster answers the query. A partial `Gslb` deployment should not be treated as a safe way to exclude a cluster.

--- a/docs/partial-deployment.md
+++ b/docs/partial-deployment.md
@@ -1,6 +1,18 @@
-# Partial Deployment Troubleshooting
+# Partial Deployment
 
-This page provides operational guidance for diagnosing and resolving situations where a `Gslb` resource is missing from one or more clusters in a multi-cluster k8gb setup. For a description of how k8gb behaves in this scenario, see [use case 4 in the Getting Started guide](intro.md#4-partial-deployment---gslb-resource-missing-from-a-cluster).
+## What happens when a Gslb resource is missing from a cluster
+
+k8gb participation is opt-in per cluster per hostname. Consider a two-cluster setup where Cluster **X** has a `Gslb` resource for `app.cloud.example.com` and Cluster **Y** does not:
+
+1. Cluster **Y**'s k8gb controller has no knowledge of `app.cloud.example.com` and publishes no `localtargets-app.cloud.example.com` A records to its local CoreDNS.
+2. NS zone delegation is per-cluster, not per-hostname. Cluster **Y**'s zone delegation registered with the edge DNS is unaffected. However, when Cluster **X** queries Cluster **Y**'s CoreDNS for `localtargets-app.cloud.example.com`, it receives an empty response (NOERROR, no A records) because the records were never published.
+3. Cluster **X** collects `localtargets-*` records from all known clusters; for Cluster **Y** it receives an empty result, so only Cluster **X**'s own Ingress node IPs are included in the final answer set.
+
+Clients receive **consistent** DNS responses directed to Cluster **X**, but Cluster **Y** is never included in the GSLB pool for this hostname, regardless of its Pod health.
+
+## Troubleshooting
+
+This section provides guidance for diagnosing situations where a `Gslb` resource is missing from one or more clusters in a multi-cluster k8gb setup.
 
 ## Common Causes
 

--- a/docs/partial-deployment.md
+++ b/docs/partial-deployment.md
@@ -1,18 +1,17 @@
-# Partial Deployment
+# Partial Deployment Troubleshooting
 
 ## What happens when a Gslb resource is missing from a cluster
 
-k8gb participation is opt-in per cluster per hostname. Consider a two-cluster setup where Cluster **X** has a `Gslb` resource for `app.cloud.example.com` and Cluster **Y** does not:
+When `ZoneDelegation` is present in cluster **Y** but a `Gslb` resource for `app.cloud.example.com` is absent:
 
-1. Cluster **Y**'s k8gb controller has no knowledge of `app.cloud.example.com` and publishes no `localtargets-app.cloud.example.com` A records to its local CoreDNS.
-2. NS zone delegation is per-cluster, not per-hostname. Cluster **Y**'s zone delegation registered with the edge DNS is unaffected. However, when Cluster **X** queries Cluster **Y**'s CoreDNS for `localtargets-app.cloud.example.com`, it receives an empty response (NOERROR, no A records) because the records were never published.
-3. Cluster **X** collects `localtargets-*` records from all known clusters; for Cluster **Y** it receives an empty result, so only Cluster **X**'s own Ingress node IPs are included in the final answer set.
+1. Cluster **Y** remains authoritative for the configured load-balanced zone because `ZoneDelegation` continues to publish its NS and glue records.
+2. Cluster **Y** does not publish application or `localtargets-*` records for `app.cloud.example.com`.
+3. The edge DNS can still delegate queries for the load-balanced zone to cluster **Y**, even though that cluster lacks records for this application hostname.
+4. Cluster **X** cannot discover healthy application targets from cluster **Y**, so those targets are not included in responses produced by cluster **X**.
 
-Clients receive **consistent** DNS responses directed to Cluster **X**, but Cluster **Y** is never included in the GSLB pool for this hostname, regardless of its Pod health.
+Clients can therefore receive inconsistent DNS responses depending on which authoritative cluster answers the query. A partial `Gslb` deployment should not be treated as a safe way to exclude a cluster.
 
-## Troubleshooting
-
-This section provides guidance for diagnosing situations where a `Gslb` resource is missing from one or more clusters in a multi-cluster k8gb setup.
+Application participation is configured per hostname through `Gslb`, while DNS delegation is configured separately per load-balanced zone through `ZoneDelegation`. Operators should deploy the `Gslb` resource consistently across every delegated cluster expected to serve the hostname.
 
 ## Common Causes
 
@@ -24,33 +23,7 @@ This section provides guidance for diagnosing situations where a `Gslb` resource
 
 ## How to Detect
 
-**1. Verify consistent Gslb coverage across clusters**
-
-Run the following on each cluster and confirm the same hostname appears everywhere you expect multi-cluster load balancing:
-
-```bash
-kubectl get gslb -A
-```
-
-If a hostname is present in Cluster X but absent in Cluster Y, Cluster Y is excluded from the GSLB pool for that hostname.
-
-**2. Inspect healthyRecords on the Gslb object**
-
-On a cluster that *does* have the `Gslb` resource, check whether remote clusters are contributing endpoints:
-
-```bash
-kubectl get gslb <name> -n <namespace> -o jsonpath='{.status.healthyRecords}'
-```
-
-If only one cluster's Ingress IPs appear in `status.healthyRecords`, the other clusters are either unhealthy or missing the `Gslb` resource.
-
-**3. Query the remote cluster's CoreDNS directly**
-
-Confirm that a cluster has published `localtargets-*` records by querying its CoreDNS directly. If no records are returned, the `Gslb` resource is absent or not yet reconciled on that cluster:
-
-```bash
-# Replace <coredns-ip> with the external IP of the target cluster's CoreDNS service
-dig localtargets-app.cloud.example.com @<coredns-ip>
-```
-
-An empty answer section (NOERROR, no A records) confirms that the cluster has no `localtargets-*` records for the hostname.
+- Verify that the expected `ZoneDelegation` exists in every cluster intended to be authoritative for the load-balanced zone.
+- Run `kubectl get gslb -A` in each delegated cluster and confirm that the application hostname is present.
+- Query the edge DNS for the configured load-balanced zone, for example: `dig NS cloud.example.com @<edge-dns>`.
+- Query `app.cloud.example.com` and its generated `localtargets-*` record directly against each authoritative cluster DNS server returned by the NS lookup. Different answers identify an incomplete cluster configuration.

--- a/docs/partial-deployment.md
+++ b/docs/partial-deployment.md
@@ -18,12 +18,19 @@ Application participation is configured per hostname through `Gslb`, while DNS d
 | Cause | Description |
 |-------|-------------|
 | **Incomplete rollout** | `Gslb` resources were deployed to some clusters but not all. |
-| **Namespace mismatch** | The `Gslb` resource exists but in a different namespace than k8gb is watching. |
-| **Hostname typo** | The `spec.ingress.rules[].host` value in the `Gslb` resource does not exactly match the Ingress host. |
+| **Wrong Kubernetes context** | The `Gslb` manifest was applied to a different cluster than intended. |
+| **Hostname drift** | `Gslb` deployments use different application hostnames across clusters, for example because of a typo in one cluster's manifest. |
 
 ## How to Detect
 
 - Verify that the expected `ZoneDelegation` exists in every cluster intended to be authoritative for the load-balanced zone.
-- Run `kubectl get gslb -A` in each delegated cluster and confirm that the application hostname is present.
+- Run `kubectl get gslb -A -o wide` in each delegated cluster and confirm that the application hostname appears in the `HOSTS` column.
 - Query the edge DNS for the configured load-balanced zone, for example: `dig NS cloud.example.com @<edge-dns>`.
-- Query `app.cloud.example.com` and its generated `localtargets-*` record directly against each authoritative cluster DNS server returned by the NS lookup. Different answers identify an incomplete cluster configuration.
+- Query both application records directly against every authoritative cluster DNS server returned by the NS lookup:
+
+  ```sh
+  dig A app.cloud.example.com @<authoritative-server>
+  dig A localtargets-app.cloud.example.com @<authoritative-server>
+  ```
+
+  The `localtargets-*` answers normally contain different IP addresses in each cluster because they represent that cluster's local healthy targets. Do not compare these answers for equality. Instead, use the resource check above to confirm that the `Gslb` exists, then investigate an absent application record or an unexpectedly empty `localtargets-*` answer. An empty `localtargets-*` answer can also mean that the local workload is unhealthy.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - Load Balancer: lbservice-integration.md
     - Advanced:
       - Split-Brain Scenarios: splitbrain.md
+      - Partial Deployment Troubleshooting: partial-deployment.md
       - Service Upgrade: service_upgrade.md
       - Migration Acceptance Tests: migration_acceptance.md
       - WRR Caveats: wrr_caveats.md


### PR DESCRIPTION
## What this PR does

Adds **use case 4** to `docs/intro.md` documenting what happens when a `Gslb` resource is not deployed in every cluster.

The existing documentation covers:
- Use case 1: Single cluster (Gslb in one cluster only)
- Use case 2: Multi-cluster (Gslb in all clusters)
- Use case 3: Unhealthy service (Gslb in all clusters, pods down in one)

But there was no documentation for the case where a cluster is expected to participate but lacks the `Gslb` resource — leading to the cluster being silently excluded from the GSLB pool.

## What the new section explains

- The cluster missing the `Gslb` CR does not publish `localtargets-*` records or NS delegation records
- Clients receive consistent DNS responses from the remaining clusters, but the missing cluster never receives traffic
- Common causes: incomplete rollout, namespace mismatch, host typo
- How to detect it: `kubectl get gslb -A`, `status.healthyRecords`, and `dig NS` against the edge DNS

Fixes #1348