### PR TITLE
docs: keep README badges together

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/k8gb-io/k8gb)](https://goreportcard.com/report/github.com/k8gb-io/k8gb)
 [![Helm Publish](https://github.com/k8gb-io/k8gb/actions/workflows/helm_publish.yaml/badge.svg)](https://github.com/k8gb-io/k8gb/actions/workflows/helm_publish.yaml)
 [![Docker Pulls](https://img.shields.io/docker/pulls/absaoss/k8gb)](https://hub.docker.com/r/absaoss/k8gb)
-
-> **Container images:** the Helm chart default is `registry.k8gb.io/k8gb-io/k8gb` (see `chart/k8gb/values.yaml`). Signed/OCI artifacts are also published to `ghcr.io/k8gb-io/*` (see [CONTRIBUTING.md](CONTRIBUTING.md)). The Docker Hub `absaoss/k8gb` badge above reflects historical pulls.
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/k8gb)](https://artifacthub.io/packages/search?repo=k8gb)
 [![doc.crds.dev](https://img.shields.io/badge/doc-crds-purple)](https://doc.crds.dev/github.com/k8gb-io/k8gb)
 [![FOSSA Status](https://app.fossa.com/api/projects/custom%2B162%2Fgithub.com%2Fk8gb-io%2Fk8gb.svg?type=shield)](https://app.fossa.com/projects/custom%2B162%2Fgithub.com%2Fk8gb-io%2Fk8gb?ref=badge_shield)
@@ -33,6 +31,7 @@
 [![CLOMonitor](https://img.shields.io/endpoint?url=https://clomonitor.io/api/projects/cncf/k8gb/badge)](https://clomonitor.io/projects/cncf/k8gb)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/k8gb-io/k8gb/badge)](https://securityscorecards.dev/viewer/?uri=github.com/k8gb-io/k8gb)
 
+> **Container images:** the Helm chart default is `registry.k8gb.io/k8gb-io/k8gb` (see `chart/k8gb/values.yaml`). Signed/OCI artifacts are also published to `ghcr.io/k8gb-io/*` (see [CONTRIBUTING.md](CONTRIBUTING.md)). The Docker Hub `absaoss/k8gb` badge above reflects historical pulls.
 
 A Global Service Load Balancing solution with a focus on having cloud native qualities and work natively in a Kubernetes context.
 


### PR DESCRIPTION
## Summary

- keep all README badges in one Markdown block
- move the container-image note below the badges so later badges are not rendered as part of the blockquote

## Verification

- `git diff --check`