### PR TITLE
fix: (ZoneDelegations) allow empty dnsZones

### DIFF
--- a/controllers/resolver/config_delegationZones.go
+++ b/controllers/resolver/config_delegationZones.go
@@ -90,6 +90,9 @@ func parseDelegationZones(config *Config) ([]*DelegationZoneInfo, error) {
 	}
 	var dzi []*DelegationZoneInfo
 	zones = strings.TrimSuffix(strings.TrimSuffix(zones, ";"), " ")
+	if len(zones) == 0 {
+		return []*DelegationZoneInfo{}, nil
+	}
 	di, err := getEnvAsArrayOfPairsOrFallback(zones)
 	if err != nil {
 		return dzi, err

--- a/controllers/resolver/resolver_test.go
+++ b/controllers/resolver/resolver_test.go
@@ -765,8 +765,9 @@ cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc3.eee`
 				ExtClustersGeoTagsRaw: []string{"za", "eu"},
 			},
 			expectedLen: 0,
-			assert: func(_ []*DelegationZoneInfo, err error) {
-				assert.Error(t, err)
+			assert: func(zd []*DelegationZoneInfo, err error) {
+				assert.Empty(t, zd)
+				assert.NoError(t, err)
 			},
 		},
 	}


### PR DESCRIPTION
by default we we create ZoneDelegations out of dnsZones:

```yaml
  dnsZones:
    - parentZone: "example.com" # -- parent zone which would contain gslb zone to delegate (same meaning as the old edgeDNSZone)
      loadBalancedZone: "cloud.example.com" # -- zone controlled by gslb (same meaning as the old dnsZone)
      dnsZoneNegTTL: 30  # -- Negative TTL for SOA record# -- host/ip[:port] format is supported here where port defaults to 53
      extraPlugins: [] # -- Extra CoreDNS plugins to be enabled for this zone
      extraServerBlocks: "" # -- Extra CoreDNS server blocks for this zone
      geoDataFilePath: "" # -- GeoData file path
      geoDataField: "" # -- GeoData field
```

while `dnsZones` is empty, `DNS_ZONES` envvar is `""` and causes error during parsing. This fix allows to empty dnsZones 