### PR TITLE
docs: replace removed Helm keys with current chart values

### DIFF
--- a/docs/deploy_infoblox.md
+++ b/docs/deploy_infoblox.md
@@ -15,12 +15,16 @@ cp chart/k8gb/values.yaml ~/k8gb/eu-cluster.yaml
 ```
 
 * Modify the example configuration. Important parameters described below:
-  * `dnsZone` - this zone will be delegated to the `edgeDNS` in your environment. E.g. `yourzone.edgedns.com`
-  * `edgeDNSZone` - this zone will be automatically configured by k8gb to delegate to `dnsZone` and will make k8gb controlled nodes act as authoritative server for this zone. E.g. `edgedns.com`
-  * `parentZoneDNSServers` stable DNS servers in your environment that is controlled by edgeDNS provider e.g. Infoblox so k8gb instances will be able to talk to each other through automatically created DNS names
+  * `dnsZones` — array of zones managed by this k8gb deployment (preferred since v0.15). Each entry has:
+    * `loadBalancedZone` — zone controlled by GSLB / delegated to your edge DNS. E.g. `yourzone.edgedns.com`
+    * `parentZone` — parent zone that contains the GSLB zone and where NS/glue records are created. E.g. `edgedns.com`
+  * `edgeDNSServers` — stable DNS servers in your environment controlled by the edge DNS provider (e.g. Infoblox) so k8gb instances can discover each other through automatically created DNS names
   * `clusterGeoTag` to geographically tag your cluster. We are operating `eu` cluster in this example
   * `extGslbClustersGeoTags` contains Geo tag of the cluster(s) to talk with when k8gb is deployed to multiple clusters. Imagine your second cluster is `us` so we tag it accordingly
   * `infoblox.enabled: true` to enable automated zone delegation configuration at edgeDNS provider. You don't need it for local testing and can optionally be skipped. Meanwhile, in this section we will cover a fully operational end-to-end scenario.
+
+> **Legacy note:** the old top-level `dnsZone` / `edgeDNSZone` keys still work via chart helpers (`dnsZone` ≈ `loadBalancedZone`, `edgeDNSZone` ≈ `parentZone`), but new installs should use `dnsZones`. See [Multizone Support](multizone.md).
+
 The other parameters do not need to be modified unless you want to do something special. E.g. to use images from private registry
 
   * Export Infoblox related information in the shell.

--- a/docs/deploy_route53.md
+++ b/docs/deploy_route53.md
@@ -25,7 +25,9 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/cont
 
 Example helm configuration files can be found [here](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/route53/k8gb)
 
-Modify them to reflect your `dnsZone`, `edgeDNSZone`, valid `hostedZoneID` and `irsaRole` ARN.
+Modify them to reflect your `k8gb.dnsZones` (`loadBalancedZone` / `parentZone`), valid `hostedZoneID` / IRSA role ARN under `extdns`, and related settings.
+
+> **Legacy note:** older docs used top-level `dnsZone` / `edgeDNSZone`; prefer `dnsZones` (see [Multizone Support](multizone.md)).
 
 Clone k8gb repository and use `helm` with custom values
 
@@ -75,7 +77,7 @@ kubectl -n test-gslb get gslb test-gslb-failover -o yaml
 aws route53 list-resource-record-sets --hosted-zone-id $YOUR_HOSTED_ZONE_ID
 ```
 
-You should see that `gslb-ns-$dnsZone-$geotag` NS and glue A records were created to
+You should see that `gslb-ns-$loadBalancedZone-$geotag` NS and glue A records were created to
 automatically configure DNS zone delegation.
 
 * Check test application availability.

--- a/docs/deploy_windowsdns.md
+++ b/docs/deploy_windowsdns.md
@@ -80,13 +80,10 @@ Before deploying K8GB and the demo workload, ensure required configurations on W
     * [External DNS - RFC2126](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/rfc2136.md "RFC2136 documentation")
     * A sample values.yaml for K8GB configuration can be found [here](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/windowsdns/k8gb/).
         * Ensure that the following properties are updated with your values:
-            * dnsZone
-            * edgeDNSZone
-            * parentZoneDNSServers
-            * host - always use FQDN with GSS-TSIG, not IP address
-            * kerberos-username
-            * kerberos-password
-            * kerberos-realm
+            * `k8gb.dnsZones[].loadBalancedZone` / `k8gb.dnsZones[].parentZone` (preferred; replaces legacy `dnsZone` / `edgeDNSZone`)
+            * `k8gb.edgeDNSServers`
+            * `extdns.extraArgs` host — always use FQDN with GSS-TSIG, not IP address (`rfc2136-host`)
+            * `extdns.extraArgs` kerberos-username / kerberos-password / kerberos-realm (`rfc2136-kerberos-*`)
     * At this moment ExternalDNS doesn't provide a way to use secrets as the source for the kerberos-password setting, so you must ensure this is stored in a secure way
 
 ### Install K8gb

--- a/docs/provider_rfc2136.md
+++ b/docs/provider_rfc2136.md
@@ -1,8 +1,10 @@
 # Enabling RFC2136 for ExternalDNS
 
-In order to enable the provider RFC2136 on ExternalDNS, the following `rfc2136.*` [parameters](https://github.com/k8gb-io/k8gb/blob/master/chart/k8gb/README.md#values) should be changed in the values.yaml of the K8GB helm chart:
+RFC2136 is configured through the embedded ExternalDNS subchart (`extdns`), not through top-level `rfc2136.*` chart values.
+Set `extdns.provider.name: rfc2136` and pass provider flags under `extdns.extraArgs` (and secrets via `extdns.env` when needed).
+See the chart [values reference](https://github.com/k8gb-io/k8gb/blob/master/chart/k8gb/README.md#values) for `extdns.*` and the upstream [external-dns RFC2136 tutorial](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/rfc2136.md).
 
-* One authentication method should be enabled on the values:
+* One authentication method should be enabled via `extdns.extraArgs`:
   * Insecure
     * This method doesn't use any authentication and anonymous updates to the DNS records can be executed
   * TSIG
@@ -11,12 +13,12 @@ In order to enable the provider RFC2136 on ExternalDNS, the following `rfc2136.*
     * This method uses GSS-TSIG authentication, which is a variation of the TSIG method, but uses Kerberos for the generation of tokens for authentication and authorization
     * Method used by Active Directory Windows DNS
 
-* GSS-TSIG
-  * kerberos-username
-    * this key should have the value of a Active Directory user account that has permissions for DNS updates
-  * kerberos-password
+* GSS-TSIG (`extdns.extraArgs`)
+  * `rfc2136-kerberos-username`
+    * this key should have the value of an Active Directory user account that has permissions for DNS updates
+  * `rfc2136-kerberos-password`
     * password of the user account that will be used. Be aware that this isn't encrypted and so far ExternalDNS doesn't support adding a Secret reference for this value, so it will be stored in clear text
-  * kerberos-realm
+  * `rfc2136-kerberos-realm`
     * domain that will be used for authentication of the user
 
 # Sample for GSS-TSIG authentication

--- a/docs/proxy_externaldns.md
+++ b/docs/proxy_externaldns.md
@@ -1,9 +1,10 @@
 # External DNS behind a proxy
 
-External DNS needs to communicate with a DNS server outside of the kubernetes cluster to update records. If a proxy is used for egress from the Kubernetes cluster the following should be configured:
-```
-externaldns:
-  extraEnv:
+External DNS needs to communicate with a DNS server outside of the Kubernetes cluster to update records. If a proxy is used for egress from the Kubernetes cluster, configure the embedded ExternalDNS subchart under the `extdns` key (the chart alias for `external-dns`):
+
+```yaml
+extdns:
+  env:
   - name: HTTPS_PROXY
     value: http://proxy.example.com:8080
   extraVolumes:
@@ -18,3 +19,5 @@ externaldns:
 
 The `HTTPS_PROXY` environment variable should contain the address of the proxy.
 The volume mount should contain the proxy CA certificate so that the container can trust the proxy.
+
+> Use `extdns.env` (not `extraEnv`) — that matches the upstream [external-dns Helm chart](https://github.com/kubernetes-sigs/external-dns/tree/master/charts/external-dns) values.

--- a/docs/rancher.md
+++ b/docs/rancher.md
@@ -1,11 +1,21 @@
 # Integration with Rancher Fleet
 
-The K8gb has been modified to be easily deployed using [Rancher Fleet](https://fleet.rancher.io/). All you need to supply is a 
-[fleet.yaml](https://fleet.rancher.io/ref-fleet-yaml) file  and possibly expose the labels on your cluster.
+The K8gb has been modified to be easily deployed using [Rancher Fleet](https://fleet.rancher.io/). All you need to supply is a
+[fleet.yaml](https://fleet.rancher.io/ref-fleet-yaml) file and possibly expose the labels on your cluster.
 
 ## Deploy k8gb to Target clusters
-The following shows the rancher application that will be installed on the target cluster.  The values `k8gb-dnsZone`, 
-`k8gb-clusterGeoTag`, `k8gb-extGslbClustersGeoTags` will be taken from the labels that are set on the cluster.
+
+The following shows the Rancher/Fleet application that will be installed on the target cluster. Cluster-specific values are
+taken from labels set on each Fleet cluster:
+
+| Cluster label | Helm value | Meaning |
+| --- | --- | --- |
+| `k8gb-dnsZone` | `k8gb.dnsZones[].loadBalancedZone` | GSLB / load-balanced zone for that cluster |
+| `k8gb-clusterGeoTag` | `k8gb.clusterGeoTag` | Geo tag of this cluster |
+| `k8gb-extGslbClustersGeoTags` | `k8gb.extGslbClustersGeoTags` | Comma-separated geo tags of peer clusters |
+
+`parentZone` is usually shared across clusters (hardcoded below). Use `edgeDNSServers` for resolvers that can answer
+the parent zone — that is the only supported chart key for this purpose.
 
 ```yaml
 # fleet.yaml
@@ -17,14 +27,14 @@ labels:
 helm:
   repo: https://www.k8gb.io
   chart: k8gb
-  version: v0.11.4
+  version: v0.20.0
   releaseName: k8gb
   values:
     k8gb:
       dnsZones:
-        - parentZone: cloud.example.com
+        - parentZone: example.com
           loadBalancedZone: global.fleet.clusterLabels.k8gb-dnsZone
-      parentZoneDNSServers:
+      edgeDNSServers:
         - "1.2.3.4"
         - "5.6.7.8"
       clusterGeoTag: global.fleet.clusterLabels.k8gb-clusterGeoTag


### PR DESCRIPTION
Align Infoblox, Windows DNS, Route53, Rancher, ExternalDNS proxy, and RFC2136 docs with edgeDNSServers, dnsZones, and extdns.* so Helm installs stop silently ignoring stale keys.

Fixes #2446

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
