### PR TITLE
docs: fix metrics.md for current Service and metric names

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,78 +1,32 @@
 # Metrics
 
-K8GB generates [Prometheus][prometheus]-compatible metrics.
-Metrics endpoints are exposed via `-metrics` service in operator namespace and can be scraped by 3rd party tools:
+K8GB exposes [Prometheus][prometheus]-compatible metrics from the operator process on
+`k8gb.metricsAddress` (default `0.0.0.0:8080`, path `/metrics`).
 
-``` yaml
+When `k8gb.exposeMetrics` or `k8gb.serviceMonitor.enabled` is set, the chart creates a
+ClusterIP Service named `k8gb-metrics` with a single port `metrics` derived from
+`k8gb.metricsAddress` (port `8080` by default):
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8gb-metrics
 spec:
-...
+  type: ClusterIP
   ports:
-  - name: http-metrics
-    port: 8383
+  - name: metrics
+    port: 8080
     protocol: TCP
-    targetPort: 8383
-  - name: cr-metrics
-    port: 8686
-    protocol: TCP
-    targetPort: 8686
 ```
 
-Metrics can be also automatically discovered and monitored by [Prometheus Operator][prometheus-operator] via automatically generated [ServiceMonitor][service-monitor] CRDs , in case if [Prometheus Operator][prometheus-operator]  is deployed into the cluster.
+With `k8gb.serviceMonitor.enabled: true`, the chart also installs a
+[ServiceMonitor][service-monitor] that scrapes the `metrics` port when
+[Prometheus Operator][prometheus-operator] is present in the cluster.
 
-### General metrics
-
-[controller-runtime][controller-runtime-metrics] standard metrics, extended with K8GB operator-specific metrics listed below:
-
-#### `healthy_records`
-
-Number of healthy records observed by K8GB.
-
-Example:
-
-```yaml
-# HELP k8gb_gslb_healthy_records Number of healthy records observed by K8GB.
-# TYPE k8gb_gslb_healthy_records gauge
-k8gb_gslb_healthy_records{name="test-gslb",namespace="test-gslb"} 6
-```
-
-#### `ingress_hosts_per_status`
-
-Number of ingress hosts per status (NotFound, Healthy, Unhealthy), observed by K8GB.
-
-Example:
-
-```yaml
-# HELP k8gb_gslb_ingress_hosts_per_status Number of managed hosts observed by K8GB.
-# TYPE k8gb_gslb_ingress_hosts_per_status gauge
-k8gb_gslb_ingress_hosts_per_status{name="test-gslb",namespace="test-gslb",status="Healthy"} 1
-k8gb_gslb_ingress_hosts_per_status{name="test-gslb",namespace="test-gslb",status="NotFound"} 1
-k8gb_gslb_ingress_hosts_per_status{name="test-gslb",namespace="test-gslb",status="Unhealthy"} 2
-```
-
-Served on `0.0.0.0:8383/metrics` endpoint
-
-### Custom resource specific metrics
-
-Info metrics, automatically exposed by operator based on the number of the current instances of an operator's custom resources in the cluster.
-
-Example:
-
-```yaml
-# HELP gslb_info Information about the Gslb custom resource.
-# TYPE gslb_info gauge
-gslb_info{namespace="test-gslb",gslb="test-gslb"} 1
-```
-
-Served on `0.0.0.0:8686/metrics` endpoint
-
-[prometheus]: https://prometheus.io/
-[prometheus-operator]: https://github.com/coreos/prometheus-operator
-[service-monitor]: https://github.com/coreos/prometheus-operator#customresourcedefinitions
-[controller-runtime-metrics]: https://book.kubebuilder.io/reference/metrics.html
-
-## Metrics
-
-The k8gb exposes several metrics to help you monitor the health and behavior.
+In addition to [controller-runtime][controller-runtime-metrics] standard metrics, k8gb
+registers the following application metrics
+(`controllers/providers/metrics/prometheus.go`):
 
 | Metric | Type | Description | Labels |
 |---|:---:|---|---|
@@ -95,3 +49,8 @@ The k8gb exposes several metrics to help you monitor the health and behavior.
 ## OpenTracing
 
 Optionally k8gb operator can expose traces in OpenTelemetry format to any available OTEL compliant tracing solution. Consult the [following page](traces.md) for more details.
+
+[prometheus]: https://prometheus.io/
+[prometheus-operator]: https://github.com/prometheus-operator/prometheus-operator
+[service-monitor]: https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#servicemonitor
+[controller-runtime-metrics]: https://book.kubebuilder.io/reference/metrics.html


### PR DESCRIPTION
Replace the stale dual-port operator-sdk metrics docs with the real k8gb-metrics Service on port 8080 and the prometheus.go metric table.

Fixes #2447

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
