### PR TITLE
docs: align Kubernetes, Go, and Liqo versions with CI reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ k8gb is tested with the following environment options and integration scenarios.
 
 | Type                             | Implementation                                                               |
 |----------------------------------|------------------------------------------------------------------------------|
-| Kubernetes Version               | >= `1.21`                                                                    |
+| Kubernetes Version               | >= `1.32` (CI matrix: `v1.32` / `v1.33` / `v1.34`)                            |
 | Environment                      | Any conformant Kubernetes cluster on-prem or in cloud                        |
 | Ingress Controller               | NGINX, Istio, AWS Load Balancer Controller [*](#clarify)                     |
 | EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS, GCP Cloud DNS                  |

--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://www.k8gb.io/images/k8gb-icon-color.svg
 type: application
 version: v0.21.0-rc2
 appVersion: v0.21.0-rc2
-kubeVersion: ">= 1.21.0-0"
+kubeVersion: ">= 1.32.0-0"
 
 dependencies:
   - name: coredns

--- a/docs/liqo.md
+++ b/docs/liqo.md
@@ -13,26 +13,42 @@ The figure below outlines the high-level scenario, with a client consuming an ap
 
 ## Setup Environment
 
-Checkout the [liqo docs](https://docs.liqo.io/en/v0.5.4/examples/global-ingress.html) to get the environment setup script and to get more details.
+Use Liqo **1.x** with current [liqoctl](https://docs.liqo.io/en/latest/installation/liqoctl.html).
+
+Checkout the Liqo [global-ingress example](https://github.com/liqotech/liqo/tree/master/examples/global-ingress)
+(`examples/global-ingress/setup.sh` in the Liqo repository) for the environment setup script and more details.
 It creates the k3d clusters required for the K8GB playground as described in [Local playground for testing and development](local.md) and installs Liqo over them.
+
+After the script finishes, export kubeconfigs (names match the Liqo example clusters):
+
+```bash
+export KUBECONFIG_DNS=$(k3d kubeconfig write edgedns)
+export KUBECONFIG=$(k3d kubeconfig write gslb-eu)
+export KUBECONFIG_US=$(k3d kubeconfig write gslb-us)
+```
 
 ## Peer the clusters
 
-To proceed, first generate a new *peer command* from the *gslb-us* cluster:
+Liqo 1.x peers clusters with a single `liqoctl peer` invocation (the old `liqoctl generate peer-command` flow was removed).
+See [Peer two Clusters](https://docs.liqo.io/en/latest/usage/peer.html).
+
+From the *gslb-eu* consumer cluster, peer to *gslb-us*. The example environments typically expose the Liqo gateway with a `NodePort` service:
 
 ```bash
-PEER_US=$(liqoctl generate peer-command --only-command --kubeconfig $KUBECONFIG_US)
+liqoctl peer --remote-kubeconfig "$KUBECONFIG_US" --gw-server-service-type NodePort
 ```
 
-And then, run the generated command from the *gslb-eu* cluster:
+When the command returns successfully, check the peering status:
 
 ```bash
-echo "$PEER_US" | bash
+kubectl get foreignclusters
+kubectl get node --selector=liqo.io/type=virtual-node
 ```
 
 ## Deploy an application
 
-First, create a hosting namespace in the *gslb-eu* cluster, and offload it to the remote cluster through Liqo.
+First, create a hosting namespace in the *gslb-eu* cluster, and offload it to the remote cluster through Liqo
+([namespace offloading](https://docs.liqo.io/en/latest/usage/namespace-offloading.html)):
 
 ```bash
 kubectl create namespace podinfo
@@ -78,7 +94,7 @@ To this end, create a pod in one of the clusters (it does not matter which one) 
 HOSTNAME="liqo.cloud.example.com"
 K8GB_COREDNS_IP=$(kubectl get svc k8gb-coredns -n k8gb -o custom-columns='IP:spec.clusterIP' --no-headers)
 
-kubectl run -it --rm curl --restart=Never --image=curlimages/curl:7.82.0 --command \
+kubectl run -it --rm curl --restart=Never --image=curlimages/curl:8.21.0 --command \
     --overrides "{\"spec\":{\"dnsConfig\":{\"nameservers\":[\"${K8GB_COREDNS_IP}\"]},\"dnsPolicy\":\"None\"}}" \
-    -- curl $HOSTNAME -v
+    -- curl "$HOSTNAME" -v
 ```

--- a/docs/local.md
+++ b/docs/local.md
@@ -24,7 +24,7 @@ For more user-centric targets in that makefile consult `make help`.
 
 ## Environment prerequisites
 
-- [Install **Go 1.22.3**](https://golang.org/dl/)
+- [Install **Go**](https://go.dev/dl/) at the version declared in [`go.mod`](https://github.com/k8gb-io/k8gb/blob/master/go.mod) (CI uses `go-version-file: ./go.mod`)
 
 - [Install **Git**](https://git-scm.com/downloads)
 


### PR DESCRIPTION
Raise the kubeVersion floor to 1.32, point local Go setup at go.mod, and rewrite the Liqo tutorial for liqoctl peer on Liqo 1.x.

Fixes #2454

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
