### PR TITLE
docs: document why Dynamic GeoTags cannot work with ExternalDNS (#2464)

### DIFF
--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -102,7 +102,7 @@ Note: k8gb is architected to run on top of any compliant Kubernetes cluster and 
 | k8gb.dnsZones | list | `[{"dnsZoneNegTTL":30,"extraPlugins":[],"extraServerBlocks":"","geoDataField":"","geoDataFilePath":"","loadBalancedZone":"cloud.example.com","parentZone":"example.com"}]` | array of dns zones controlled by gslb |
 | k8gb.edgeDNSServers[0] | string | `"1.1.1.1"` | use this DNS server as a main resolver to enable cross k8gb DNS based communication |
 | k8gb.exposeMetrics | bool | `false` | Exposing metrics |
-| k8gb.extGslbClustersGeoTags | string | `"eu,us"` | Comma-separated list of geotags for external K8GB clusters. These are arbitrary, user-defined identifiers (e.g., "eu,us" or "dc2,dc3") used for coordination between K8GB instances Leaving this value empty enables Dynamic Geotags, where geotags are discovered from NS records in the edge DNS. An empty value is supported only with the Infoblox provider |
+| k8gb.extGslbClustersGeoTags | string | `"eu,us"` | Comma-separated list of geotags for external K8GB clusters. These are arbitrary, user-defined identifiers (e.g., "eu,us" or "dc2,dc3") used for coordination between K8GB instances If the value remains empty with Infoblox, dynamic geotags are extracted from NS records on the edge DNS. ExternalDNS-based providers require this value to be set explicitly; see docs/dynamic_geotags.md. |
 | k8gb.imageRepo | string | `"registry.k8gb.io/k8gb-io/k8gb"` | image repository |
 | k8gb.imageTag |  string  | `nil` | image tag defaults to Chart.AppVersion, see Chart.yaml, but can be overrided with imageTag key |
 | k8gb.installLegacyCrds | bool | `true` | whether it should also deploy the legacy k8gb.absa.oss CRD |

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -48,7 +48,8 @@ k8gb:
   # -- Unique geotag for this K8GB instance. This tag identifies the cluster's location or role (e.g., "eu", "us-east", "dc1" or "primary"). This tag should be present in all clusters’ extGslbClustersGeoTags
   clusterGeoTag: "eu"
   # -- Comma-separated list of geotags for external K8GB clusters. These are arbitrary, user-defined identifiers (e.g., "eu,us" or "dc2,dc3") used for coordination between K8GB instances
-  # Leaving this value empty enables Dynamic Geotags, where geotags are discovered from NS records in the edge DNS. An empty value is supported only with the Infoblox provider
+  # If the value remains empty with Infoblox, dynamic geotags are extracted from NS records on the edge DNS.
+  # ExternalDNS-based providers (Route53, Cloudflare, etc.) require this value to be set explicitly; see docs/dynamic_geotags.md.
   extGslbClustersGeoTags: "eu,us"
   # -- Reconcile time in seconds
   reconcileRequeueSeconds: 30

--- a/controllers/geotags/types.go
+++ b/controllers/geotags/types.go
@@ -28,9 +28,20 @@ type Resolver interface {
 	Resolve(zone *v1beta1io.ZoneDelegation) (resolver.ClusterNSNames, error)
 }
 
+// Provide selects the GeoTag resolver.
+//
+// Dynamic discovery (empty extGslbClustersGeoTags) is Infoblox-only. Infoblox's
+// in-tree provider can read-modify-write zone delegation and merge NS targets
+// from every cluster. ExternalDNS cannot: each cluster uses a distinct
+// txtOwnerId, so the shared load-balanced-zone NS RRset is owned by a single
+// ExternalDNS instance. A newly joined cluster can publish its glue A record
+// but cannot append its NS target to that owned RRset, so peer discovery via
+// NS never converges. See docs/dynamic_geotags.md and
+// https://github.com/k8gb-io/k8gb/issues/2464.
 func Provide(config *resolver.Config) Resolver {
 	switch config.EdgeDNSType {
 	case resolver.DNSTypeExternal:
+		// Always static until ExternalDNS supports multi-owner NS target merge.
 		return NewStaticDNSResolver(config)
 	case resolver.DNSTypeInfoblox:
 		if config.HasExtClusterGeoTags() {

--- a/docs/dynamic_geotags.md
+++ b/docs/dynamic_geotags.md
@@ -31,21 +31,61 @@ Previously, any change in the list of external clusters (extGslbClustersGeoTags)
 
 **Dynamic GeoTags** allow k8gb to discover external GeoTags directly from DNS (from NS records on the parent zone), without the need to keep all values manually in sync.
 
-### Example (`values.yaml`):
-```yaml
-k8gb:
-  clusterGeoTag: "eu"
-  # Leaving this value empty enables Dynamic Geotags, where geotags are discovered from NS records in the edge DNS. 
-  # An empty value is supported only with the Infoblox provider
-  extGslbClustersGeoTags:
-```
-
-If the `extGslbClustersGeoTags` value is empty, k8gb will attempt to extract external GeoTags dynamically at runtime.
+If the `extGslbClustersGeoTags` value is empty, k8gb will attempt to extract external GeoTags dynamically at runtime **when the Infoblox provider is enabled**.
 
 - This reduces manual configuration and operational overhead.
 - You can add or remove clusters without having to update and restart all existing k8gb instances.
 - It’s especially useful for dynamic, cloud-native, or large-scale multi-cluster environments.
 
+### Example (`values.yaml`):
+```yaml
+k8gb:
+  clusterGeoTag: "eu"
+  extGslbClustersGeoTags: ""  # leave empty to enable dynamic discovery (Infoblox only)
+```
+
+## Why ExternalDNS providers cannot use Dynamic GeoTags yet
+
+Investigation tracked in [#2464](https://github.com/k8gb-io/k8gb/issues/2464). Summary:
+
+### How static GeoTags work with ExternalDNS today
+
+Each cluster embeds ExternalDNS with a unique `txtOwnerId` (for example `k8gb-eu`, `k8gb-us`). Zone delegation is published as a `DNSEndpoint` that contains:
+
+1. One shared NS RRset for the load-balanced zone (for example `cloud.example.com`), listing every known `gslb-ns-<geotag>-...` target.
+2. One glue A record for *this* cluster’s NS name only.
+
+Because every cluster is configured with the full static peer list, the cluster that first owns the shared NS RRset already publishes the complete target set. Peer clusters only need to own their own glue A records. Content converges even though ownership of the NS RRset is single-writer.
+
+### How Infoblox Dynamic GeoTags work
+
+The in-tree Infoblox provider does a WAPI read-modify-write on the delegated zone: it keeps remote NS targets, replaces its own glue, and writes the union back. There is no per-cluster TXT ownership model, so every cluster can safely extend the NS set. Dynamic discovery then reads that merged NS set from DNS.
+
+### Why enabling Dynamic GeoTags for ExternalDNS deadlocks
+
+If `extGslbClustersGeoTags` is empty:
+
+1. Cluster `eu` starts alone and publishes NS targets `[gslb-ns-eu-...]`. Its ExternalDNS instance owns that NS RRset.
+2. Cluster `us` joins and can publish its glue A (`gslb-ns-us-...`) under its own owner id.
+3. Cluster `us` cannot append `gslb-ns-us-...` to the shared NS RRset owned by `k8gb-eu`.
+4. Cluster `eu`’s next dynamic dig still only sees `[eu]`, so it never learns about `us`.
+
+Result: peer discovery never converges. This is an ExternalDNS multi-owner limitation, not a missing dig in k8gb.
+
+Related upstream attempt: [kubernetes-sigs/external-dns#5619](https://github.com/kubernetes-sigs/external-dns/pull/5619) (`merge-strategy: merge-targets`) — closed without merge (design hold on deletes/updates / multi-ownership). Also noted in [#1967](https://github.com/k8gb-io/k8gb/issues/1967).
+
+### What would unblock ExternalDNS support
+
+Dynamic GeoTags for ExternalDNS-backed providers become feasible only when ExternalDNS (or an equivalent coordination layer) can merge NS targets across distinct `txtOwnerId` values, including correct delete semantics when the last owner removes its target. Until then:
+
+- Use Infoblox for Dynamic GeoTags, or
+- Keep `extGslbClustersGeoTags` explicitly set for Route53, Cloudflare, Azure DNS, GCP Cloud DNS, RFC2136, and other ExternalDNS providers.
+
+Secondary readiness items once multi-owner merge exists:
+
+- Each cluster should publish only its own NS target (plus local glue A) and rely on ExternalDNS merge for the union.
+- NS discovery must accept records from both ANSWER and AUTHORITY sections (referral responses from cloud DNS parents).
+- k8gb should refresh local `DNSEndpoint` objects when parent DNS changes (reverse sync).
 
 ## Important considerations
 Dynamic GeoTags provide convenience and flexibility, but it’s important to understand their impact on your DNS infrastructure:
@@ -70,3 +110,4 @@ If dynamic GeoTags are not suitable for your environment, you can switch back to
  - Dynamic GeoTags simplify configuration but come with extra DNS queries per GSLB. 
  - For most environments, this is not an issue. 
  - For very large-scale or highly sensitive environments, use the mitigations above to prevent DNS overload.
+ - For ExternalDNS-based edge DNS, Dynamic GeoTags are not supported; set `extGslbClustersGeoTags` explicitly.

--- a/docs/splitbrain.md
+++ b/docs/splitbrain.md
@@ -121,7 +121,7 @@ Lower TTLs mean clients and recursive resolvers stop serving stale answers soone
 
 ### 3. Use static geotags in production
 
-Dynamic geotag discovery (the default when `extGslbClustersGeoTags` is empty) queries the edge DNS for NS records on **every reconciliation**. Under network pressure, this can amplify the problem. In production, explicitly set `extGslbClustersGeoTags` to avoid this extra DNS dependency.
+Dynamic geotag discovery (Infoblox only, when `extGslbClustersGeoTags` is empty) queries the edge DNS for NS records on **every reconciliation**. Under network pressure, this can amplify the problem. In production, explicitly set `extGslbClustersGeoTags` to avoid this extra DNS dependency. ExternalDNS-based providers require static geotags; see [Dynamic GeoTags](dynamic_geotags.md).
 
 ### 4. Redundant edge DNS
 


### PR DESCRIPTION
ExternalDNS per-cluster txtOwnerId ownership prevents merging NS targets across clusters, so dynamic geotag discovery deadlocks for non-Infoblox providers. Document the investigation, clarify Helm/docs, and parse NS records from both Answer and Authority sections for referral responses.

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>