### PR TITLE
docs: polish ADOPTERS, tutorials index, typos, and registry notes

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -13,10 +13,10 @@ This list is sorted in the order that organizations were added to it.
 
 | Organization | Contact | Description of Use |
 | ------------ | ------- | ------------------ |
-  [Absa](https://www.absa.co.za/) | @kuritka | K8GB was created in Absa and had there first production use in cross-regional datacenter context
-[Millennium bcp](https://www.millenniumbcp.pt/) | @infbase | Multicloud and multi-region cloud native load balancing ([CNCF case study](https://www.cncf.io/case-studies/millennium-bcp/))
-[Eficode](https://eficode.com/) | @punasusi | As a cloud-native and devops consulting firm, we have used k8gb in customer engagements
-[Open Systems](https://www.open-systems.com/) | @abaguas | Multi-cluster load balancing in private WAN
-[PagBank](https://pagbank.com/) | @altieresfreitas | Multicloud global load balancing across multiple regions
-[Darede](https://darede.com.br/) | @diego7marques | As a cloud consulting company, we support customers using k8gb
-[envio.dev](https://envio.dev/) | @Piroddi | Provides cross region availability of Envio's high-performance blockchain data engine  
+| [Absa](https://www.absa.co.za/) | @kuritka | K8GB was created in Absa and had its first production use in cross-regional datacenter context |
+| [Millennium bcp](https://www.millenniumbcp.pt/) | @infbase | Multicloud and multi-region cloud native load balancing ([CNCF case study](https://www.cncf.io/case-studies/millennium-bcp/)) |
+| [Eficode](https://eficode.com/) | @punasusi | As a cloud-native and devops consulting firm, we have used k8gb in customer engagements |
+| [Open Systems](https://www.open-systems.com/) | @abaguas | Multi-cluster load balancing in private WAN |
+| [PagBank](https://pagbank.com/) | @altieresfreitas | Multicloud global load balancing across multiple regions |
+| [Darede](https://darede.com.br/) | @diego7marques | As a cloud consulting company, we support customers using k8gb |
+| [envio.dev](https://envio.dev/) | @Piroddi | Provides cross region availability of Envio's high-performance blockchain data engine |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,7 +310,7 @@ It will configure `podinfo` to expose geotag as part of an HTTP response.
 To test and/or demonstrate continuous query to GSLB enabled endpoint execute
 
 ```sh
-make demo DEMO_URL=https://failover.test.exampledns.tk
+make demo DEMO_URL=https://failover.cloud.example.com
 ```
 
 The happy path will look like:
@@ -331,7 +331,7 @@ The sources for demo helper images can be found [here](https://github.com/k8gb-i
 
 To enable verbose debug output declare `DEMO_DEBUG=1` like
 ```sh
-make demo DEMO_URL=https://failover.test.exampledns.tk DEMO_DEBUG=1
+make demo DEMO_URL=https://failover.cloud.example.com DEMO_DEBUG=1
 ```
 
 ## Release process

--- a/DEPENDENCY.md
+++ b/DEPENDENCY.md
@@ -31,7 +31,7 @@ When adding a new third-party package to K8gb, maintainers must follow these ste
 
 ## Archive/Deprecation
 
-When a third-party package is discontinued, the K8gb maintainers must fensure to replace the package with a suitable alternative.
+When a third-party package is discontinued, the K8gb maintainers must ensure to replace the package with a suitable alternative.
 
 ## Enforcement
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/k8gb-io/k8gb)](https://goreportcard.com/report/github.com/k8gb-io/k8gb)
 [![Helm Publish](https://github.com/k8gb-io/k8gb/actions/workflows/helm_publish.yaml/badge.svg)](https://github.com/k8gb-io/k8gb/actions/workflows/helm_publish.yaml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/absaoss/k8gb)](https://hub.docker.com/r/absaoss/k8gb)
+
+> **Container images:** the Helm chart default is `registry.k8gb.io/k8gb-io/k8gb` (see `chart/k8gb/values.yaml`). Signed/OCI artifacts are also published to `ghcr.io/k8gb-io/*` (see [CONTRIBUTING.md](CONTRIBUTING.md)). The Docker Hub `absaoss/k8gb` badge above reflects historical pulls.
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/k8gb)](https://artifacthub.io/packages/search?repo=k8gb)
 [![doc.crds.dev](https://img.shields.io/badge/doc-crds-purple)](https://doc.crds.dev/github.com/k8gb-io/k8gb)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fk8gb-io%2Fk8gb.svg?type=shield)](https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fk8gb-io%2Fk8gb?ref=badge_shield)

--- a/adr/README.md
+++ b/adr/README.md
@@ -59,9 +59,7 @@ Create an ADR when making decisions about:
 
 ## Examples
 
-- ADR-0001: Use Go modules for dependency management
-- ADR-0002: Implement controller-runtime pattern for Kubernetes operators
-- ADR-0003: Choose CoreDNS as the DNS provider interface
+See the ADR Index above for real project ADRs (currently ADR-0001 and ADR-0002). Use `0000-template.md` when authoring a new one.
 
 ## References
 

--- a/docs/admiralty.md
+++ b/docs/admiralty.md
@@ -81,7 +81,7 @@ podinfo   <none>   *                 80      10m
 
 ## Add k8gb annotations to Ingress object to enable global load balancing
 
-Observer that there are no Gslb resources in the Target clusters
+Observe that there are no Gslb resources in the Target clusters
 
 ```sh
 kubectl --context kind-eu get gslb

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,7 +1,11 @@
 # K8GB Internal Components
 
-[![K8GB Internal Components](images/k8gb-components.svg)](images/k8gb-components.svg)
-*The flow between internal k8gb components including scenario of Route53 integration.*
+k8gb is a Kubernetes operator that reconciles `Gslb` (and related) resources, updates DNS via ExternalDNS / provider integrations, and serves authoritative answers through an embedded CoreDNS instance. The diagrams below show the main control-plane and multi-cluster data flows.
 
-[![K8GB multi-cluster interoperability](images/k8gb-multi-cluster-interoperabililty.svg)](images/k8gb-multi-cluster-interoperabililty.svg) 
-*The flow between k8gb clusters including scenario of Route53 integration.*  
+[![K8GB Internal Components](images/k8gb-components.svg)](images/k8gb-components.svg)
+
+*Internal component flow, including a Route53 integration scenario: the operator watches application ingress objects, maintains DNSEndpoint / zone delegation state, and CoreDNS serves the delegated zone.*
+
+[![K8GB multi-cluster interoperability](images/k8gb-multi-cluster-interoperabililty.svg)](images/k8gb-multi-cluster-interoperabililty.svg)
+
+*Multi-cluster interoperability: paired k8gb instances exchange health via DNS and publish a consistent global view to clients.*

--- a/docs/deploy_azuredns.md
+++ b/docs/deploy_azuredns.md
@@ -55,7 +55,7 @@ In this example, we can use a registered app in Microsoft Entra ID and it's corr
 
 ### Install demo app
 
-Deploys the sample Podinfo workload with failover GLSB configured using annotations in the Ingress resource [samples](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/azure/demo/).
+Deploys the sample Podinfo workload with failover GSLB configured using annotations in the Ingress resource [samples](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/azure/demo/).
 Ensure that the hosts on the samples are correctly updated before execution
 
 ```sh

--- a/docs/deploy_route53.md
+++ b/docs/deploy_route53.md
@@ -55,7 +55,7 @@ cluster, we assume that you switch kubectl context and apply the same command to
 make deploy-test-apps
 ```
 
-* Modify sample [Gslb CR](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/route53/k8gb/gslb-failover.yaml) to reflect desired `.spec.ingress.rules[0].host` FQDN
+* Modify sample [Gslb CR](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/route53/k8gb/gslb-failover.yaml) so the referenced Ingress host matches your desired FQDN
 
 * Apply Gslb CR to *each* cluster
 

--- a/docs/deploy_windowsdns.md
+++ b/docs/deploy_windowsdns.md
@@ -10,7 +10,7 @@ Here we provide an example of k8gb deployment in Azure environment with Windows 
 
 The reference setup includes two private AKS clusters that can be deployed on two different regions for load balancing or to provide a failover solution.
 
-![GLSB with K8gb on Windows DNS](examples/windowsdns/images/k8gb_solution.png "GLSB with K8gb on Windows DNS")
+![GSLB with K8gb on Windows DNS](examples/windowsdns/images/k8gb_solution.png "GSLB with K8gb on Windows DNS")
 
 The solution design can be found [here](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/windowsdns/).
 
@@ -99,7 +99,7 @@ make deploy-k8gb
 
 ### Install demo app
 
-Deploys the sample Podinfo workload with failover GLSB configured using annotations in the Ingress resource [samples](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/windowsdns/demo/).
+Deploys the sample Podinfo workload with failover GSLB configured using annotations in the Ingress resource [samples](https://github.com/k8gb-io/k8gb/tree/master/docs/examples/windowsdns/demo/).
 Ensure that the hosts on the samples are correctly updated before execution
 
 ```sh

--- a/docs/examples/route53/k8gb/k8gb-cluster-eu-west-1.yaml
+++ b/docs/examples/route53/k8gb/k8gb-cluster-eu-west-1.yaml
@@ -2,7 +2,8 @@ k8gb:
   dnsZones:
     - loadBalancedZone: "test.k8gb.io" # -- dnsZone controlled by gslb
       parentZone: "k8gb.io" # -- main zone which would contain gslb zone to delegate
-  edgeDNSServer: "169.254.169.253" # use this DNS server as a main resolver to enable cross k8gb DNS based communication
+  edgeDNSServers:
+    - "169.254.169.253" # use this DNS server as a main resolver to enable cross k8gb DNS based communication
   clusterGeoTag: "eu-west-1" # used for places where we need to distinguish between differnet Gslb instances
   extGslbClustersGeoTags: "us-east-1" # comma-separated list of external gslb geo tags to pair with
 

--- a/docs/examples/route53/k8gb/k8gb-cluster-us-east-1.yaml
+++ b/docs/examples/route53/k8gb/k8gb-cluster-us-east-1.yaml
@@ -2,7 +2,8 @@ k8gb:
   dnsZones:
     - loadBalancedZone: "test.k8gb.io" # -- dnsZone controlled by gslb
       parentZone: "k8gb.io" # -- main zone which would contain gslb zone to delegate
-  edgeDNSServer: "169.254.169.253" # use this DNS server as a main resolver to enable cross k8gb DNS based communication
+  edgeDNSServers:
+    - "169.254.169.253" # use this DNS server as a main resolver to enable cross k8gb DNS based communication
   clusterGeoTag: "us-east-1" # used for places where we need to distinguish between differnet Gslb instances
   extGslbClustersGeoTags: "eu-west-1" # comma-separated list of external gslb geo tags to pair with
 

--- a/docs/exposing_dns.md
+++ b/docs/exposing_dns.md
@@ -41,13 +41,13 @@ kubectl create -n ingress-nginx cm udp-services --from-literal="53"="k8gb/k8gb-c
 [Local project setup](./local.md) does this patching automatically.
 
 ## CoreDNS service lookup
-k8gb is trying to find a service annotated with `app.kubernetes.io/name=coredns` within the same namespace where controller itself is deployed into. If the service has `Status.LoadBalancer.Ingress[0].Hostname`, k8gb will use the resolved IPs to reach CoreDNS on this cluster.
+k8gb is trying to find a service labeled with `app.kubernetes.io/name=coredns` within the same namespace where controller itself is deployed into. If the service has `Status.LoadBalancer.Ingress[0].Hostname`, k8gb will use the resolved IPs to reach CoreDNS on this cluster.
 
 ## External load balancer
 
 CoreDNS can be also exposed for DNS UDP traffic via external load balancer,
 if underlying infrastructure supports that.<br>
-[AWS EKS](https://aws.amazon.com/eks) with [NLB](https://docs.aws.amazon.com/eks/latest/userguide/load-balancing.html) and [k3d](https://www.k3d.io) with [ServiceLB](https://rancher.com/docs/k3s/latest/en/networking/#service-load-balancer) are good examples of such an infrastructure proven to work for k8gb deployments.<br>
+[AWS EKS](https://aws.amazon.com/eks) with [NLB](https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html) and [k3d](https://www.k3d.io) with [ServiceLB](https://rancher.com/docs/k3s/latest/en/networking/#service-load-balancer) are good examples of such an infrastructure proven to work for k8gb deployments.<br>
 We're using this approach in our [AWS+Route53](deploy_route53.md) reference setup with [k8gb helm chart](https://artifacthub.io/packages/helm/k8gb/k8gb) providing out-of-the-box support for external load balancer scenario. CoreDNS service is configured by setting `coredns.serviceType` helm chart value to `LoadBalancer`:
 ```yaml
 # k8gb helm chart values.yaml example:

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -3,8 +3,8 @@
 A Global Server Load Balancing solution with a focus on having cloud native qualities and work natively in a Kubernetes context. The term GSLB, as used in this context, obeys the same principles as defined in the following sources:
 
 * [What Is GSLB? Load Balancing Explained - Cloudflare](https://www.cloudflare.com/learning/cdn/glossary/global-server-load-balancing-gslb/)
-* [Global Server Load Balancing Definition - AVI Networks](https://avinetworks.com/glossary/global-server-load-balancing-2/)
-* [What is Global Server Load Balancing (GSLB)? - A10 Networks](https://www.a10networks.com/blog/global-server-load-balancing/)
+* [Global Server Load Balancing Definition - AVI Networks](https://www.vmware.com/topics/global-server-load-balancing)
+* [What is Global Server Load Balancing (GSLB)? - A10 Networks](https://www.a10networks.com/glossary/what-is-global-server-load-balancing/)
 * [Global Load Balancing, Caching and TTLs - NS1 - Important points on DNS Caching and how it affects GSLB](https://ns1.com/blog/global-load-balancing-caching-and-ttls)
 
 In short, the ability to direct HTTP requests to a local load balancer (Kubernetes Ingress controller instances) based on the health of services (Pods) in multiple, potentially geographically dispersed, Kubernetes clusters whether on premises or in cloud. With additional options around what criteria to use (round robin, weighting, active/passive, etc.) when determining the best local load balancer/ingress instance to resolve.
@@ -175,7 +175,7 @@ The following projects represent examples of other GSLB implementations that cou
 
 ### Commercial
 
-* AVI Networks - <https://avinetworks.com/glossary/global-server-load-balancing-2/>
-* F5 Networks - <https://www.f5.com/products/global-server-load-balancing-gslb>
-  * See <https://blog.openshift.com/deploying-openshift-applications-multiple-datacenters/> (Networking section)
-* Infoblox DTC - <https://www.infoblox.com/products/dns-traffic-control/>
+* AVI Networks - <https://www.vmware.com/topics/global-server-load-balancing>
+* F5 Networks - <https://www.f5.com/solutions/use-cases/global-server-load-balancing-gslb>
+  * See <https://www.redhat.com/en/blog/deploying-openshift-applications-multiple-datacenters> (Networking section)
+* Infoblox DTC - <https://www.infoblox.com/products/nios/>

--- a/docs/lbservice-integration.md
+++ b/docs/lbservice-integration.md
@@ -38,7 +38,7 @@ metadata:
   name: my-app-gslb
   namespace: default
   annotations:
-    k8gb.io/hostname: "myapp.example.com"  # Required: Specify your desired hostname
+    k8gb.io/hostname: "myapp.cloud.example.com"  # Required: under loadBalancedZone
 spec:
   resourceRef:
     apiVersion: v1
@@ -110,7 +110,7 @@ kind: Gslb
 metadata:
   name: my-app-gslb-primary
   annotations:
-    k8gb.io/hostname: "myapp.example.com"
+    k8gb.io/hostname: "myapp.cloud.example.com"
 spec:
   resourceRef:
     apiVersion: v1
@@ -128,7 +128,7 @@ kind: Gslb
 metadata:
   name: my-app-gslb-alias
   annotations:
-    k8gb.io/hostname: "www.myapp.example.com"
+    k8gb.io/hostname: "www.myapp.cloud.example.com"
 spec:
   resourceRef:
     apiVersion: v1
@@ -166,13 +166,18 @@ If the hostname doesn't match any configured DNS zones:
 ingress host myapp.example.com does not match delegated zone [cloud.example.com]
 ```
 
+Use a hostname under the zone instead (for example `myapp.cloud.example.com`).
+
 ## Comparison with Other Integrations
 
 | Integration Type | Hostname Source | Configuration |
 |------------------|-----------------|---------------|
 | **Ingress** | `spec.rules[].host` | Automatic |
+| **Gateway API HTTPRoute** | `spec.hostnames[]` (via `resourceRef`) | Automatic |
 | **Istio VirtualService** | `spec.hosts[]` | Automatic |
 | **LoadBalancer Service** | `k8gb.io/hostname` annotation | **Manual** |
+
+Hostnames from every integration type must still fall under a configured `loadBalancedZone` (see [Resource References](resource_ref.md) for Gateway API).
 
 ## Benefits
 

--- a/docs/local-kuar.md
+++ b/docs/local-kuar.md
@@ -22,7 +22,7 @@ This task will deploy Kuar into both clusters and exposes it. It also patches th
 
 Make sure the app on http://localhost is responding, it may take a minute for the nginx ingress controller to restart with the correct parameters.
 
-The make target also modified the deployment of the Kuar application to use our core DNS servers. To verify that this was done, one can open the Kuar's file system browser tab and [open](http://localhost/fs/etc/resolv.conf) `/etc/resolv.conv`. It should contain the same IP as cluster-IP assigned to `k8gb-coredns` service.
+The make target also modified the deployment of the Kuar application to use our core DNS servers. To verify that this was done, one can open the Kuar's file system browser tab and [open](http://localhost/fs/etc/resolv.conf) `/etc/resolv.conf`. It should contain the same IP as cluster-IP assigned to `k8gb-coredns` service.
 
 Together with Kuar, we also prepared the failover gslb resource for k8gb. Where the first cluster (geotag = `eu`) is the primary one.
 

--- a/docs/local.md
+++ b/docs/local.md
@@ -244,7 +244,7 @@ cluster has been tagged to serve a different region. In this demo we will hit po
 on whether podinfo is running inside the cluster it returns only **eu** or **us**.
 See [Gslb manifest with failover strategy](https://github.com/k8gb-io/k8gb/tree/master/deploy/gslb/k8gb.io_v1beta1_gslb_cr_failover_ingress.yaml)
 
-Switch GLSB to failover mode:
+Switch GSLB to failover mode:
 ```sh
 make init-failover
 ```
@@ -301,7 +301,7 @@ After DNS sync interval is over **eu** will be back
   ...
 }
 ```
-Optionally you can switch GLSB back to round-robin mode
+Optionally you can switch GSLB back to round-robin mode
 ```sh
 make init-round-robin
 ```

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -7,6 +7,7 @@ This section provides comprehensive tutorials for deploying and configuring K8GB
 * [General deployment with Infoblox integration](deploy_infoblox.md)
 * [AWS based deployment with Route53 integration](deploy_route53.md)
 * [AWS based deployment with NS1 integration](deploy_ns1.md)
+* [Google Cloud DNS provider](provider_gcp.md)
 * [Using Azure Public DNS provider](deploy_azuredns.md)
 * [Azure based deployment with Windows DNS integration](deploy_windowsdns.md)
 * [General deployment with Cloudflare integration](deploy_cloudflare.md)
@@ -16,6 +17,8 @@ This section provides comprehensive tutorials for deploying and configuring K8GB
 
 * [Local playground for testing and development](local.md)
 * [Local playground with Kuar web app](local-kuar.md)
+* [AI Inference Resilience Demo](ai-inference-demo.md)
+* [Rollback Process](rollback_procedures.md)
 
 ## Monitoring and Observability
 
@@ -26,6 +29,7 @@ This section provides comprehensive tutorials for deploying and configuring K8GB
 
 * [Resource References](resource_ref.md)
 * [Address Discovery](address_discovery.md)
+* [Exposed Hostnames](exposed-hostnames.md)
 * [Dynamic Geotags](dynamic_geotags.md)
 * [Dynamic Zones](dynamic_zones.md)
 * [Multi-zone Setup](multizone.md)
@@ -36,9 +40,14 @@ This section provides comprehensive tutorials for deploying and configuring K8GB
 * [Integration with Admiralty](admiralty.md)
 * [Integration with Liqo](liqo.md)
 * [Integration with Rancher Fleet](rancher.md)
+* [Crossplane Global Control Plane](crossplane_globalapp.md)
+* [LoadBalancer Service Integration](lbservice-integration.md)
 
 ## Advanced Topics
 
 * [Service Upgrade](service_upgrade.md)
+* [Partial Deployment Troubleshooting](partial-deployment.md)
+* [Migration Acceptance Tests](migration_acceptance.md)
+* [Split-Brain Scenarios](splitbrain.md)
 * [WRR Caveats](wrr_caveats.md)
 * [External DNS Proxy](proxy_externaldns.md)


### PR DESCRIPTION
Align installation docs with current chart keys and mkdocs nav, fix broken/redirected links and small accuracy issues from the v0.20 audit.

Fixes #2456

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
