### PR TITLE
Bump CoreDNS CRD Plugin to v0.6.0

### DIFF
--- a/chart/k8gb/values.yaml
+++ b/chart/k8gb/values.yaml
@@ -118,7 +118,7 @@ coredns:
     # -- CoreDNS CRD plugin image
     repository: registry.k8gb.io/k8gb-io/k8s_crd
     # -- image tag
-    tag: v0.5.0
+    tag: v0.6.0
   # -- Creates serviceAccount for coredns
   serviceAccount:
     create: true


### PR DESCRIPTION
To include security fixes from https://github.com/k8gb-io/coredns-crd-plugin/releases/tag/v0.6.0

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
