### PR TITLE
fix: Skip GSLB reconciliation when ZoneDelegation is removed

### DIFF
--- a/controllers/gslb_controller_reconciliation.go
+++ b/controllers/gslb_controller_reconciliation.go
@@ -148,10 +148,16 @@ func (r *GslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		m.IncrementError(gslb)
 		return result.RequeueError(fmt.Errorf("getting delegation zones (%s)", err))
 	}
-	filteredServers := filterServersByZoneDelegations(r.Logger, servers, list)
+	filteredServers := filterServersByZoneDelegations(servers, list)
 
 	if len(filteredServers) == 0 {
-		return result.RequeueError(fmt.Errorf("no hosts match delegated zones %v", list.ListZones()))
+		r.Logger.
+			Info().
+			Str("gslb", gslb.Name).
+			Str("namespace", gslb.Namespace).
+			Strs("server hosts", listHosts(servers)).
+			Msgf("Skipping delegation DNS endpoint update: ZoneDelegation is not present")
+		return result.Requeue()
 	}
 
 	gslb.Status.Servers = filteredServers
@@ -246,19 +252,21 @@ func splitIPsByVersion(logger *zerolog.Logger, ips []string) ([]string, []string
 
 // filterServersByZoneDelegations filters servers to only include those with hosts that match the delegation zones
 func filterServersByZoneDelegations(
-	logger *zerolog.Logger,
 	servers []*k8gbv1beta1io.Server,
 	zoneDelegations *k8gbv1beta1io.ZoneDelegationList) []*k8gbv1beta1io.Server {
 	var filtered []*k8gbv1beta1io.Server
 	for _, server := range servers {
 		if zoneDelegations.ContainsZone(server.Host) {
 			filtered = append(filtered, server)
-		} else {
-			logger.Debug().
-				Str("host", server.Host).
-				Strs("zoneDelegations", zoneDelegations.ListZones()).
-				Msg("Skipping host - does not match any delegated zone")
 		}
 	}
 	return filtered
+}
+
+func listHosts(servers []*k8gbv1beta1io.Server) []string {
+	hosts := []string{}
+	for _, server := range servers {
+		hosts = append(hosts, server.Host)
+	}
+	return hosts
 }

--- a/controllers/gslb_controller_reconciliation_test.go
+++ b/controllers/gslb_controller_reconciliation_test.go
@@ -203,7 +203,6 @@ func TestSplitIPsByVersion(t *testing.T) {
 }
 
 func TestFilterServersByDelegationZones(t *testing.T) {
-	log := logging.Logger()
 	tests := []struct {
 		name              string
 		servers           []*v1beta1io.Server
@@ -272,7 +271,7 @@ func TestFilterServersByDelegationZones(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			zoneDelegations := createTestZonesDelegations(test.delegationZones)
 
-			filtered := filterServersByZoneDelegations(log, test.servers, zoneDelegations)
+			filtered := filterServersByZoneDelegations(test.servers, zoneDelegations)
 
 			assert.Equal(t, test.expectedHostCount, len(filtered))
 			if test.expectedHostCount > 0 {

--- a/controllers/gslb_legacy_controller.go
+++ b/controllers/gslb_legacy_controller.go
@@ -119,9 +119,15 @@ func (r *LegacyGslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		m.IncrementError(gslb)
 		return result.RequeueError(fmt.Errorf("getting delegation zones (%s)", err))
 	}
-	filteredServers := filterServersByZoneDelegations(r.Logger, servers, list)
+	filteredServers := filterServersByZoneDelegations(servers, list)
 	if len(filteredServers) == 0 {
-		return result.RequeueError(fmt.Errorf("no hosts match delegated zones %v", list.ListZones()))
+		r.Logger.
+			Info().
+			Str("gslb", gslb.Name).
+			Str("namespace", gslb.Namespace).
+			Strs("server hosts", listHosts(servers)).
+			Msgf("Skipping delegation DNS endpoint update: ZoneDelegation is not present")
+		return result.Requeue()
 	}
 	gslb.Status.Servers = filteredServers
 


### PR DESCRIPTION
Skip GSLB reconciliation when ZoneDelegation is removed instead of requeing error. 
