### PR TITLE
feat: ZONE_DELEGATION_RECONCILE_REQUEUE_SECONDS as dedicated value fo…

### DIFF
--- a/chart/k8gb/templates/deployment.yaml
+++ b/chart/k8gb/templates/deployment.yaml
@@ -78,6 +78,10 @@ spec:
               value: {{ include "k8gb.dnsZonesString" . }}
             - name: RECONCILE_REQUEUE_SECONDS
               value: {{ quote .Values.k8gb.reconcileRequeueSeconds }}
+            - name: ZONE_DELEGATION_RECONCILE_REQUEUE_SECONDS
+              value: {{ quote .Values.k8gb.zoneDelegationReconcileRequeueSeconds }}
+            - name: ZONE_DELEGATION_RECOVERY_SECONDS
+              value: {{ quote .Values.k8gb.zoneDelegationRecoverySeconds }}
             - name: NS_RECORD_TTL
               value: {{ quote .Values.k8gb.nsRecordTTL }}
             {{- if .Values.infoblox.enabled }}

--- a/chart/k8gb/values.schema.json
+++ b/chart/k8gb/values.schema.json
@@ -443,6 +443,14 @@
                     "type": "integer",
                     "minimum": 0
                 },
+                "zoneDelegationReconcileRequeueSeconds": {
+                    "type": "integer",
+                    "minimum": 0
+                },
+                "zoneDelegationRecoverySeconds": {
+                    "type": "integer",
+                    "minimum": 0
+                },
                 "nsRecordTTL": {
                     "type": "integer",
                     "minimum": 0

--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -53,6 +53,10 @@ k8gb:
   extGslbClustersGeoTags: "eu,us"
   # -- Reconcile time in seconds
   reconcileRequeueSeconds: 30
+  # -- ZoneDelegation reconcile time in seconds
+  zoneDelegationReconcileRequeueSeconds: 300
+  # -- ZoneDelegation reconcile recovery time in seconds
+  zoneDelegationRecoverySeconds: 60
   # -- TTL of the NS and respective glue record used by external DNS
   nsRecordTTL: 30
 

--- a/controllers/bootstrap_controller_reconciliation.go
+++ b/controllers/bootstrap_controller_reconciliation.go
@@ -53,7 +53,7 @@ type CoreDNSReconciler struct {
 
 func (r *CoreDNSReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	var err error
-	result := utils.NewReconcileResultHandler(0)
+	result := utils.NewReconcileResultHandler(0, 30)
 	r.Logger.Info().Msg("Reconciling CoreDNS delegation")
 
 	ips, err := r.IPResolver.GetExposedIPs(ctx)

--- a/controllers/gslb_controller_reconciliation.go
+++ b/controllers/gslb_controller_reconciliation.go
@@ -78,7 +78,7 @@ func (r *GslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	ctx, span := r.Tracer.Start(ctx, "Reconcile")
 	defer span.End()
 
-	result := utils.NewReconcileResultHandler(r.Config.ReconcileRequeueSeconds)
+	result := utils.NewReconcileResultHandler(r.Config.ReconcileRequeueSeconds, r.Config.ReconcileRequeueSeconds)
 	// Check that cluster provides available IPs. Without IP's I'm skipping GSLB reconciliation
 	if !r.ZoneService.HasAvailableIPs(ctx) {
 		r.Logger.Info().

--- a/controllers/gslb_legacy_controller.go
+++ b/controllers/gslb_legacy_controller.go
@@ -58,7 +58,7 @@ type LegacyGslbReconciler struct {
 
 // Reconcile runs legacy runtime reconciliation only for legacy objects that are not migration requested/migrated yet.
 func (r *LegacyGslbReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	result := utils.NewReconcileResultHandler(r.Config.ReconcileRequeueSeconds)
+	result := utils.NewReconcileResultHandler(r.Config.ReconcileRequeueSeconds, r.Config.ReconcileRequeueSeconds)
 
 	// Check that cluster provides available IPs. Without IP's I'm skipping GSLB reconciliation
 	if !r.ZoneService.HasAvailableIPs(ctx) {

--- a/controllers/resolver/config.go
+++ b/controllers/resolver/config.go
@@ -43,6 +43,10 @@ type Config struct {
 
 	ReconcileRequeueSeconds int `env:"RECONCILE_REQUEUE_SECONDS" optional:""  default:"30" validate:"min=0" help:"delay between individual reconciliations. If set to 0, reconciliation is only triggered at startup or when the GSLB, Ingress, or DNSEndpoint changes."`
 
+	ZoneDelegationReconcileRequeueSeconds int `env:"ZONE_DELEGATION_RECONCILE_REQUEUE_SECONDS" optional:""  default:"300" validate:"min=0" help:"delay between individual reconciliations. If set to 0, reconciliation is only triggered at startup or when the ZoneDelegation changes."`
+
+	ZoneDelegationRecoverySeconds int `env:"ZONE_DELEGATION_RECOVERY_SECONDS" optional:""  default:"3600" validate:"min=0" help:"delay between individual reconciliations when ZoneDelegation fails. If set to 0, reconciliation is only triggered at startup or when the ZoneDelegation changes."`
+
 	NSRecordTTL int `env:"NS_RECORD_TTL" optional:"" default:"30" validate:"min=1" help:"TTL of the NS and respective glue record used by external DNS."`
 
 	K8gbNamespace string `env:"POD_NAMESPACE" optional:"" default:"k8gb" help:"namespace where k8gb pod is running"`

--- a/controllers/utils/reconciler_result.go
+++ b/controllers/utils/reconciler_result.go
@@ -26,11 +26,17 @@ import (
 
 type ReconcileResultHandler struct {
 	delayedResult ctrl.Result
+	errorResult   ctrl.Result
 }
 
-func NewReconcileResultHandler(reconcileAfter int) *ReconcileResultHandler {
+// NewReconcileResultHandler creates reconciler
+// reconcileAfter defines reconciliation heartbeat.
+// reconcileAfterError defines reconciliation recovery after error.
+// e.g: you can reconcile ZoneDelegation very 5 minutes while, you can reconcile after 30sec when error occurs
+func NewReconcileResultHandler(reconcileAfter, reconcileAfterError int) *ReconcileResultHandler {
 	return &ReconcileResultHandler{
 		delayedResult: ctrl.Result{RequeueAfter: time.Second * time.Duration(reconcileAfter)},
+		errorResult:   ctrl.Result{RequeueAfter: time.Second * time.Duration(reconcileAfterError)},
 	}
 }
 
@@ -43,7 +49,7 @@ func (r *ReconcileResultHandler) Stop() (ctrl.Result, error) {
 // see default controller limiter: https://danielmangum.com/posts/controller-runtime-client-go-rate-limiting/
 func (r *ReconcileResultHandler) RequeueError(err error) (ctrl.Result, error) {
 	// logging error is handled in caller function
-	return r.delayedResult, err
+	return r.errorResult, err
 }
 
 // Requeue requeue loop after config.ReconcileRequeueSeconds
@@ -52,6 +58,10 @@ func (r *ReconcileResultHandler) RequeueError(err error) (ctrl.Result, error) {
 // see: https://github.com/operator-framework/operator-sdk/issues/1164
 func (r *ReconcileResultHandler) Requeue() (ctrl.Result, error) {
 	return r.delayedResult, nil
+}
+
+func (r *ReconcileResultHandler) RequeueAfter(seconds int) (ctrl.Result, error) {
+	return ctrl.Result{RequeueAfter: time.Second * time.Duration(seconds)}, nil
 }
 
 func (r *ReconcileResultHandler) RequeueNow() (ctrl.Result, error) {

--- a/controllers/zone_delegation_reconciliation.go
+++ b/controllers/zone_delegation_reconciliation.go
@@ -56,15 +56,15 @@ const zoneDelegationFinalizer = "k8gb.io/finalizer"
 
 func (r *ZoneDelegationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var err error
-	result := utils.NewReconcileResultHandler(r.Config.ReconcileRequeueSeconds)
+	result := utils.NewReconcileResultHandler(r.Config.ZoneDelegationReconcileRequeueSeconds, r.Config.ZoneDelegationRecoverySeconds)
 	r.Logger.Info().
 		Str("name", req.Name).
 		Msg("Reconciling ZoneDelegation")
 	if !r.ZoneService.HasAvailableIPs(ctx) {
 		r.Logger.Info().
 			Str("name", req.Name).
-			Msg("Waiting for available IPs. Skipping ZoneDelegation reconciliation")
-		return result.Requeue()
+			Msgf("Waiting %v for available IPs. Skipping ZoneDelegation reconciliation", 10)
+		return result.RequeueAfter(10)
 	}
 
 	zone, err := r.ZoneService.Get(ctx, req.NamespacedName)

--- a/deploy/helm/next.yaml
+++ b/deploy/helm/next.yaml
@@ -1,5 +1,7 @@
 k8gb:
   reconcileRequeueSeconds: 10
+  zoneDelegationReconcileRequeueSeconds: 10
+  zoneDelegationRecoverySeconds: 10
 
   extraVolumeMounts:
     - name: dynamic-zones


### PR DESCRIPTION
…r ZD reconciliation

For zoneDelegation we need dedicated reconciliation requeue seconds (till now we used GSLB requeue seconds). In our environment we are fine if ZD if refreshed every 5 minutes. Also, when IPs are not yet ready for k8gb or ZD reconciliation fails, we need different intervals than 5 minutes.

For that reason we bring `ZONE_DELEGATION_RECONCILE_REQUEUE_SECONDS` and `ZONE_DELEGATION_RECOVERY_SECONDS` which distinguish between ZD  reconciliation and recovery time. 
