### PR TITLE
fix: zone delegation reconciliation panics on invalid rfc1035

### DIFF
--- a/controllers/zone_delegation_reconciliation.go
+++ b/controllers/zone_delegation_reconciliation.go
@@ -84,14 +84,14 @@ func (r *ZoneDelegationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	err = r.ensureFinalizer(ctx, zone)
 	if err != nil {
 		r.Logger.Err(err).
-			Str("name", zone.Name).
+			Str("name", req.Name).
 			Msg("Error ensuring finalizer")
 		return result.RequeueError(err)
 	}
 
 	err = r.ZoneService.UpdateCoreDNSConfiguration(ctx, zone)
 	if err != nil {
-		r.Logger.Err(err).Str("Name", zone.Name).Msg("Error updating zone delegation")
+		r.Logger.Err(err).Str("Name", req.Name).Msg("Error updating zone delegation")
 		return result.RequeueError(err)
 	}
 
@@ -105,13 +105,13 @@ func (r *ZoneDelegationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	zone, err = r.ZoneService.UpdateStatus(ctx, zone)
 	if err != nil {
-		r.Logger.Err(err).Str("Name", zone.Name).Msg("Error updating zone delegation")
+		r.Logger.Err(err).Str("Name", req.Name).Msg("Error updating zone delegation")
 		return result.RequeueError(err)
 	}
 
 	exZD, err := r.ZoneService.ExtendedZoneDelegation(ctx, zone)
 	if err != nil {
-		r.Logger.Err(err).Str("Name", zone.Name).Msg("Error getting extended zone delegation")
+		r.Logger.Err(err).Str("Name", req.Name).Msg("Error getting extended zone delegation")
 		return result.RequeueError(err)
 	}
 

--- a/controllers/zones/zone_service_test.go
+++ b/controllers/zones/zone_service_test.go
@@ -46,6 +46,27 @@ func TestUpdateStatus(t *testing.T) {
 		arrangemocks   func(bs *ipresolver.MockResolver)
 	}{
 		{
+			name:          "invalid rfc1035",
+			expectedError: true,
+			zoneDelegation: &v1beta1io.ZoneDelegation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: v1beta1io.ZoneDelegationSpec{
+					LoadBalancedZone: "very-long-domain-name.with-foo-and-balh.cloud.example.com",
+					ParentZone:       "example.com",
+				},
+			},
+			config: &resolver.Config{
+				ClusterGeoTag:         "eu-west-dc-1",
+				ExtClustersGeoTagsRaw: []string{"us-west-dc-1", "za-west-dc-1"},
+			},
+			arrangemocks: func(ips *ipresolver.MockResolver) {
+				ips.EXPECT().GetExposedIPs(gomock.Any()).Return(&ipresolver.Resolved{IPs: []string{"172.18.0.1", "172.18.0.2"}}, nil).AnyTimes()
+			},
+			expectedStatus: nil,
+		},
+		{
 			name:          "create status on new ZoneDelegation",
 			expectedError: false,
 			zoneDelegation: &v1beta1io.ZoneDelegation{


### PR DESCRIPTION
```go
zone, err = r.ZoneService.UpdateStatus(ctx, zone)
if err != nil {
	r.Logger.Err(err).
          Str("Name", zone.Name).Msg("Error updating zone delegation") // if err != nil && zone == nil it panics 
	return result.RequeueError(err)
}
```