### PR TITLE
docs: align documented K8s, Go and Liqo versions with CI and go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ k8gb is tested with the following environment options and integration scenarios.
 
 | Type                             | Implementation                                                               |
 |----------------------------------|------------------------------------------------------------------------------|
-| Kubernetes Version               | >= `1.21`                                                                    |
+| Kubernetes Version               | >= `1.32`                                                                    |
 | Environment                      | Any conformant Kubernetes cluster on-prem or in cloud                        |
 | Ingress Controller               | NGINX, Istio, AWS Load Balancer Controller [*](#clarify)                     |
 | EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS, GCP Cloud DNS                  |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ k8gb is tested with the following environment options and integration scenarios.
 
 | Type                             | Implementation                                                               |
 |----------------------------------|------------------------------------------------------------------------------|
-| Kubernetes Version               | >= `1.21`                                                                    |
+| Kubernetes Version               | >= `1.32`                                                                    |
 | Environment                      | Any conformant Kubernetes cluster on-prem or in cloud                        |
 | Ingress Controller               | NGINX, Istio, AWS Load Balancer Controller [*](#clarify)                     |
 | EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS, GCP Cloud DNS                  |

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://www.k8gb.io/images/k8gb-icon-color.svg
 type: application
 version: v0.21.0-rc2
 appVersion: v0.21.0-rc2
-kubeVersion: ">= 1.21.0-0"
+kubeVersion: ">= 1.32.0-0"
 
 dependencies:
   - name: coredns

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://www.k8gb.io/images/k8gb-icon-color.svg
 type: application
 version: v1.0.0
 appVersion: v1.0.0
-kubeVersion: ">= 1.21.0-0"
+kubeVersion: ">= 1.32.0-0"
 
 dependencies:
   - name: coredns

--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -32,18 +32,18 @@ A Helm chart for Kubernetes Global Balancer
 
 ## Requirements
 
-Kubernetes: `>= 1.21.0-0`
+Kubernetes: `>= 1.32.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://coredns.github.io/helm | coredns | 1.46.1 |
+| https://coredns.github.io/helm | coredns | 1.47.0 |
 | https://kubernetes-sigs.github.io/external-dns | extdns(external-dns) | 1.21.1 |
 
 #### Tested Environment Configurations:
 
 | Type                             | Implementation                                                |
 |----------------------------------|---------------------------------------------------------------|
-| Kubernetes Version               | >= 1.21                                                       |
+| Kubernetes Version               | `>= 1.32.0-0`                                          |
 | Environment                      | Any conformant Kubernetes cluster on-prem or in cloud         |
 | Ingress Controller               | NGINX, Istio, AWS Load Balancer Controller                    |
 | EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS, GCP Cloud DNS   |

--- a/chart/k8gb/_helm-docs-template.gotmpl
+++ b/chart/k8gb/_helm-docs-template.gotmpl
@@ -27,7 +27,7 @@
 
 | Type                             | Implementation                                                |
 |----------------------------------|---------------------------------------------------------------|
-| Kubernetes Version               | >= 1.21                                                       |
+| Kubernetes Version               | `{{ .KubeVersion }}`                                          |
 | Environment                      | Any conformant Kubernetes cluster on-prem or in cloud         |
 | Ingress Controller               | NGINX, Istio, AWS Load Balancer Controller                    |
 | EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS, GCP Cloud DNS   |

--- a/docs/liqo.md
+++ b/docs/liqo.md
@@ -13,22 +13,18 @@ The figure below outlines the high-level scenario, with a client consuming an ap
 
 ## Setup Environment
 
-Checkout the [liqo docs](https://docs.liqo.io/en/v0.5.4/examples/global-ingress.html) to get the environment setup script and to get more details.
+Checkout the [liqo docs](https://docs.liqo.io/en/stable/usage/peer.html) to get the environment setup script and to get more details.
 It creates the k3d clusters required for the K8GB playground as described in [Local playground for testing and development](local.md) and installs Liqo over them.
 
 ## Peer the clusters
 
-To proceed, first generate a new *peer command* from the *gslb-us* cluster:
+To proceed, establish a peering from the *gslb-eu* cluster (consumer) to the *gslb-us* cluster (provider) with `liqoctl peer`:
 
 ```bash
-PEER_US=$(liqoctl generate peer-command --only-command --kubeconfig $KUBECONFIG_US)
+liqoctl peer --kubeconfig "$KUBECONFIG_EU" --remote-kubeconfig "$KUBECONFIG_US"
 ```
 
-And then, run the generated command from the *gslb-eu* cluster:
-
-```bash
-echo "$PEER_US" | bash
-```
+`liqoctl` needs the kubeconfigs of both clusters: it applies resources on both sides and connects them. See the [Liqo peering docs](https://docs.liqo.io/en/stable/usage/peer.html) for details.
 
 ## Deploy an application
 
@@ -78,7 +74,7 @@ To this end, create a pod in one of the clusters (it does not matter which one) 
 HOSTNAME="liqo.cloud.example.com"
 K8GB_COREDNS_IP=$(kubectl get svc k8gb-coredns -n k8gb -o custom-columns='IP:spec.clusterIP' --no-headers)
 
-kubectl run -it --rm curl --restart=Never --image=curlimages/curl:7.82.0 --command \
+kubectl run -it --rm curl --restart=Never --image=curlimages/curl:8.21.0 --command \
     --overrides "{\"spec\":{\"dnsConfig\":{\"nameservers\":[\"${K8GB_COREDNS_IP}\"]},\"dnsPolicy\":\"None\"}}" \
     -- curl $HOSTNAME -v
 ```

--- a/docs/liqo.md
+++ b/docs/liqo.md
@@ -13,15 +13,16 @@ The figure below outlines the high-level scenario, with a client consuming an ap
 
 ## Setup Environment
 
-Checkout the [liqo docs](https://docs.liqo.io/en/stable/usage/peer.html) to get the environment setup script and to get more details.
-It creates the k3d clusters required for the K8GB playground as described in [Local playground for testing and development](local.md) and installs Liqo over them.
+The commands below assume k8gb and Liqo 1.x are installed in both clusters. See [Local playground for testing and development](local.md) for k8gb setup and the [Liqo installation guide](https://docs.liqo.io/en/stable/installation/install.html) for Liqo. Use a `liqoctl` version that matches the installed Liqo version.
+
+Export `KUBECONFIG` with the path of the *gslb-eu* cluster's kubeconfig and `KUBECONFIG_US` with the path of the *gslb-us* cluster's kubeconfig. This also selects *gslb-eu* for the subsequent `kubectl` and Helm commands.
 
 ## Peer the clusters
 
 To proceed, establish a peering from the *gslb-eu* cluster (consumer) to the *gslb-us* cluster (provider) with `liqoctl peer`:
 
 ```bash
-liqoctl peer --kubeconfig "$KUBECONFIG_EU" --remote-kubeconfig "$KUBECONFIG_US"
+liqoctl peer --kubeconfig "$KUBECONFIG" --remote-kubeconfig "$KUBECONFIG_US"
 ```
 
 `liqoctl` needs the kubeconfigs of both clusters: it applies resources on both sides and connects them. See the [Liqo peering docs](https://docs.liqo.io/en/stable/usage/peer.html) for details.

--- a/docs/local.md
+++ b/docs/local.md
@@ -24,7 +24,7 @@ For more user-centric targets in that makefile consult `make help`.
 
 ## Environment prerequisites
 
-- [Install **Go 1.22.3**](https://golang.org/dl/)
+- [Install **Go**](https://golang.org/dl/) — use the version pinned in the repository's `go.mod` (currently `1.26.5`)
 
 - [Install **Git**](https://git-scm.com/downloads)
 


### PR DESCRIPTION
Closes #2454

## What changed
- README.md and chart/k8gb/Chart.yaml: raise the Kubernetes floor from >= 1.21 to >= 1.32 (the oldest version CI covers; heavy-tests run v1.32/v1.33/v1.34)
- docs/local.md: point Go installation at the version pinned in go.mod (currently 1.26.5) instead of the stale 1.22.3
- docs/liqo.md: update the Liqo tutorial from v0.5.x to Liqo 1.x — `liqoctl generate peer-command` is replaced by `liqoctl peer --kubeconfig ... --remote-kubeconfig ...`, the docs link points to the stable peering guide, and the pinned curl image is bumped from 7.82.0 to 8.21.0

## Checklist
- [x] README + Chart.yaml floor raised to oldest version CI covers
- [x] local.md Go install points at go.mod
- [x] liqo.md rewritten for Liqo 1.x (liqoctl peer)
- [x] All commits signed (DCO)