### PR TITLE
docs: fix broken Gateway API, golangci-lint, and Crossplane image links

### DIFF
--- a/docs/examples/crossplane/globalapp/README.md
+++ b/docs/examples/crossplane/globalapp/README.md
@@ -22,13 +22,13 @@ This reference architecture showcases a Crossplane-based Global Control Plane wi
 
 ### Crossplane Function Health Monitoring Flow
 
-![Crossplane Function Health Monitoring](/docs/examples/crossplane/globalapp/assets/crossplane-function-health-monitoring.png)
+![Crossplane Function Health Monitoring](assets/crossplane-function-health-monitoring.png)
 
 This diagram illustrates how the Crossplane function dynamically monitors GSLB health status and adjusts management policies. The function observes the GSLB resource status and conditionally sets management policies - when active and healthy, it enables full management (`managementPolicies: ["*"]`), otherwise it switches to observe-only mode (`managementPolicies: ["Observe"]`).
 
 ### Active/Passive Cluster Management Policies  
 
-![Active Passive Cluster Policies](/docs/examples/crossplane/globalapp/assets/active-passive-cluster-policies.png)
+![Active Passive Cluster Policies](assets/active-passive-cluster-policies.png)
 
 This diagram shows the management policy differences between Active and Passive clusters. The Active cluster (with green checkmark) has full management policies including Create, Delete, Observe, and Update capabilities. The Passive cluster (with red X) is restricted to Observe-only mode, ensuring it monitors health without making changes until it needs to become active during failover.
 

--- a/docs/local.md
+++ b/docs/local.md
@@ -44,7 +44,7 @@ For more user-centric targets in that makefile consult `make help`.
 
  - [install **k3d**](https://k3d.io/#installation) to run local [k3s](https://k3s.io/) clusters (minimum v5.3.0 version is required)
 
- - [install **golangci-lint**](https://golangci-lint.run/usage/install/#local-installation) for code quality checks
+ - [install **golangci-lint**](https://golangci-lint.run/docs/welcome/install/) for code quality checks
 
 ## Running project locally
 

--- a/docs/resource_ref.md
+++ b/docs/resource_ref.md
@@ -8,10 +8,10 @@ K8GB supports the following ingress resources:
 * [Kubernetes LoadBalancer Service](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)
 * [Istio Virtual Service](https://istio.io/latest/docs/reference/config/networking/virtual-service/)
 * Gateway API Resources(available since **v0.17.0**):
-  - [HTTPRoute](https://gateway-api.sigs.k8s.io/api-types/httproute/)
-  - [GRPCRoute](https://gateway-api.sigs.k8s.io/api-types/grpcroute/)
-  - [TCPRoute](https://gateway-api.sigs.k8s.io/guides/tcp/)
-  - [UDPRoute](https://gateway-api.sigs.k8s.io/reference/1.4/spec/?h=udproute#udproute)
+  - [HTTPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/httproute/)
+  - [GRPCRoute](https://gateway-api.sigs.k8s.io/reference/api-types/grpcroute/)
+  - [TCPRoute](https://gateway-api.sigs.k8s.io/guides/user-guides/tcp/)
+  - [UDPRoute](https://gateway-api.sigs.k8s.io/reference/api-types/udproute/)
   - [TLSRoute](https://gateway-api.sigs.k8s.io/geps/gep-2643/?h=tls#tlsroute-tls-passthrough)
 
 ## 1. Declaration by Name


### PR DESCRIPTION
Point resource_ref and local.md at current upstream URLs, and use relative asset paths so Crossplane images resolve on the mkdocs site.

Fixes #2451

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
