### PR TITLE
fix: default CoreDNS endpoint for empty ZoneDelegation

### DIFF
--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -8,6 +8,13 @@ metadata:
 {{ include "chart.labels" . | indent 4  }}
 data:
   Corefile: |-
+    . {
+      health
+      {{- if $.Values.coredns.corefile.reload.enabled }}
+      reload {{ $.Values.coredns.corefile.reload.interval }} {{ $.Values.coredns.corefile.reload.jitter }}
+      {{- end }}
+      ready
+    }
     (k8gbplugins) {
         errors
         health


### PR DESCRIPTION
Add default CoreDNS endpoint to keep CoreDNS healthy when no ZoneDelegation resources are present.

