### PR TITLE
fix: correct malformed if condition to properly skip terratest for re…

### DIFF
--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -45,7 +45,7 @@ jobs:
   terratest:
     runs-on: ubuntu-24.04
     needs: skip-check
-    if: ${{ needs.skip-check.outputs.should_skip != 'true' }} && !contains( github.event.pull_request.labels.*.name, 'renovate')
+    if: ${{ needs.skip-check.outputs.should_skip != 'true'  && !contains( github.event.pull_request.labels.*.name, 'renovate')}}
     strategy:
       matrix:
         k8s-version: ${{ contains(github.event.pull_request.labels.*.name, 'heavy-tests') && fromJSON('["v1.32.11-k3s1","v1.33.7-k3s1","v1.34.3-k3s1"]') || fromJSON('["v1.34.3-k3s1"]') }}


### PR DESCRIPTION
…novate PRs

## What this fixes

The `if:` condition on the `terratest` job in `terratest.yaml` was only partially
wrapped in `${{ }}`:

    if: ${{ needs.skip-check.outputs.should_skip != 'true' }} && !contains( github.event.pull_request.labels.*.name, 'renovate')

Only the first part (`needs.skip-check.outputs.should_skip != 'true'`) was
evaluated as an expression. The `&& !contains(...)` part outside `${{ }}` was
treated as literal text, so the condition never actually excluded `renovate`
PRs from running the full terratest job.

This fix wraps the entire condition in a single `${{ }}` block so both checks
are evaluated correctly:

    if: ${{ needs.skip-check.outputs.should_skip != 'true' && !contains(github.event.pull_request.labels.*.name, 'renovate') }}

## Verification

Confirmed the bug by checking CI runs on merged `renovate`-labeled PRs
(#2492, #2424) — in both cases, `Terratest/terratest (pull_request)` ran in
full (~24-26 min) instead of being skipped.

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
