### PR TITLE
docs: clarify dynamic zone cluster participation

### DIFF
--- a/docs/dynamic_zones.md
+++ b/docs/dynamic_zones.md
@@ -28,6 +28,20 @@ The feature introduces a cluster-scoped resource `ZoneDelegation` that contains:
 Pre-configuring zones in anonymous or shared clusters makes CoreDNS authoritative too early, causing `NXDOMAIN` responses.
 `ZoneDelegation` lets applications ship their own zone definitions, enabling dynamic activation.
 
+## Deploying Load-Balanced Zones to a Subset of Clusters
+
+In multi-cluster environments, a load-balanced application does not have to be deployed to every cluster in the k8gb network.
+The `ZoneDelegation` resource should be deployed together with the application to each cluster that participates in serving
+that application's `loadBalancedZone`.
+
+If a cluster does not have a `ZoneDelegation` for a `loadBalancedZone`, k8gb does not configure CoreDNS to serve that zone
+from the cluster. The cluster is therefore excluded from that GSLB zone instead of returning inconsistent DNS responses for
+an application it does not host.
+
+When different applications are deployed to different cluster subsets, give each application or team its own delegated
+sub-zone. For example, deploy `ZoneDelegation` for `app1.gslb.example.com` only in the clusters that host `app1`, and
+deploy `ZoneDelegation` for `app2.gslb.example.com` only in the clusters that host `app2`.
+
 ## Example
 
 ```yaml

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -27,6 +27,7 @@ This section provides comprehensive tutorials for deploying and configuring K8GB
 * [Resource References](resource_ref.md)
 * [Address Discovery](address_discovery.md)
 * [Dynamic Geotags](dynamic_geotags.md)
+* [Dynamic Zones](dynamic_zones.md)
 * [Multi-zone Setup](multizone.md)
 * [Exposing DNS](exposing_dns.md)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Address Discovery: address_discovery.md
       - Exposed Hostnames: exposed-hostnames.md
       - Dynamic Geotags: dynamic_geotags.md
+      - Dynamic Zones: dynamic_zones.md
       - Multi-zone Setup: multizone.md
       - Exposing DNS: exposing_dns.md
     - Development & Testing:


### PR DESCRIPTION
## Summary

- document how Dynamic Zones behave when a load-balanced application is deployed only to a subset of clusters
- clarify that clusters without a matching `ZoneDelegation` are excluded from serving that `loadBalancedZone`
- add the Dynamic Zones page to the MkDocs navigation and configuration tutorial index

Closes #1348.

## Checks

- `git diff --check`
- `mkdocs build --strict` with the docs workflow packages in a temporary venv; this reached the docs build but failed on existing unrelated strict warnings for `ai-inference-demo.md`, `examples/crossplane/globalapp/README.md`, and `examples/gcp/README.md` not being included in nav
