### PR TITLE
RELEASE: v1.0.0

### DIFF
--- a/chart/k8gb/Chart.yaml
+++ b/chart/k8gb/Chart.yaml
@@ -3,8 +3,8 @@ name: k8gb
 description: A Helm chart for Kubernetes Global Balancer
 icon: https://www.k8gb.io/images/k8gb-icon-color.svg
 type: application
-version: v0.21.0-rc4
-appVersion: v0.21.0-rc4
+version: v1.0.0
+appVersion: v1.0.0
 kubeVersion: ">= 1.21.0-0"
 
 dependencies:

--- a/chart/k8gb/README.md
+++ b/chart/k8gb/README.md
@@ -1,6 +1,6 @@
 # k8gb
 
-![Version: v0.21.0-rc4](https://img.shields.io/badge/Version-v0.21.0--rc4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.21.0-rc4](https://img.shields.io/badge/AppVersion-v0.21.0--rc4-informational?style=flat-square)
+![Version: v1.0.0](https://img.shields.io/badge/Version-v0.21.0--rc4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0](https://img.shields.io/badge/AppVersion-v0.21.0--rc4-informational?style=flat-square)
 
 A Helm chart for Kubernetes Global Balancer
 

--- a/deploy/helm/stable.yaml
+++ b/deploy/helm/stable.yaml
@@ -1,5 +1,7 @@
 k8gb:
   reconcileRequeueSeconds: 10
+  zoneDelegationReconcileRequeueSeconds: 10
+  zoneDelegationRecoverySeconds: 10
 
   extraVolumeMounts:
     - name: dynamic-zones


### PR DESCRIPTION
This release marks a major milestone for k8gb as a CNCF Incubating project and reflects the project's maturity.

Fixes #52

..

<details>
  <summary>HOW TO RUN CI</summary>
---

  By default, all the checks will be run automatically. Furthermore, when changing website-related stuff, the preview will be generated by the netlify bot.

  ### Heavy tests
  Add the [`heavy-tests`](/k8gb-io/k8gb/issues?q=is%3A*+label%3Aheavy-tests) label on this PR if you want full-blown tests that include more than 2-cluster scenarios.

  ### Debug tests
  If the test suite is failing for you, you may want to try triggering `Re-run all jobs` (top right) with [debug logging](https://docs.github.com/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging) enabled. It will also make the [print debug](/k8gb-io/k8gb/blob/master/.github/actions/print-terratest-debug/action.yaml) action more verbose.

</details>
