### PR TITLE
refactor: remove extClusterGeoTags from ZD wrapper

### DIFF
--- a/controllers/gslb_legacy_controller_test.go
+++ b/controllers/gslb_legacy_controller_test.go
@@ -229,7 +229,6 @@ func newLegacyRuntimeReconciler(t *testing.T, objs ...client.Object) (*LegacyGsl
 		},
 	}
 	zoneService.EXPECT().HasAvailableIPs(gomock.Any()).Return(true).AnyTimes()
-	zoneService.EXPECT().HasExtClusterGeoTags(gomock.Any()).Return(len(reconciler.Config.ExtClustersGeoTagsRaw) > 0).AnyTimes()
 	zoneService.EXPECT().List(gomock.Any()).Return(&k8gbv1beta1io.ZoneDelegationList{
 		Items: []k8gbv1beta1io.ZoneDelegation{
 			{

--- a/controllers/providers/dns/external_test.go
+++ b/controllers/providers/dns/external_test.go
@@ -125,9 +125,6 @@ func TestCreateZoneDelegation(t *testing.T) {
 				NegativeTTL:            60,
 				LocalCoreDNSExposedIPs: []string{"10.0.0.1", "10.0.0.2"},
 				ClusterNSName:          "gslb-ns-eu-k8gb-test-gslb.cloud.example.com",
-				ExtClusterNSNames: resolver.ClusterNSNames{
-					"gslb-ns-us-k8gb-test-gslb.cloud.example.com": resolver.NewGeoTag(false, "us"),
-				},
 			},
 			client:        getFakeClientForExistingEndpoint(ctx, getExistingEndpoint("k8gb-ns-extdns-cloud-example-com", "k8gb")),
 			expectedError: false,
@@ -154,9 +151,6 @@ func TestCreateZoneDelegation(t *testing.T) {
 				NegativeTTL:            60,
 				LocalCoreDNSExposedIPs: []string{"10.0.0.1", "10.0.0.2"},
 				ClusterNSName:          "gslb-ns-eu-k8gb-test-gslb.cloud.example.com",
-				ExtClusterNSNames: resolver.ClusterNSNames{
-					"gslb-ns-us-k8gb-test-gslb.cloud.example.com": resolver.NewGeoTag(false, "us"),
-				},
 			},
 			client:        getFakeClient(ctx, "k8gb", "k8gb-ns-extdns-cloud-example-com"),
 			expectedError: false,

--- a/controllers/providers/dns/infoblox_test.go
+++ b/controllers/providers/dns/infoblox_test.go
@@ -50,9 +50,6 @@ func TestCreateZoneDelegationInfoblox(t *testing.T) {
 				ClusterNSName:          "gslb-ns-eu-cloud.example.com",
 				LocalCoreDNSExposedIPs: []string{"10.0.0.1", "10.0.0.2"},
 				NegativeTTL:            30,
-				ExtClusterNSNames: resolver.ClusterNSNames{
-					"gslb-ns-us-cloud.example.com": resolver.NewGeoTag(false, "us"),
-				},
 			},
 			config: resolver.Config{
 				K8gbNamespace: "k8gb",
@@ -104,10 +101,6 @@ func TestCreateZoneDelegationInfoblox(t *testing.T) {
 				ClusterNSName:          "gslb-ns-eu-cloud.example.com",
 				LocalCoreDNSExposedIPs: []string{"10.0.0.1", "10.0.0.2"},
 				NegativeTTL:            30,
-				ExtClusterNSNames: resolver.ClusterNSNames{
-					"gslb-ns-us-cloud.example.com": resolver.NewGeoTag(false, "us"),
-					"gslb-ns-za-cloud.example.com": resolver.NewGeoTag(false, "za"),
-				},
 			},
 			config: resolver.Config{
 				K8gbNamespace: "k8gb",
@@ -147,10 +140,6 @@ func TestCreateZoneDelegationInfoblox(t *testing.T) {
 				ClusterNSName:          "gslb-ns-eu-cloud.example.com",
 				LocalCoreDNSExposedIPs: []string{"10.0.0.1", "10.0.0.2"},
 				NegativeTTL:            30,
-				ExtClusterNSNames: resolver.ClusterNSNames{
-					"gslb-ns-us-cloud.example.com": resolver.NewGeoTag(false, "us"),
-					"gslb-ns-za-cloud.example.com": resolver.NewGeoTag(false, "za"),
-				},
 			},
 			config: resolver.Config{
 				K8gbNamespace: "k8gb",
@@ -219,10 +208,6 @@ func TestCreateZoneDelegationInfoblox(t *testing.T) {
 				ClusterNSName:          "gslb-ns-eu-cloud.example.com",
 				LocalCoreDNSExposedIPs: []string{"10.0.0.1", "10.0.0.2"},
 				NegativeTTL:            30,
-				ExtClusterNSNames: resolver.ClusterNSNames{
-					"gslb-ns-us-cloud.example.com": resolver.NewGeoTag(false, "us"),
-					"gslb-ns-za-cloud.example.com": resolver.NewGeoTag(false, "za"),
-				},
 			},
 			config: resolver.Config{
 				K8gbNamespace: "k8gb",
@@ -257,9 +242,6 @@ func TestCreateZoneDelegationInfoblox(t *testing.T) {
 				ClusterNSName:          "gslb-ns-eu-cloud.example.com",
 				LocalCoreDNSExposedIPs: []string{"10.0.0.1", "10.0.0.2"},
 				NegativeTTL:            30,
-				ExtClusterNSNames: resolver.ClusterNSNames{
-					"gslb-ns-us-cloud.example.com": resolver.NewGeoTag(false, "us"),
-				},
 			},
 			config: resolver.Config{
 				K8gbNamespace: "k8gb",

--- a/controllers/providers/k8gbendpoint/applicationDNSEndpoint_weight_test.go
+++ b/controllers/providers/k8gbendpoint/applicationDNSEndpoint_weight_test.go
@@ -352,7 +352,6 @@ func TestWeight(t *testing.T) {
 				func(q *dns.Msg) []string { return utils.NewDNSQueryService().ExtractARecords(q) },
 			).AnyTimes()
 			zs.EXPECT().List(gomock.Any()).Return(test.zoneDelegationList, nil).AnyTimes()
-			zs.EXPECT().HasExtClusterGeoTags(gomock.Any()).Return(len(test.config.ExtClustersGeoTagsRaw) > 0).AnyTimes()
 			ipr.EXPECT().GetExposedIPs(gomock.Any()).Return(&ipresolver.Resolved{IPs: test.gslb.Status.LoadBalancer.ExposedIPs}, nil).AnyTimes()
 			zd, _ := zones.NewZoneDelegationWrapper(&test.zoneDelegationList.Items[0], test.config, ipr).GetDetail(context.TODO())
 			zs.EXPECT().ExtendedZoneDelegation(gomock.Any(), gomock.Any()).Return(zd, nil).AnyTimes()

--- a/controllers/zones/wrapper.go
+++ b/controllers/zones/wrapper.go
@@ -35,12 +35,11 @@ type ZoneDelegationWrapper struct {
 }
 
 type ExtendedZoneDelegation struct {
-	wrapper           *ZoneDelegationWrapper
-	LoadBalancedZone  string
-	ParentZone        string
-	NegativeTTL       int
-	ClusterNSName     string
-	ExtClusterNSNames resolver.ClusterNSNames
+	wrapper          *ZoneDelegationWrapper
+	LoadBalancedZone string
+	ParentZone       string
+	NegativeTTL      int
+	ClusterNSName    string
 	// TODO: use directly GetExposedIPs(ctx) on places where LocalCoreDNSExposedIPs are required
 	LocalCoreDNSExposedIPs ZoneDelegationIPs
 	name                   string
@@ -75,7 +74,6 @@ func (z *ZoneDelegationWrapper) GetDetail(ctx context.Context) (*ExtendedZoneDel
 		ParentZone:             z.zoneDelegation.Spec.ParentZone,
 		NegativeTTL:            z.zoneDelegation.Spec.DNSZoneNegTTL,
 		ClusterNSName:          z.config.GetClusterNSName(*z.zoneDelegation),
-		ExtClusterNSNames:      z.config.GetClusterNsNames(z.zoneDelegation).ExtClusterNsNames(),
 		LocalCoreDNSExposedIPs: ZoneDelegationIPs(ips.IPs),
 	}
 	err = validateRFC1035(z.zoneDelegation)

--- a/controllers/zones/zone_delegation_service_mock.go
+++ b/controllers/zones/zone_delegation_service_mock.go
@@ -118,20 +118,6 @@ func (mr *MockZoneDelegationMockRecorder) HasAvailableIPs(ctx any) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasAvailableIPs", reflect.TypeOf((*MockZoneDelegation)(nil).HasAvailableIPs), ctx)
 }
 
-// HasExtClusterGeoTags mocks base method.
-func (m *MockZoneDelegation) HasExtClusterGeoTags(ctx context.Context) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasExtClusterGeoTags", ctx)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// HasExtClusterGeoTags indicates an expected call of HasExtClusterGeoTags.
-func (mr *MockZoneDelegationMockRecorder) HasExtClusterGeoTags(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasExtClusterGeoTags", reflect.TypeOf((*MockZoneDelegation)(nil).HasExtClusterGeoTags), ctx)
-}
-
 // List mocks base method.
 func (m *MockZoneDelegation) List(ctx context.Context) (*v1beta1io.ZoneDelegationList, error) {
 	m.ctrl.T.Helper()

--- a/controllers/zones/zone_service.go
+++ b/controllers/zones/zone_service.go
@@ -47,7 +47,6 @@ type ZoneDelegation interface {
 	ListAllZoneDelegations(ctx context.Context) (*v1beta1io.ZoneDelegationList, error)
 	AvailableIPs(ctx context.Context) (ZoneDelegationIPs, error)
 	HasAvailableIPs(ctx context.Context) bool
-	HasExtClusterGeoTags(ctx context.Context) bool
 	UpdateStatus(ctx context.Context, zd *v1beta1io.ZoneDelegation) (*v1beta1io.ZoneDelegation, error)
 	ExtendedZoneDelegation(ctx context.Context, zd *v1beta1io.ZoneDelegation) (*ExtendedZoneDelegation, error)
 	ResolveAuthoritativeServersFromZoneDelegations(ctx context.Context, host string) (AuthoritativeServers, error)
@@ -265,21 +264,6 @@ func (z *ZoneDelegationImpl) HasAvailableIPs(ctx context.Context) bool {
 		return false
 	}
 	return len(exposedIPs) != 0
-}
-
-func (z *ZoneDelegationImpl) HasExtClusterGeoTags(ctx context.Context) bool {
-	l, err := z.List(ctx)
-	if err != nil {
-		return false
-	}
-	if len(l.Items) == 0 {
-		return false
-	}
-	detail, err := NewZoneDelegationWrapper(&l.Items[0], z.config, z.ipresolver).GetDetail(ctx)
-	if err != nil {
-		return false
-	}
-	return len(detail.ExtClusterNSNames) > 0
 }
 
 func (z *ZoneDelegationImpl) ExtendedZoneDelegation(ctx context.Context, zd *v1beta1io.ZoneDelegation) (*ExtendedZoneDelegation, error) {


### PR DESCRIPTION
Extended ZoneDelegation has ExtClusterNSNames which
- is NOT called anywhere
- increased complexity because only provider  for ExtClusterNSNames is `geotags` package giving static or dynamic `ExtClusterNSNames`


Signed-off-by: Michal Kuritka <kuritka@gmail.com>