### PR TITLE
docs: note ingress-nginx retirement and steer to Gateway API

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,9 @@ k8gb is tested with the following environment options and integration scenarios.
 |----------------------------------|------------------------------------------------------------------------------|
 | Kubernetes Version               | >= `1.21`                                                                    |
 | Environment                      | Any conformant Kubernetes cluster on-prem or in cloud                        |
-| Ingress Controller               | NGINX, Istio, AWS Load Balancer Controller [*](#clarify)                     |
+| Ingress / Gateway                | Gateway API (recommended), Istio, AWS Load Balancer Controller; Ingress NGINX only as legacy [*](#clarify) |
 | EdgeDNS                          | Infoblox, Route53, NS1, CloudFlare, AzureDNS, GCP Cloud DNS                  |
-| Ingress Integration Modes        | Kubernetes Ingress (embedded/referenced), Istio (VirtualService + Gateway)   |
+| Ingress Integration Modes        | Gateway API (`HTTPRoute` / related), Kubernetes Ingress (embedded/referenced), Istio (VirtualService + Gateway) |
 | Automated E2E Validation         | Multi-cluster automated E2E testing with Terratest and Chainsaw               |
 
 <a name="clarify"></a>

--- a/docs/deploy_route53.md
+++ b/docs/deploy_route53.md
@@ -15,10 +15,26 @@ Feel free to reuse this code fully or partially and adapt for your existing scen
 * EKS custom tags
 * IRSA(IAM Roles for Service Accounts) role reference
 
-## Install Ingress Controller
+## Install a north-south data plane (prefer Gateway API)
+
+For **new** deployments, prefer [Gateway API](https://gateway-api.sigs.k8s.io/) with a maintained
+implementation (for example AWS Gateway API controller / your platform's Gateway). k8gb can
+reference HTTPRoute and related resources via `spec.resourceRef` — see
+[Resource References](resource_ref.md). Local playground samples live under
+`deploy/gslb/*gatewayapi*`.
+
+> **Ingress NGINX status:** the Kubernetes Ingress NGINX project was
+> [retired in March 2026](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/)
+> ([Steering/SRC statement](https://www.kubernetes.io/blog/2026/01/29/ingress-nginx-statement/)).
+> Do not start new production installs on it. Existing tutorials that still show
+> `ingressClassName: nginx` are legacy examples only.
+
+If you must follow a legacy Ingress-based sample in an existing cluster that already runs
+Ingress NGINX, use a current controller tag (not old 0.x pins), for example:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.40.2/deploy/static/provider/aws/deploy.yaml
+# Legacy path only — prefer Gateway API for new installs
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.15.1/deploy/static/provider/aws/deploy.yaml
 ```
 
 ## Deploy k8gb

--- a/docs/examples/route53/Makefile
+++ b/docs/examples/route53/Makefile
@@ -22,4 +22,5 @@ login:
 .PHONY: k8gb-reference-setup
 k8gb-reference-setup:
 	terraform apply
-	kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.40.2/deploy/static/provider/aws/deploy.yaml
+	# Legacy Ingress NGINX path only — prefer Gateway API for new installs (see docs/deploy_route53.md).
+	kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.15.1/deploy/static/provider/aws/deploy.yaml

--- a/docs/exposing_dns.md
+++ b/docs/exposing_dns.md
@@ -7,7 +7,10 @@ type of load balancer or ingress controller used etc.
 This topic is outside the project's scope, as often the related configuration is shared by cluster services, requires additional permissions, and as result can't be owned by k8gb controller deployment.
 However, we can describe a few examples using common Kubernetes configurations, which have been thoroughly tested in local and production environments.
 
-## Ingress Controller with UDP support (NGINX)
+## Ingress Controller with UDP support (NGINX) — legacy
+
+> **Prefer exposing CoreDNS via `LoadBalancer` / NLB** (see [External load balancer](#external-load-balancer) below) or your platform's Gateway / UDP path.
+> Ingress NGINX was [retired in March 2026](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/); keep this section only if you already run it.
 
 > *Check [NGINX Ingress controller official documentation](https://kubernetes.github.io/ingress-nginx/user-guide/exposing-tcp-udp-services/) for additional information*
 

--- a/docs/resource_ref.md
+++ b/docs/resource_ref.md
@@ -1,8 +1,11 @@
 # GSLB ResourceRef Support
-Starting from v0.15.0, k8gb introduces a much simpler way to link a GSLB resource to an Ingress object in Kubernetes. You no longer need to duplicate the Ingress configuration in your GSLB definition—instead, you can simply reference an existing Ingress. 
+Starting from v0.15.0, k8gb introduces a much simpler way to link a GSLB resource to an Ingress object in Kubernetes. You no longer need to duplicate the Ingress configuration in your GSLB definition—instead, you can simply reference an existing Ingress.
 This makes your Ingress the single source of truth for application routing.
 
-K8GB supports the following ingress resources:
+For **new** deployments, prefer [Gateway API](https://gateway-api.sigs.k8s.io/) resources (supported since v0.17.0). Kubernetes Ingress remains supported; Ingress NGINX itself was
+[retired in March 2026](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/) and should not be chosen for greenfield installs.
+
+K8GB supports the following ingress / gateway resources:
 
 * [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/)
 * [Kubernetes LoadBalancer Service](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -2,6 +2,10 @@
 
 This section provides comprehensive tutorials for deploying and configuring K8GB with various DNS providers and environments.
 
+> **North-south data plane:** for new installs prefer [Gateway API](resource_ref.md) (k8gb `resourceRef` since v0.17).
+> Many older tutorials still show Kubernetes Ingress / NGINX examples; treat those as legacy — Ingress NGINX was
+> [retired in March 2026](https://www.kubernetes.dev/blog/2025/11/12/ingress-nginx-retirement/).
+
 ## DNS Provider Integrations
 
 * [General deployment with Infoblox integration](deploy_infoblox.md)


### PR DESCRIPTION
..

## Summary
- Document Ingress NGINX retirement and prefer Gateway API for new installs
- Stop pinning ancient controller versions; align Route53 example with `controller-v1.15.1`
- Mark remaining NGINX UDP guidance as legacy

Fixes #2453

## Test plan
- [ ] Skim changed docs for accurate Gateway API / NGINX wording
- [ ] Confirm Route53 example Makefile pin matches docs

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
