### PR TITLE
fix: make legacy migration cleanup reliable

### DIFF
--- a/.github/workflows/chainsaw.yaml
+++ b/.github/workflows/chainsaw.yaml
@@ -21,6 +21,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: chainsaw-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
+
 env:
   K3D_VERSION: v5.8.3
 
@@ -45,7 +49,7 @@ jobs:
   chainsaw:
     runs-on: ubuntu-24.04
     needs: skip-check
-    if: ${{ needs.skip-check.outputs.should_skip != 'true' }} && !contains( github.event.pull_request.labels.*.name, 'renovate')
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' && !contains(github.event.pull_request.labels.*.name, 'renovate') && !startsWith(github.event.pull_request.head.ref || github.ref_name, 'renovate/') }}
     strategy:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}

--- a/chainsaw/tests/legacy-migration-requested-pauses-runtime/chainsaw-test.yaml
+++ b/chainsaw/tests/legacy-migration-requested-pauses-runtime/chainsaw-test.yaml
@@ -115,10 +115,14 @@ spec:
           value: legacy-requested-pause
         content: |
           if ! kubectl delete gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" --wait=true --timeout=60s; then
-            echo "Legacy Gslb deletion timed out"
-            kubectl get gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" -o yaml || true
-            kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp || true
-            exit 1
+            REMAINING=$(kubectl get gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" --ignore-not-found -o name) || exit 1
+            if [ -n "$REMAINING" ]; then
+              echo "Legacy Gslb deletion timed out"
+              kubectl get gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" -o yaml
+              kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp
+              exit 1
+            fi
+            echo "Legacy Gslb was deleted at the timeout boundary"
           fi
           kubectl get gslb.k8gb.io "$NAME" -n "$NAMESPACE"
           kubectl get dnsendpoint "$NAME" -n "$NAMESPACE"

--- a/chainsaw/tests/legacy-migration-requested-pauses-runtime/chainsaw-test.yaml
+++ b/chainsaw/tests/legacy-migration-requested-pauses-runtime/chainsaw-test.yaml
@@ -71,8 +71,8 @@ spec:
           echo "DNSEndpoint ownership is not canonical-only"
           kubectl get dnsendpoint "$NAME" -n "$NAMESPACE" -o yaml
           exit 1
-  - name: retrigger reconcile remains canonical-owned
-    description: repeated reconcile with both labels should not reintroduce legacy ownership
+  - name: repeat migration remains canonical-owned
+    description: repeating migration should not reintroduce legacy ownership
     cluster: eu
     try:
     - script:
@@ -82,11 +82,12 @@ spec:
           value: legacy-requested-pause
         content: |
           LEGACY_UID=$(kubectl get gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" -o jsonpath='{.metadata.uid}')
-          kubectl annotate gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" migration-recheck-ts="$(date +%s)" --overwrite
+          kubectl label gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" k8gb.io/migrated-to-k8gb-io=false --overwrite
           TMP_JSON=$(mktemp)
           trap 'rm -f "$TMP_JSON"' EXIT
           for i in $(seq 1 30); do
-            if kubectl get dnsendpoint "$NAME" -n "$NAMESPACE" -o json >"$TMP_JSON" 2>/dev/null; then
+            if [ "$(kubectl get gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" -o jsonpath='{.metadata.labels.k8gb\.io/migrated-to-k8gb-io}' 2>/dev/null)" = "true" ] && \
+              kubectl get dnsendpoint "$NAME" -n "$NAMESPACE" -o json >"$TMP_JSON" 2>/dev/null; then
               if jq -e --arg name "$NAME" --arg legacy_uid "$LEGACY_UID" '
                 (.metadata.ownerReferences | length) == 1 and
                 .metadata.ownerReferences[0].apiVersion == "k8gb.io/v1beta1" and
@@ -100,7 +101,8 @@ spec:
             fi
             sleep 2
           done
-          echo "DNSEndpoint ownership changed after retrigger"
+          echo "Repeated migration did not restore canonical-only DNSEndpoint ownership"
+          kubectl get gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" -o yaml
           kubectl get dnsendpoint "$NAME" -n "$NAMESPACE" -o yaml
           exit 1
   - name: delete legacy object keeps canonical resources
@@ -112,6 +114,11 @@ spec:
         - name: NAME
           value: legacy-requested-pause
         content: |
-          kubectl delete gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" --wait=true --timeout=90s
+          if ! kubectl delete gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" --wait=true --timeout=60s; then
+            echo "Legacy Gslb deletion timed out"
+            kubectl get gslb.k8gb.absa.oss "$NAME" -n "$NAMESPACE" -o yaml || true
+            kubectl get events -n "$NAMESPACE" --sort-by=.lastTimestamp || true
+            exit 1
+          fi
           kubectl get gslb.k8gb.io "$NAME" -n "$NAMESPACE"
           kubectl get dnsendpoint "$NAME" -n "$NAMESPACE"

--- a/controllers/gslb_migration_controller.go
+++ b/controllers/gslb_migration_controller.go
@@ -183,9 +183,8 @@ func shouldReconcileLegacyMigrationUpdate(e event.TypedUpdateEvent[client.Object
 		return false
 	}
 
-	oldDeleting := e.ObjectOld.GetDeletionTimestamp() != nil
 	newDeleting := e.ObjectNew.GetDeletionTimestamp() != nil
-	if oldDeleting != newDeleting {
+	if newDeleting {
 		return true
 	}
 	if e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration() {

--- a/controllers/gslb_migration_controller_test.go
+++ b/controllers/gslb_migration_controller_test.go
@@ -371,6 +371,18 @@ func TestShouldReconcileLegacyMigrationUpdate(t *testing.T) {
 			ObjectNew: newObj,
 		}))
 	})
+
+	t.Run("reconciles updates while deletion is in progress", func(t *testing.T) {
+		oldObj := base()
+		now := metav1.Now()
+		oldObj.DeletionTimestamp = &now
+		newObj := oldObj.DeepCopy()
+		newObj.Status.GeoTag = "us"
+		require.True(t, shouldReconcileLegacyMigrationUpdate(event.TypedUpdateEvent[client.Object]{
+			ObjectOld: oldObj,
+			ObjectNew: newObj,
+		}))
+	})
 }
 
 func newLegacyMigrationReconciler(t *testing.T, objs ...client.Object) (*LegacyGslbMigrationReconciler, client.Client, *record.FakeRecorder) {


### PR DESCRIPTION
Legacy Gslb deletion could stall when the migration controller only observed an update after deletion had already started. The update predicate accepted only the transition into deletion, so subsequent updates to a terminating object were filtered and the migration protection finalizer could remain indefinitely.

Reconcile every update for a terminating legacy Gslb and cover that behavior with a regression test. Make the Chainsaw retry change a watched migration label, report useful state before its outer timeout, and serialize workflow runs per source branch. Also repair the Renovate guard so duplicate workflows no longer amplify the flake.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
