### PR TITLE
docs: update CNCF maturity to Incubating

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 
 <p align="center">
-  <a href="https://landscape.cncf.io/?item=orchestration-management--coordination-service-discovery--k8gb">CNCF Sandbox Project</a> | 
+  <a href="https://landscape.cncf.io/?item=orchestration-management--coordination-service-discovery--k8gb">CNCF Incubating Project</a> |
   <a href="https://github.com/orgs/k8gb-io/projects/2/views/2">Roadmap</a> | 
   <a href="https://cloud-native.slack.com/archives/C021P656HGB">Join #k8gb on CNCF Slack</a> |  
   <a href="#community-meetings">Join our Community Meetings</a> 

--- a/self-assessment.md
+++ b/self-assessment.md
@@ -55,7 +55,7 @@ k8gb is implemented using the Kubernetes operator pattern with a single CRD (Cus
 
 Global enterprises moving to the cloud need a global load balancer to make intelligent routing decisions based on the health and availability of Kubernetes services across multiple clusters and geographic regions. Traditional proprietary software and vendor solutions exist, but these are often expensive, complex, and not cloud native. Many require dedicated hardware appliances and operate outside the Kubernetes ecosystem, creating operational overhead and vendor lock-in.
 
-k8gb addresses these challenges as a vendor-neutral, CNCF (Cloud Native Computing Foundation) Sandbox project. It is designed as a cloud-native Kubernetes Global Load Balancer that operates entirely within the Kubernetes ecosystem. Unlike traditional solutions, k8gb does not require any special software, dedicated hardware, or external management systems - it relies exclusively on open source software (OSS) and CNCF projects, integrating seamlessly with existing Kubernetes workflows such as GitOps, Kustomize, and Helm package management.
+k8gb addresses these challenges as a vendor-neutral, CNCF (Cloud Native Computing Foundation) Incubating project. It is designed as a cloud-native Kubernetes Global Load Balancer that operates entirely within the Kubernetes ecosystem. Unlike traditional solutions, k8gb does not require any special software, dedicated hardware, or external management systems - it relies exclusively on open source software (OSS) and CNCF projects, integrating seamlessly with existing Kubernetes workflows such as GitOps, Kustomize, and Helm package management.
 
 ### Actors
 


### PR DESCRIPTION
## Summary

- update the README to identify k8gb as a CNCF Incubating project
- update the security self-assessment with the new maturity level
- preserve historical Sandbox references in project meeting notes

## Verification

- `git diff --check`

CNCF TOC confirmation: https://github.com/cncf/toc/issues/1472#issuecomment-5012745158