### PR TITLE
Fix dynmaic tags discovery for new zones

### DIFF
--- a/controllers/ipresolver/discovery.go
+++ b/controllers/ipresolver/discovery.go
@@ -70,6 +70,11 @@ func DiscoverNameServers(edge *utils.DNSServer, zone *v1beta1io.ZoneDelegation, 
 		return tags, fmt.Errorf("empty DNS response for %s via %s", zone.Spec.LoadBalancedZone, edge.String())
 	}
 
+	// NXDOMAIN is valid case when zone doesn't exist yet.
+	if r.Rcode == dns.RcodeNameError {
+		return tags, nil
+	}
+
 	if r.Rcode != dns.RcodeSuccess {
 		return tags, fmt.Errorf("NS query for %s via %s failed with rcode %s", zone.Spec.LoadBalancedZone, edge.String(), dns.RcodeToString[r.Rcode])
 	}


### PR DESCRIPTION
When we bootstrap cluster zone doesn't exist yet (to be created by k8gb). NXDOMAIN is a valid response in this case.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
