### PR TITLE
ci: avoid cancelled Chainsaw checks

### DIFF
--- a/.github/workflows/chainsaw.yaml
+++ b/.github/workflows/chainsaw.yaml
@@ -2,6 +2,10 @@ name: Chainsaw
 
 on:
   push:
+    branches:
+      - master
+    tags:
+      - '**'
     paths-ignore:
       - '**.md'
       - '**.svg'
@@ -29,31 +33,17 @@ env:
   K3D_VERSION: v5.8.3
 
 jobs:
-  skip-check:
-    runs-on: ubuntu-latest
-    name: Skip the job?
-    outputs:
-          should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-      with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-    - id: skip_check
-      uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf # v5.3.1
-      with:
-        skip_after_successful_duplicate: 'true'
-        do_not_skip: '["workflow_dispatch", "schedule"]'
-
   chainsaw:
     runs-on: ubuntu-24.04
-    needs: skip-check
-    if: ${{ needs.skip-check.outputs.should_skip != 'true' }}
     strategy:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
## Summary

- run Chainsaw push validation only for master and tags
- remove the duplicate-skip pre-job
- harden the actual Chainsaw job before checkout and execution

## Context

<img width="1081" height="263" alt="image" src="https://github.com/user-attachments/assets/d50633f9-0bd7-40f6-89dd-c1c58850c1cd" />


Same-repository pull requests trigger both push and pull_request. They previously shared the same concurrency group, so the pull request run cancelled the push run and left cancelled checks on the head commit even when Chainsaw passed.

Scoping branch pushes to master keeps pull request validation in pull_request context, including heavy-tests labels, without the false red status. Direct pushes to other branches now rely on pull request validation; tag coverage is preserved.

## Validation

- actionlint passed with the installed versions stale ubuntu-24.04 label diagnostic ignored
- workflow trigger and job structure verified with yq
- git diff --check