### PR TITLE
ci: run Chainsaw for Renovate PRs

### DIFF
--- a/.github/workflows/chainsaw.yaml
+++ b/.github/workflows/chainsaw.yaml
@@ -49,7 +49,7 @@ jobs:
   chainsaw:
     runs-on: ubuntu-24.04
     needs: skip-check
-    if: ${{ needs.skip-check.outputs.should_skip != 'true' && !contains(github.event.pull_request.labels.*.name, 'renovate') && !startsWith(github.event.pull_request.head.ref || github.ref_name, 'renovate/') }}
+    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     strategy:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}


### PR DESCRIPTION
Remove the Renovate job exclusion so branch concurrency leaves one runnable Chainsaw job instead of cancelling the push run and skipping the pull request run.

example of current problematic skipped run: https://github.com/k8gb-io/k8gb/pull/2410

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
