### PR TITLE
fix(chart): restore extraPlugins per-zone server blocks in CoreDNS config

### DIFF
--- a/chart/k8gb/templates/coredns/cm.yaml
+++ b/chart/k8gb/templates/coredns/cm.yaml
@@ -8,13 +8,6 @@ metadata:
 {{ include "chart.labels" . | indent 4  }}
 data:
   Corefile: |-
-    . {
-      health
-      {{- if $.Values.coredns.corefile.reload.enabled }}
-      reload {{ $.Values.coredns.corefile.reload.interval }} {{ $.Values.coredns.corefile.reload.jitter }}
-      {{- end }}
-      ready
-    }
     (k8gbplugins) {
         errors
         health
@@ -36,6 +29,16 @@ data:
             {{- end }}
         }
     }
+{{- range .Values.k8gb.dnsZones }}
+    {{ .loadBalancedZone }}:5353 {
+        import k8gbplugins
+{{- if .extraPlugins }}
+{{- range .extraPlugins }}
+{{ . | nindent 8 }}
+{{- end }}
+{{- end }}
+    }
+{{- end }}
 {{- with .extraServerBlocks -}}
 {{- tpl . $ | nindent 4 }}
 {{- end }}
@@ -48,4 +51,3 @@ metadata:
   name: k8gb-zone-delegation
   namespace: {{ .Release.Namespace }}
 data: {}
-


### PR DESCRIPTION
v0.20.0 removed the range over .Values.k8gb.dnsZones from cm.yaml during the ZoneDelegation refactor. This silently dropped per-zone server blocks and the extraPlugins content that users configure.

Restores the range block so dnsZones[].extraPlugins renders correctly again.