### PR TITLE
docs: update v0.20.0 maturity to Incubating

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -92,6 +92,10 @@ jobs:
         if: github.ref == 'refs/heads/master'
         run: make docs-sync-blog
 
+      - name: Update v0.20.0 documentation from Sandbox to Incubating
+        if: github.ref == 'refs/heads/master'
+        run: sed -i 's/CNCF Sandbox Project/CNCF Incubating Project/g' "${GHPAGES_DIR}/v0.20.0/index.html"
+
       - name: Commit and push
         run: |
           # Commit and push if there are changes


### PR DESCRIPTION
## Summary

- update the generated v0.20.0 documentation homepage from CNCF Sandbox to Incubating
- ensure the current `latest` alias reflects the same update because it points to v0.20.0
- keep the correction in place when tagged documentation is rebuilt

## Verification

- confirmed the deployed `latest` alias points to `v0.20.0`
- validated the Sandbox-to-Incubating substitution against the current `gh-pages` content
- `actionlint`
- `git diff --check`